### PR TITLE
AixPb: Put /usr/bin to the front of the PATH

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
@@ -97,7 +97,7 @@
         path: /etc/security/login.cfg
         regexp: 'shells = '
         replace: 'shells = /bin/bash,'
-      tags: 
+      tags:
         - login_shell
         - adoptopenjdk
 
@@ -118,7 +118,7 @@
           AIXTHREAD_HRT=true
           PKG_CONFIG_PATH=/opt/freeware/lib64/pkgconfig:/opt/freeware/lib/pkgconfig
           PERL5LIB=/opt/freemarker/lib/perl5
-      tags: 
+      tags:
         - login_shell
         - adoptopenjdk
 
@@ -127,7 +127,7 @@
         path: /etc/environment
         regexp: 'PATH=/usr/bin:/etc'
         replace: 'PATH=/usr/bin:/opt/IBM/xlC/13.1.3/bin:/opt/freeware/bin:/etc'
-      tags: 
+      tags:
         - login_shell
         - adoptopenjdk
 

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
@@ -97,14 +97,18 @@
         path: /etc/security/login.cfg
         regexp: 'shells = '
         replace: 'shells = /bin/bash,'
-      tags: login_shell
+      tags: 
+        - login_shell
+        - adoptopenjdk
 
     - name: Add bash to available login shells
       blockinfile:
         dest: /etc/shells
         block: |
           /bin/bash
-      tags: login_shell
+      tags: 
+        - login_shell
+        - adoptopenjdk
 
     # move to role later
     - name: Set variables for global environment
@@ -114,14 +118,18 @@
           AIXTHREAD_HRT=true
           PKG_CONFIG_PATH=/opt/freeware/lib64/pkgconfig:/opt/freeware/lib/pkgconfig
           PERL5LIB=/opt/freemarker/lib/perl5
-      tags: login_shell
+      tags: 
+        - login_shell
+        - adoptopenjdk
 
     - name: Add freeware and xlc to PATH for global environment
       replace:
         path: /etc/environment
         regexp: 'PATH=/usr/bin:/etc'
         replace: 'PATH=/usr/bin:/opt/IBM/xlC/13.1.3/bin:/opt/freeware/bin:/etc'
-      tags: login_shell
+      tags: 
+        - login_shell
+        - adoptopenjdk
 
   ##############
   # freemarker #

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
@@ -120,7 +120,7 @@
       replace:
         path: /etc/environment
         regexp: 'PATH=/usr/bin'
-        replace: 'PATH=usr/bin:/opt/IBM/xlC/13.1.3/bin:/opt/freeware/bin/'
+        replace: 'PATH=/usr/bin:/opt/IBM/xlC/13.1.3/bin:/opt/freeware/bin/'
       tags: login_shell
 
   ##############

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
@@ -92,9 +92,12 @@
   ######################################
   # Add bash to available login shells #
   ######################################
-    - name: Add bash, ksh and /bin/false to available login shells
-      command: chsec -f /etc/security/login.cfg -s usw -a shells=/usr/bin/bash,/usr/bin/ksh,/bin/false
-      tags:
+    - name: Add bash to available login shells
+      replace:
+        path: /etc/security/login.cfg
+        regexp: 'shells = '
+        replace: 'shells = /bin/bash,'
+      tags: 
         - login_shell
         - adoptopenjdk
 

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
@@ -120,7 +120,7 @@
       replace:
         path: /etc/environment
         regexp: 'PATH=/usr/bin'
-        replace: 'PATH=/opt/freeware/bin:/opt/IBM/xlC/13.1.3/bin:/usr/bin'
+        replace: 'PATH=usr/bin:/opt/IBM/xlC/13.1.3/bin:/opt/freeware/bin/'
       tags: login_shell
 
   ##############

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
@@ -106,7 +106,7 @@
         dest: /etc/shells
         block: |
           /bin/bash
-      tags: 
+      tags:
         - login_shell
         - adoptopenjdk
 

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
@@ -119,8 +119,8 @@
     - name: Add freeware and xlc to PATH for global environment
       replace:
         path: /etc/environment
-        regexp: 'PATH=/usr/bin'
-        replace: 'PATH=/usr/bin:/opt/IBM/xlC/13.1.3/bin:/opt/freeware/bin/'
+        regexp: 'PATH=/usr/bin:/etc'
+        replace: 'PATH=/usr/bin:/opt/IBM/xlC/13.1.3/bin:/opt/freeware/bin:/etc'
       tags: login_shell
 
   ##############

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
@@ -92,12 +92,9 @@
   ######################################
   # Add bash to available login shells #
   ######################################
-    - name: Add bash to available login shells
-      replace:
-        path: /etc/security/login.cfg
-        regexp: 'shells = '
-        replace: 'shells = /bin/bash,'
-      tags: 
+    - name: Add bash, ksh and /bin/false to available login shells
+      command: chsec -f /etc/security/login.cfg -s usw -a shells=/usr/bin/bash,/usr/bin/ksh,/bin/false
+      tags:
         - login_shell
         - adoptopenjdk
 


### PR DESCRIPTION
Following on from a discussion with @sxa in slack, /usr/bin should be at the beginning of the PATH variable, ahead of /opt/freeware/bin