### PR TITLE
inventory: Remove old Packet/aarch64 systems

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -64,8 +64,6 @@ hosts:
           centos74-ppc64le-2: {ip: 140.211.168.117}
 
       - packet:
-          centos74-armv8-1: {ip: 147.75.196.30, description: ThunderX}
-          ubuntu1804-armv8-1: {ip: 139.178.82.234, description: D05}
           centos8-armv8-1: {ip: 139.178.86.243, description: Altra}
 
       - scaleway:
@@ -92,7 +90,6 @@ hosts:
           ubuntu1604-s390x-1: {ip: 148.100.113.58, user: ubuntu}
 
       - packet:
-          ubuntu1604-armv8-1: {ip: 147.75.77.146, description: D05}
           ubuntu2004-armv8-1: {ip: 139.178.82.146, description: Ampere eMag}
           ubuntu2004-x64-1: {ip: 139.178.85.251, description: AMD EPYC}
 
@@ -149,8 +146,6 @@ hosts:
           ubuntu2004-ppc64le-1: {ip: 140.211.168.235, user: ubuntu}
 
       - packet:
-          ubuntu1604-armv8-1: {ip: 147.75.74.50, description: ThunderX}
-          ubuntu1604-armv8-2: {ip: 147.75.193.234, description: ThunderX}
           ubuntu1604-x64-1: {ip: 147.75.204.239}
           ubuntu1604-x64-2: {ip: 147.75.100.127}
           win2012r2-x64-1: {ip: 147.75.32.146, user: Admin}


### PR DESCRIPTION
Part of https://github.com/adoptium/infrastructure/issues/2078

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

This covers the ThunderX and D05 systems. For now I'm retaining the (newer) eMag one as there are still some things running on it.