### PR TITLE
unixPB: set /etc/hosts to use IPV4 address rather than ansible_host

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adopt_etc/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adopt_etc/tasks/main.yml
@@ -60,7 +60,7 @@
   lineinfile:
     dest: /etc/hosts
     regexp: "^(.*){{ ansible_hostname }}(.*)$"
-    line: "{{ ansible_host }} {{ inventory_hostname }}.{{ Domain }} {{ inventory_hostname }}"
+    line: "{{ ansible_default_ipv4.address }} {{ inventory_hostname }}.{{ Domain }} {{ inventory_hostname }}"
     state: present
   when:
     - Domain == "adoptopenjdk.net"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adopt_etc/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adopt_etc/tasks/main.yml
@@ -60,6 +60,19 @@
   lineinfile:
     dest: /etc/hosts
     regexp: "^(.*){{ ansible_hostname }}(.*)$"
+    line: "{{ ansible_host }} {{ inventory_hostname }}.{{ Domain }} {{ inventory_hostname }}"
+    state: present
+  when:
+    - Domain == "adoptopenjdk.net"
+    - inventory_hostname != ansible_host
+    - ansible_host != "127.0.0.1"
+    - inventory_hostname != "localhost"
+  tags: hosts_file, adoptopenjdk
+  
+- name: Update /etc/hosts file - IP FQDN hostname
+  lineinfile:
+    dest: /etc/hosts
+    regexp: "^(.*){{ ansible_hostname }}(.*)$"
     line: "{{ ansible_default_ipv4.address }} {{ inventory_hostname }}.{{ Domain }} {{ inventory_hostname }}"
     state: present
   when:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adopt_etc/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adopt_etc/tasks/main.yml
@@ -68,7 +68,7 @@
     - ansible_host != "127.0.0.1"
     - inventory_hostname != "localhost"
   tags: hosts_file, adoptopenjdk
-  
+
 - name: Update /etc/hosts file - IP FQDN hostname
   lineinfile:
     dest: /etc/hosts


### PR DESCRIPTION
On Solaris where we use a jumpbox ansible_host is set to cloud.siteox.com rather than the IPv4 address so the machine is unable to resolve its hostname

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
