### PR TITLE
pbTests: Change any occurrence of openjdk-tests to aqa-tests in the test script

### DIFF
--- a/ansible/pbTestScripts/testJDK.sh
+++ b/ansible/pbTestScripts/testJDK.sh
@@ -10,9 +10,9 @@ else
 fi
 
 mkdir -p $HOME/testLocation
-[ ! -d $HOME/testLocation/openjdk-tests ] && git clone https://github.com/adoptopenjdk/openjdk-tests $HOME/testLocation/openjdk-tests
-$HOME/testLocation/openjdk-tests/get.sh -t $HOME/testLocation/openjdk-tests
-cd $HOME/testLocation/openjdk-tests/TKG || exit 1
+[ ! -d $HOME/testLocation/aqa-tests ] && git clone https://github.com/adoptium/aqa-tests.git $HOME/testLocation/aqa-tests
+$HOME/testLocation/aqa-tests/get.sh -t $HOME/testLocation/aqa-tests
+cd $HOME/testLocation/aqa-tests/TKG || exit 1
 export BUILD_LIST=functional
 $MAKE_COMMAND compile
 # Runs this test to check for prerequisite perl modules


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly


ref https://github.com/adoptium/infrastructure/issues/2121

The latest failure on the QEMU ppc64le job produces this failure

```
00:17:27 TESTDIR: /home/linux/testLocation/openjdk-tests is invalid. Please use --testdir|-t to set valid TESTDIR under aqa-tests. Default value current dir (pwd) is used if not provided.
00:17:32 /home/linux/openjdk-infrastructure/ansible/pbTestScripts/testJDK.sh: line 15: cd: /home/linux/testLocation/openjdk-tests/TKG: No such file or directory
00:17:32 + grep -q 'FAILED: 0' /home/vagrant1/workspace/QEMUPlaybookCheck/ARCHITECTURE/ppc64le/OS/ubuntu18/label/vagrant/ansible/pbTestScripts/qemu_pbCheck/logFiles/UBUNTU18.PPC64LE.test_log
00:17:32 + echo TEST FAILED
```

The other QEMU jobs would produce the same failure if they get to the test stage, but they keep failing before that.

Making these changes fixes the issue on my local machine, will test on the QEMU disk image before merging