### PR TITLE
Remove LJC codesign certs from all machines

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/macos_codesign/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/macos_codesign/tasks/main.yml
@@ -3,130 +3,20 @@
 # macOS Codesign #
 ##################
 
-- name: Set Jenkins user password
-  user:
-    name: jenkins
-    password: "{{ macOS_Jenkins_Password }}"
+# Since moving to the Eclipse Foundation, we no longer need these steps and so we've changed this role to ensure that no LJC certs exist on the machines.
+# See https://github.com/adoptium/infrastructure/blob/ccdc434d5f13861a03b598e9e34674d978c85d34/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/macos_codesign/tasks/main.yml for the original content.
 
-- name: Create Jenkins password file
-  file: path="/Users/jenkins/.password" state=touch
+- name: Remove Jenkins password file
+  file: path="/Users/jenkins/.password" state=absent
 
-- name: Copy password to file
-  copy: content="{{ macOS_Jenkins_Password }}" dest="/Users/jenkins/.password"
-
-- name: Get macOS version
-  shell: sw_vers -productVersion
-  register: macos_version
-
-- name: Check if Default keychain is correct
-  shell: security default-keychain | tr -d '[:space:]' | sed 's/"//g'
-  register: default_keychain
+- name: Remove Application Certificate
+  shell: |
+    security delete-certificate -c "Developer ID Application: London Jamocha Community CIC" "/Users/jenkins/Library/Keychains/login.keychain-db"
   become_user: jenkins
   ignore_errors: true
 
-- name: Create Keychain if it doesn't exist
-  shell: security create-keychain -p "{{ macOS_Jenkins_Password }}" "/Users/jenkins/Library/Keychains/login.keychain-db"
-  become_user: jenkins
-  when:
-    - not macos_version | regex_search("10.10")
-    - default_keychain.stderr | regex_search("A default keychain could not be found")
-
-- name: Set Default keychain
-  shell: security default-keychain -s "/Users/jenkins/Library/Keychains/login.keychain-db"
-  become_user: jenkins
-  when:
-    - not macos_version | regex_search("10.10")
-    - default_keychain.stdout != "/Users/jenkins/Library/Keychains/login.keychain-db"
-
-- name: Reboot macOS after setting Default keychain
-  reboot:
-    reboot_timeout: 3600
-  when:
-    - not macos_version | regex_search("10.10")
-    - default_keychain.stdout != "/Users/jenkins/Library/Keychains/login.keychain-db"
-
-- name: Test Application Certificate
+- name: Remove Installer Certificate
   shell: |
-    security unlock-keychain -p `cat ~/.password` login.keychain-db
-    rm -rf /Users/jenkins/test && touch /Users/jenkins/test
-    codesign --sign "Developer ID Application: London Jamocha Community CIC" /Users/jenkins/test
+    security delete-certificate -c "Developer ID Installer: London Jamocha Community CIC" "/Users/jenkins/Library/Keychains/login.keychain-db"
   become_user: jenkins
-  register: application_cert
   ignore_errors: true
-  when:
-    - not macos_version | regex_search("10.10")
-
-- name: Get the Application Certificate from Vendor Secrets
-  copy:
-    src: vendor_files/macos_codesign_certs/application.p12
-    dest: /Users/jenkins/application.p12
-  when:
-    - not macos_version | regex_search("10.10")
-    - application_cert.stderr | regex_search("The specified item could not be found in the keychain")
-
-- name: Install Application Certificate
-  shell: |
-    security unlock-keychain -p `cat ~/.password` login.keychain-db
-    security import /Users/jenkins/application.p12 -P "{{ macOS_Codesign_Application_Password }}" -T /usr/bin/codesign
-  become_user: jenkins
-  when:
-    - not macos_version | regex_search("10.10")
-    - application_cert.stderr | regex_search("The specified item could not be found in the keychain")
-
-- name: Test Installer Certificate
-  shell: |
-    security unlock-keychain -p `cat ~/.password` login.keychain-db
-    rm -rf /Users/jenkins/installer.pkg /Users/jenkins/installer_signed.pkg
-    # We need to test sign an actual installer
-    curl -L https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u265-b01/OpenJDK8U-jre_x64_mac_hotspot_8u265b01.pkg -o /Users/jenkins/installer.pkg
-    productsign --sign "Developer ID Installer: London Jamocha Community CIC" /Users/jenkins/installer.pkg /Users/jenkins/installer_signed.pkg
-  become_user: jenkins
-  register: installer_cert
-  ignore_errors: true
-  when:
-    - not macos_version | regex_search("10.10")
-
-- name: Get the Installer Certificate from Vendor Secrets
-  copy:
-    src: vendor_files/macos_codesign_certs/installer.p12
-    dest: /Users/jenkins/installer.p12
-  when:
-    - not macos_version | regex_search("10.10")
-    - installer_cert.stderr | regex_search("no identity found") or installer_cert.stderr | regex_search("Could not find appropriate signing identity for")
-
-- name: Install Installer Certificate
-  shell: |
-    security unlock-keychain -p `cat ~/.password` login.keychain-db
-    security import /Users/jenkins/installer.p12 -P "{{ macOS_Codesign_Installer_Password }}" -T /usr/bin/pkgbuild -T /usr/bin/productsign -T /usr/bin/productbuild
-  become_user: jenkins
-  when:
-    - not macos_version | regex_search("10.10")
-    - installer_cert.stderr | regex_search("no identity found") or installer_cert.stderr | regex_search("Could not find appropriate signing identity for")
-
-- name: Disable keychain timeout
-  shell: |
-    security unlock-keychain -p `cat ~/.password` login.keychain-db
-    security set-keychain-settings /Users/jenkins/Library/Keychains/login.keychain-db
-  become_user: jenkins
-  when:
-    - not macos_version | regex_search("10.10")
-
-- name: Allow codesign via ssh
-  shell: |
-    security unlock-keychain -p `cat ~/.password` login.keychain-db
-    security set-key-partition-list -S apple-tool:,apple: -s -k "{{ macOS_Jenkins_Password }}" /Users/jenkins/Library/Keychains/login.keychain-db
-  become_user: jenkins
-  when:
-    - not macos_version | regex_search("10.10")
-
-- name: Cleanup files
-  file:
-    path: "{{ item }}"
-    state: absent
-  with_items:
-    - /Users/jenkins/application.p12
-    - /Users/jenkins/installer.p12
-    - /Users/jenkins/test
-    - /Users/jenkins/installer.pkg
-    - /Users/jenkins/installer_signed.pkg
-  ignore_errors: yes

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/CodesignCert/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/CodesignCert/tasks/main.yml
@@ -3,22 +3,10 @@
 # CodesignCert #
 ################
 
-- name: Check if windows.p12 exists
-  win_stat:
-    path: C:\openjdk\windows.p12
-  register: cert_installed
-  tags:
-    - ccert
-    - jenkins
-    - adoptopenjdk
+# Since moving to the Eclipse Foundation, we no longer need these steps and so we've changed this role to ensure that no LJC certs exist on the machines.
+# See https://github.com/adoptium/infrastructure/blob/cbadc5c45871c22e6a011999bf5ab3a3fdc926cf/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/CodesignCert/tasks/main.yml for the original content.
 
-# The vendor files are retrieved by the Get_Vendor_Files role
-- name: Get windows.p12 and put in C:\openjdk Directory
-  win_copy:
-    src: vendor_files/windows.p12
-    dest: C:\openjdk\windows.p12
-  when: (not cert_installed.stat.exists)
-  tags:
-    - ccert
-    - jenkins
-    - adoptopenjdk
+- name: Remove windows.p12, if present
+  ansible.windows.win_file:
+    path: C:\openjdk\windows.p12
+    state: absent


### PR DESCRIPTION
We no longer need these codesign certs. The safest option is to fully remove them from the machines to prevent us signing an Adoptium build with the wrong cert

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [ ] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
