### PR TITLE
remove GPL headers and add COC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,79 @@
+# Community Code of Conduct
+
+**Version 1.1 
+October 21, 2019**
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at codeofconduct@eclipse.org. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,38 @@
-# Contributing to AdoptOpenJDK/infrastructure
+# Contributing to infrastructure
 
-Thank you for your interest in AdoptOpenJDK/infrastructure!
+Thanks for your interest in this project.
 
-We welcome and encourage all kinds of contributions to the project, not only
-code. This includes bug reports, user experience feedback, assistance in
-reproducing issues and more.
+## Project description
+
+This repo contains all information about machine maintenance and configurations
+
+* https://github.com/adoptium/infrastructure
+
+## Developer resources
+
+The project maintains the following source code repositories
+
+* https://github.com/adoptium/infrastructure
+
+## Eclipse Contributor Agreement
+
+Before your contribution can be accepted by the project team contributors must
+electronically sign the Eclipse Contributor Agreement (ECA).
+
+* http://www.eclipse.org/legal/ECA.php
+
+Commits that are provided by non-committers must have a Signed-off-by field in
+the footer indicating that the author is aware of the terms by which the
+contribution has been provided to the project. The non-committer must
+additionally have an Eclipse Foundation account and must have a signed Eclipse
+Contributor Agreement (ECA) on file.
+
+For more information, please see the Eclipse Committer Handbook:
+https://www.eclipse.org/projects/handbook/#resources-commit
+
+## Contact
+
+Contact the Eclipse Foundation Webdev team via webdev@eclipse-foundation.org.
 
 ## Mission Statement
 

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/nagios/nagios_aix.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/nagios/nagios_aix.yml
@@ -3,12 +3,6 @@
 # AdoptOpenJDK - Ansible Playbook to install Nagios plugins on AIX #
 ####################################################################
 
-###########################################################################
-# License Information:                                                    #
-# Nagios core and its plugins are lincesed under GPL                      #
-# For more information please see: https://www.nagios.com/legal/licenses/ #
-###########################################################################
-
 - debug: msg='Installing Nagios plugins'
 ##########
 # Layout #

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/additional_plugins/check_pkg
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/additional_plugins/check_pkg
@@ -1,9 +1,3 @@
-###########################################################################
-# License Information:                                                    #
-# Nagios core and its plugins are lincesed under GPL                      #
-# For more information please see: https://www.nagios.com/legal/licenses/ #
-###########################################################################
-
 #!/bin/bash
 # Nagios Plugin to check for OS updates using ‘pkg’ for FreeBSD
 #

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/additional_plugins/check_sw_up
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/additional_plugins/check_sw_up
@@ -1,9 +1,3 @@
-###########################################################################
-# License Information:                                                    #
-# Nagios core and its plugins are lincesed under GPL                      #
-# For more information please see: https://www.nagios.com/legal/licenses/ #
-###########################################################################
-
 #!/bin/bash
 # Nagios Plugin to check for OS updates using ‘softwareupdate’ for MacOSX
 #

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/additional_plugins/check_yum
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/additional_plugins/check_yum
@@ -1,9 +1,3 @@
-###########################################################################
-# License Information:                                                    #
-# Nagios core and its plugins are lincesed under GPL                      #
-# For more information please see: https://www.nagios.com/legal/licenses/ #
-###########################################################################
-
 #!/bin/bash
 # Nagios Plugin to check for OS updates using ‘yum’ for RedHat like systems
 #

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/additional_plugins/check_zypper
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/additional_plugins/check_zypper
@@ -1,9 +1,3 @@
-###########################################################################
-# License Information:                                                    #
-# Nagios core and its plugins are lincesed under GPL                      #
-# For more information please see: https://www.nagios.com/legal/licenses/ #
-###########################################################################
-
 #!/bin/bash
 # Nagios Plugin to check for OS updates using ‘zypper’ for SuSE like systems
 #

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_CentOS.yml
@@ -3,12 +3,6 @@
 # AdoptOpenJDK - Ansible Playbook to install Nagios plugins on CentOS 7 on x86 hardware #
 #########################################################################################
 
-###########################################################################
-# License Information:                                                    #
-# Nagios core and its plugins are lincesed under GPL                      #
-# For more information please see: https://www.nagios.com/legal/licenses/ #
-###########################################################################
-
 ###############
 # Nagios user #
 ###############

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_Debian.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_Debian.yml
@@ -3,12 +3,6 @@
 # AdoptOpenJDK - Ansible Playbook to install Nagios plugins on Debian on x86 hardware #
 #################################################################################################
 
-###########################################################################
-# License Information:                                                    #
-# Nagios core and its plugins are lincesed under GPL                      #
-# For more information please see: https://www.nagios.com/legal/licenses/ #
-###########################################################################
-
 ########################################
 # Install Nagios dependencies packages #
 ########################################

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_FreeBSD.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_FreeBSD.yml
@@ -3,12 +3,6 @@
 # AdoptOpenJDK - Ansible Playbook to install Nagios plugins on CentOS 7 on x86 hardware #
 #########################################################################################
 
-###########################################################################
-# License Information:                                                    #
-# Nagios core and its plugins are lincesed under GPL                      #
-# For more information please see: https://www.nagios.com/legal/licenses/ #
-###########################################################################
-
 ###############
 # Nagios user #
 ###############

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_MacOSX.yml
@@ -3,12 +3,6 @@
 # AdoptOpenJDK - Ansible Playbook to install Nagios plugins on macOS on x86 hardware #
 ######################################################################################
 
-###########################################################################
-# License Information:                                                    #
-# Nagios core and its plugins are lincesed under GPL                      #
-# For more information please see: https://www.nagios.com/legal/licenses/ #
-###########################################################################
-
 ########################################
 # Install Nagios dependencies packages #
 ########################################

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_RedHat.yml
@@ -3,12 +3,6 @@
 # AdoptOpenJDK - Ansible Playbook to install Nagios plugins on RHEL 7 on x86 hardware #
 #######################################################################################
 
-###########################################################################
-# License Information:                                                    #
-# Nagios core and its plugins are lincesed under GPL                      #
-# For more information please see: https://www.nagios.com/legal/licenses/ #
-###########################################################################
-
 ###############
 # Nagios user #
 ###############

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_SLES.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_SLES.yml
@@ -3,12 +3,6 @@
 # AdoptOpenJDK - Ansible Playbook to install Nagios plugins on SLES on x86 hardware #
 #####################################################################################
 
-###########################################################################
-# License Information:                                                    #
-# Nagios core and its plugins are lincesed under GPL                      #
-# For more information please see: https://www.nagios.com/legal/licenses/ #
-###########################################################################
-
 ########################################
 # Install Nagios dependencies packages #
 ########################################

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_Ubuntu.yml
@@ -3,12 +3,6 @@
 # AdoptOpenJDK - Ansible Playbook to install Nagios plugins on Ubuntu 14 and 16 on x86 hardware #
 #################################################################################################
 
-###########################################################################
-# License Information:                                                    #
-# Nagios core and its plugins are lincesed under GPL                      #
-# For more information please see: https://www.nagios.com/legal/licenses/ #
-###########################################################################
-
 ########################################
 # Install Nagios dependencies packages #
 ########################################

--- a/ansible/playbooks/nagios/nagios_aix.yml.old
+++ b/ansible/playbooks/nagios/nagios_aix.yml.old
@@ -3,12 +3,6 @@
 # AdoptOpenJDK - Ansible Playbook to install Nagios plugins on AIX #
 ####################################################################
 
-###########################################################################
-# License Information:                                                    #
-# Nagios core and its plugins are lincesed under GPL                      #
-# For more information please see: https://www.nagios.com/legal/licenses/ #
-###########################################################################
-
 ##########
 # Layout #
 ##########


### PR DESCRIPTION
I've double-checked both the official plugins provided by nagios as well as doing a full GitHub search. I've found no evidence to suggest that these files are licensed with the GPL license (especially considering the typo)

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [ ] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
