### PR TITLE
UnixPB: Add support for Debian11/RISC-V

### DIFF
--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -263,6 +263,8 @@ runPlaybook() {
 
 	# RISCV requires this be specified
 	if [[ $ARCHITECTURE == "RISCV" ]]; then
+		# To fix the outdated repositories of the image
+		ssh -p $PORTNO -i "$workFolder"/id_rsa linux@localhost "sudo apt-get update --fix-missing"
 		extraAnsibleArgs="-e ansible_python_interpreter=/usr/bin/python3"
 	fi
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -74,7 +74,9 @@
       when: ansible_distribution != "MacOSX"
     - role: adoptopenjdk_install
       jdk_version: 8
-      when: ansible_distribution != "Alpine"
+      when:
+        - ansible_distribution != "Alpine"
+        - ansible_architecture != "riscv64"
       tags: build_tools
     - role: adoptopenjdk_install  # JDK11 Build Bootstrap
       jdk_version: 10
@@ -82,14 +84,21 @@
         - ansible_distribution != "Alpine"
         - ansible_distribution != "MacOSX"
         - ansible_distribution != "Solaris"
+        - ansible_architecture != "riscv64"
       tags: build_tools
     - role: adoptopenjdk_install
       jdk_version: 11
-      when: ansible_distribution != "Alpine" and ansible_distribution != "Solaris"
+      when:
+        - ansible_distribution != "Alpine"
+        - ansible_distribution != "Solaris"
+        - ansible_architecture != "riscv64"
       tags: build_tools
     - role: adoptopenjdk_install  # JDK16 Build Bootstrap
       jdk_version: 15
-      when: ansible_distribution != "Alpine" and ansible_distribution != "Solaris"
+      when:
+        - ansible_distribution != "Alpine"
+        - ansible_distribution != "Solaris"
+        - ansible_architecture != "riscv64"
       tags: build_tools
     - OpenSSL102                  # OpenJ9
     - role: Nagios_Plugins        # AdoptOpenJDK Infrastructure

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
@@ -12,7 +12,7 @@
 - name: Add the openjdk repository to apt for openjdk7
   apt_repository: repo='ppa:openjdk-r/ppa' update_cache=no
   when:
-    - ansible_architecture != "armv7l"
+    - (ansible_architecture != "armv7l") and (ansible_architecture != "riscv64")
     - ansible_distribution_major_version != "10"
   tags: patch_update
 
@@ -33,11 +33,14 @@
   apt_repository:
     repo: "deb https://adoptopenjdk.jfrog.io/adoptopenjdk/deb {{ ansible_distribution_release }} main"
     update_cache: no
+  when:
+    - (ansible_architecture != "riscv64")
+  tags: patch_update
 
 - name: Add the ubuntu toolchain repository to apt
   apt_repository: repo='ppa:ubuntu-toolchain-r/test' update_cache=no
   when:
-    - ansible_architecture != "armv7l"
+    - (ansible_architecture != "armv7l") and (ansible_architecture != "riscv64")
     - ansible_distribution_major_version != "10"
   tags: patch_update
 
@@ -51,7 +54,7 @@
     - /etc/apt/sources.list.d/ppa_openjdk_r_ppa_jessie.list
     - /etc/apt/sources.list.d/ppa_ubuntu_toolchain_r_test_jessie.list
   when:
-    - ansible_architecture != "armv7l"
+    - (ansible_architecture != "armv7l") and (ansible_architecture != "riscv64")
     - ansible_distribution_major_version == "8"
   tags: patch_update
 
@@ -119,7 +122,9 @@
 - name: Call gcc-7 for all but arm32
   package: "name={{ item }} state=latest"
   with_items: "{{ gcc_7 }}"
-  when: ansible_architecture != "armv7l"
+  when:
+    - ansible_architecture != "armv7l"
+    - ansible_architecture != "riscv64"
   tags: build_tools
 
 - name: Call Build Packages and Tools Task for OpenJFX
@@ -132,6 +137,7 @@
   with_items: "{{ gcc_compiler }}"
   when:
     - (ansible_distribution_major_version != "9" and ansible_architecture != "armv7l")
+    - ansible_architecture != "riscv64"
     - ansible_distribution_major_version != "10"
   tags: build_tools
 
@@ -170,6 +176,13 @@
   with_items: "{{ Additional_Build_Tools_aarch64 }}"
   when:
     - ansible_architecture == "aarch64"
+  tags: build_tools
+
+- name: Install additional build tools for riscv64
+  package: "name={{ item }} state=latest"
+  with_items: "{{ Additional_Build_Tools_riscv64 }}"
+  when:
+    - ansible_architecture == "riscv64"
   tags: build_tools
 
 #########################

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Debian.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Debian.yml
@@ -59,7 +59,7 @@ OpenJFX_Build_Tool_Packages:
   - libxxf86vm-dev
   - ruby
 
-gcc_7:                            # On all architectures but arm32
+gcc_7:                            # On all architectures but arm32 and riscv64
   - g++-7                         # OpenJ9
   - gcc-7                         # OpenJ9
 
@@ -90,9 +90,11 @@ Additional_Build_Tools_s390x:
 Additional_Build_Tools_aarch64:
   - libpng-dev
 
+Additional_Build_Tools_riscv64:
+  - systemd-timesyncd
+
 Test_Tool_Packages:
   - acl
-  - mercurial
   - perl
   - xauth
   - xorg
@@ -102,3 +104,4 @@ Test_Tool_Packages:
 
 Test_Tool_Packages_x86_64:
   - pulseaudio
+  - mercurial

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
@@ -288,6 +288,7 @@
   package: "name=docker-ce state=latest"
   when:
     - docker_installed.rc != 0
+    - ansible_architecture != "riscv64"
     - (ansible_distribution == "Debian" and ansible_distribution_major_version|int <10)
   tags:
     - docker
@@ -298,6 +299,7 @@
   package: "name=docker.io state=latest"
   when:
     - docker_installed.rc != 0
+    - ansible_architecture != "riscv64"
     - (ansible_distribution == "Debian" and ansible_distribution_major_version|int >=10)
   tags:
     - docker
@@ -311,7 +313,9 @@
   when:
     - docker_installed.rc != 0
     - (ansible_distribution == "Ubuntu") or (ansible_distribution == "Debian")
-  tags: docker
+  tags:
+    - docker
+    - jenkins
 
 - name: Add Jenkins user to the docker group for SLES 12, CentOS7, and RHEL7
   user: name={{ Jenkins_Username }}
@@ -321,7 +325,9 @@
     - docker_installed.rc != 0
     - (ansible_distribution == "SLES" and ansible_distribution_major_version == "12") or (ansible_distribution == "RedHat" and ansible_distribution_major_version == "7") or (ansible_distribution == "CentOS" and ansible_distribution_major_version == "7")
     - (ansible_architecture == "x86_64" or ansible_architecture == "ppc64le" or ansible_architecture == "s390x")
-  tags: docker
+  tags:
+    - docker
+    - jenkins
 
 - name: Enable and Start Docker Service for Ubuntu and Debian
   service:
@@ -330,6 +336,7 @@
     enabled: yes
   when:
     - docker_installed.rc != 0
+    - ansible_architecture != "riscv64"
     - (ansible_distribution == "Ubuntu") or (ansible_distribution == "Debian")
   tags: docker
 


### PR DESCRIPTION
Ref: #2123 

Adds support for debain11/RISC-V. Tested in QPC throughout the process, see the referenced issue for details.

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) [QPC](https://ci.adoptopenjdk.net/job/QEMUPlaybookCheck/267/ARCHITECTURE=riscv,OS=debian11,label=vagrant/console)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
