### PR TITLE
unixPB: create ensure that gconfd-2 is in the correct location for TCK

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Solaris.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Solaris.yml
@@ -240,7 +240,7 @@
   tags: build_tools
 
 # Fixes: GConf Error: Failed to launch configuration server: Failed to execute child process "/usr/lib/sparcv9/gconfd-2" (No such file or directory)
-- name: Create symlinks gconfd-2 
+- name: Create symlinks gconfd-2
   file:
     src: /usr/lib/gconfd-2
     dest: /usr/lib/sparcv9/gconfd-2

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Solaris.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Solaris.yml
@@ -56,11 +56,22 @@
     - ansible_architecture == "i386"
   tags: build_tools
 
+- name: Check if Solaris Studio 12.3 is installed
+  stat:
+    path: /opt/solarisstudio12.3/bin/
+  register: solaris_studio
+  tags:
+    - build_tools
+    - solaris_studio
+    - adoptopenjdk
+
 - name: Setting Solaris Studio variables (x64)
   set_fact:
     SolarisStudioArch: "x86"
     DownloadURL: "https://ansiblestorageadopt.blob.core.windows.net/solarisstudiox64/SolarisStudio12.3-solaris-x86-pkg.tar.bz2?{{ SolarisStudio12_solaris_x86_SAS_TOKEN }}"
-  when: ansible_architecture == "i386"
+  when:
+    - not solaris_studio.stat.exists
+    - ansible_architecture == "i386"
   tags:
     - build_tools
     - solaris_studio
@@ -70,16 +81,9 @@
   set_fact:
     SolarisStudioArch: "sparc"
     DownloadURL: "https://ansiblestorageadopt.blob.core.windows.net/solarisstudiosparc/SolarisStudio12.3-solaris-sparc-pkg.tar.bz2?{{ SolarisStudio12_solaris_sparc_SAS_TOKEN }}"
-  when: ansible_architecture == "sun4v"
-  tags:
-    - build_tools
-    - solaris_studio
-    - adoptopenjdk
-
-- name: Check if Solaris Studio 12.3 is installed
-  stat:
-    path: /opt/solarisstudio12.3/bin/
-  register: solaris_studio
+  when:
+    - not solaris_studio.stat.exists
+    - ansible_architecture == "sun4v"
   tags:
     - build_tools
     - solaris_studio
@@ -234,6 +238,17 @@
     - make
     - sha256sum
   tags: build_tools
+
+# Fixes: GConf Error: Failed to launch configuration server: Failed to execute child process "/usr/lib/sparcv9/gconfd-2" (No such file or directory)
+- name: Create symlinks gconfd-2 
+  file:
+    src: /usr/lib/gconfd-2
+    dest: /usr/lib/sparcv9/gconfd-2
+    owner: root
+    group: root
+    state: link
+  when:
+    - ansible_architecture == "sun4v"
 
 - name: Install Test Tool Packages
   pkgutil: "name={{ item }} state=present"


### PR DESCRIPTION
Also swaps the Solaris studio check to be before the secrets to make it easier to run without vendor files

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
