### PR TITLE
pbTests: Stop using find -maxdepth as it is nonstandard

### DIFF
--- a/ansible/pbTestScripts/testJDK.sh
+++ b/ansible/pbTestScripts/testJDK.sh
@@ -6,7 +6,8 @@ if [[ $(uname) == "FreeBSD" ]]; then
 	cp -r $HOME/openjdk-build/workspace/build/src/build/*/jdk* $HOME
 	export TEST_JDK_HOME=$HOME/jdk
 else
-	export TEST_JDK_HOME=$(find $HOME/openjdk-build/workspace/build/src/build/*/images/ -maxdepth 1 -type d -name "jdk*"|grep -v ".*jre.*"|grep -v ".*-image")
+	export TEST_JDK_HOME=$(ls -1d "$HOME/openjdk-build/workspace/build/src/build/*/images/jdk*" |grep -v ".*jre.*"|grep -v ".*-image")
+	echo SXA: TEST_JDK_HOME = "$TEST_JDK_HOME"
 fi
 
 mkdir -p $HOME/testLocation

--- a/ansible/pbTestScripts/testJDK.sh
+++ b/ansible/pbTestScripts/testJDK.sh
@@ -6,7 +6,7 @@ if [[ $(uname) == "FreeBSD" ]]; then
 	cp -r $HOME/openjdk-build/workspace/build/src/build/*/jdk* $HOME
 	export TEST_JDK_HOME=$HOME/jdk
 else
-	export TEST_JDK_HOME=$(ls -1d "$HOME/openjdk-build/workspace/build/src/build/*/images/jdk*" |grep -v ".*jre.*"|grep -v ".*-image")
+	export TEST_JDK_HOME=$(ls -1d $HOME/openjdk-build/workspace/build/src/build/*/images/jdk* |grep -v ".*jre.*"|grep -v ".*-image")
 	echo SXA: TEST_JDK_HOME = "$TEST_JDK_HOME"
 	ls -ld $HOME/openjdk-build/workspace/build/src/build/*/images/*
 fi

--- a/ansible/pbTestScripts/testJDK.sh
+++ b/ansible/pbTestScripts/testJDK.sh
@@ -8,6 +8,7 @@ if [[ $(uname) == "FreeBSD" ]]; then
 else
 	export TEST_JDK_HOME=$(ls -1d "$HOME/openjdk-build/workspace/build/src/build/*/images/jdk*" |grep -v ".*jre.*"|grep -v ".*-image")
 	echo SXA: TEST_JDK_HOME = "$TEST_JDK_HOME"
+	ls -ld $HOME/openjdk-build/workspace/build/src/build/*/images/*
 fi
 
 mkdir -p $HOME/testLocation


### PR DESCRIPTION
Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access): [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/1178/)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

This fixes:
```
12:44:54 find: bad option -maxdepth
12:44:55 find: [-H | -L] path-list predicate-list
```
and the resulting:
```
12:48:36 makefile:20: *** Please provide TEST_JDK_HOME value..  Stop.
12:48:42 makefile:20: *** Please provide TEST_JDK_HOME value..  Stop.
```
which shows up in the Solaris VPC checks