### PR TITLE
pbTests: Update Vagrantfile paths in VPC/vmDestroy

### DIFF
--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -91,7 +91,7 @@ checkVars()
 	if [ "$vagrantOS" == "" ]; then
 		usage
 		echo "ERROR: No Vagrant OS specified - Use -h for help, -a for all or -v with one of the following:"
-		ls -1 ../Vagrantfile.* | cut -d. -f4
+		ls -1 ../vagrant/Vagrantfile.* | cut -d. -f4
 		exit 1
 	fi
 	if [[ "$runTest" == true && "$testNativeBuild" == false ]]; then 
@@ -143,9 +143,9 @@ checkVagrantOS()
 {
         local vagrantOSList
         if [[ "$newVagrantFiles" = "true" ]]; then
-                cd ${WORKSPACE}/adoptopenjdkPBTests/${gitFork}-${gitBranch}/ansible
+                cd ${WORKSPACE}/adoptopenjdkPBTests/${gitFork}-${gitBranch}/ansible/vagrant
         else    
-                cd ${scriptPath%/*}/..
+                cd ${scriptPath%/*}/../vagrant
         fi
         vagrantOSList=$(ls -1 Vagrantfile.* | cut -d. -f 2)
         if [[ -f "Vagrantfile.${vagrantOS}" ]]; then

--- a/ansible/pbTestScripts/vmDestroy.sh
+++ b/ansible/pbTestScripts/vmDestroy.sh
@@ -94,8 +94,13 @@ listOS() {
 
 destroyVMs() {
 	local OS=$1
-	vagrant global-status --prune | awk "/adoptopenjdk$OS/ { print \$1 }" | xargs vagrant destroy -f
-	echo "Destroyed all $OS Vagrant VMs"
+	local ID=$(vagrant global-status --prune | awk "/adoptopenjdk$OS/ { print \$1 }")
+	if [[ "$ID" != "" ]]; then
+		vagrant destroy -f $ID
+		echo "Destroyed all $OS vagrant VMs"
+	else
+		echo "No $1 vagrant VMs, moving on..."
+	fi
 }
 
 processArgs $*


### PR DESCRIPTION
Fixes: #2215 

VPC currently isn't running cleanly, due to a new issue with `vmDestroy.sh`. While I can't see that it's related to #2211 , `vpc.sh`, it suddenly started being an issue after this was merged. Irrespective, `vpc.sh` needs to be updated to reflect the changes in that PR anyway.

Keeping in Draft until VPC runs are (mostly) green: 
https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/1183/

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
