### PR TITLE
ansible: ignore errors on check for disabled timesyncd

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NTP_TIME/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NTP_TIME/tasks/main.yml
@@ -10,6 +10,7 @@
   tags: ntp_time
 
 - name: Ensure systemd-timesyncd service is disabled
+  ignore_errors: true
   service:
     name: systemd-timesyncd
     enabled: no


### PR DESCRIPTION
It caused a playbook failure on at least one machine for temurin-compliance.

##### Checklist
- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
