### PR TITLE
unixPB: Install gcc/g++-7 on arm32 from Ubuntu repos

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -117,6 +117,13 @@
     - ansible_architecture == "aarch64"
   tags: build_tools
 
+- name: Install additional build tools for x86
+  package: "name={{ item }} state=latest"
+  with_items: "{{ Additional_Build_Tools_armv7l }}"
+  when:
+    - ansible_architecture == "armv7l"
+  tags: build_tools
+
 #########################
 # Additional Test Tools #
 #########################

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
@@ -97,6 +97,10 @@ Additional_Build_Tools_s390x:
 Additional_Build_Tools_aarch64:
   - libpng-dev
 
+Additional_Build_Tools_armv7l:
+  - gcc-7                         # Needed as pre-built version causes crashes
+  - g++-7                         # Needed as pre-built version causes crashes
+
 Test_Tool_Packages:
   - acl
   - mercurial


### PR DESCRIPTION
Will fix https://github.com/adoptium/adoptium-support/issues/319 once a suitable break goes into the build repo ([linux.sh](https://github.com/adoptium/temurin-build/blob/master/build-farm/platform-specific-configurations/linux.sh)) to stop it picking up the version from `/usr/local/gcc`

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
