### PR TITLE
install openssh on Solaris machines

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Solaris.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Solaris.yml
@@ -12,6 +12,7 @@ Build_Tool_Packages:
   - ggrep
   - jdk7
   - jdk8
+  - openssh # needed to clone from GitHub via ssh
   - pigz
   - git
   - sudo

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Solaris.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Solaris.yml
@@ -12,7 +12,7 @@ Build_Tool_Packages:
   - ggrep
   - jdk7
   - jdk8
-  - openssh # needed to clone from GitHub via ssh
+  - openssh # needed to clone from GitHub via ssh - https://github.com/adoptium/infrastructure/pull/2220
   - pigz
   - git
   - sudo


### PR DESCRIPTION
Fixes: 

```bash
bash-3.2# ssh -T git@github.com
Client and server could not agree on a key exchange algorithm:
  client: diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha1,diffie-hellman-group1-sha1
  server: curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256
```

Once installed you need to set `GIT_SSH=/opt/csw/bin/ssh`