### PR TITLE
ansible: Add autoconf to RHEL package list (already on CentOS)

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -6,6 +6,7 @@
 # Command Build Tool Packages
 Build_Tool_Packages:
   - alsa-lib-devel
+  - autoconf
   - bind-utils
   - cpio
   - cups-devel


### PR DESCRIPTION
This stops autoconf being available on RHEL74 so will hopefully solve (or at least progress) #396