### PR TITLE
pbTests add win playbook testing using WSL

### DIFF
--- a/.github/workflows/build_wsl.yml
+++ b/.github/workflows/build_wsl.yml
@@ -56,4 +56,5 @@ jobs:
       run: |
         cd ansible
         export ANSIBLE_CONFIG=./ansible.cfg
-        ansible-playbook -i playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win -b --skip-tags adoptopenjdk,jenkins,reboot playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+        # Skip MSVS_2013 until https://github.com/adoptium/infrastructure/issues/2178 is fixed
+        ansible-playbook -i playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win -b --skip-tags adoptopenjdk,jenkins,MSVS_2013,reboot playbooks/AdoptOpenJDK_Windows_Playbook/main.yml

--- a/.github/workflows/build_wsl.yml
+++ b/.github/workflows/build_wsl.yml
@@ -1,0 +1,59 @@
+name: Windows Playbook Checker
+
+defaults:
+  run:
+    shell: wsl-bash {0}
+
+on:
+  pull_request:
+    paths:
+    - .github/workflows/build_wsl.yml
+    - ansible/playbooks/AdoptOpenJDK_Windows_Playbook/**
+    branches:         
+    - master
+
+jobs:
+  build-wsl:
+    name: Windows 2019
+    runs-on: windows-latest
+    steps:
+
+    - name: Setup WinRM and Password
+      shell: powershell
+      run: |
+        Set-LocalUser -Name "runneradmin" -Password (ConvertTo-SecureString -AsPlainText "Ansible_password123!" -Force)
+        New-NetFirewallRule -DisplayName "ALLOW TCP PORT 5986" -Direction inbound -Profile Any -Action Allow -LocalPort 5986 -Protocol TCP
+        Invoke-WebRequest https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile .\ConfigureRemotingForAnsible.ps1
+        .\ConfigureRemotingForAnsible.ps1 -CertValidityDays 9999
+        .\ConfigureRemotingForAnsible.ps1 -EnableCredSSP
+        .\ConfigureRemotingForAnsible.ps1 -ForceNewSSLCert
+        .\ConfigureRemotingForAnsible.ps1 -SkipNetworkProfileCheck
+
+    - uses: actions/checkout@v2
+
+    - uses: Vampire/setup-wsl@v1
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt install -y ansible
+
+    - name: Setup Hosts file
+      run: |
+        cd ansible
+        rm -f playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win
+        cat <<EOF > playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win
+        [windows]
+        127.0.0.1
+        [windows:vars]
+        ansible_user=runneradmin
+        ansible_password=Ansible_password123!
+        ansible_become=false
+        EOF
+        sed -i -e "s/.*hosts:.*/- hosts: all/g" playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+
+    - name: Run Ansible Playbook
+      run: |
+        cd ansible
+        export ANSIBLE_CONFIG=./ansible.cfg
+        ansible-playbook -i playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win -b --skip-tags adoptopenjdk,jenkins,MSVS_2013,MSVS_2019,reboot playbooks/AdoptOpenJDK_Windows_Playbook/main.yml

--- a/.github/workflows/build_wsl.yml
+++ b/.github/workflows/build_wsl.yml
@@ -56,4 +56,4 @@ jobs:
       run: |
         cd ansible
         export ANSIBLE_CONFIG=./ansible.cfg
-        ansible-playbook -i playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win -b --skip-tags adoptopenjdk,jenkins,MSVS_2013,MSVS_2019,reboot playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+        ansible-playbook -i playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win -b --skip-tags adoptopenjdk,jenkins,reboot playbooks/AdoptOpenJDK_Windows_Playbook/main.yml

--- a/.github/workflows/build_wsl.yml
+++ b/.github/workflows/build_wsl.yml
@@ -38,7 +38,7 @@ jobs:
         .\ConfigureRemotingForAnsible.ps1 -ForceNewSSLCert
         .\ConfigureRemotingForAnsible.ps1 -SkipNetworkProfileCheck
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: Vampire/setup-wsl@v1
 

--- a/.github/workflows/build_wsl.yml
+++ b/.github/workflows/build_wsl.yml
@@ -2,7 +2,7 @@ name: Windows Playbook Checker
 
 defaults:
   run:
-    shell: wsl-sh {0}
+    shell: wsl-bash {0}
 
 on:
   pull_request:
@@ -43,9 +43,13 @@ jobs:
     - uses: Vampire/setup-wsl@v1
       with:
         distribution: Alpine
+        additional-packages:
+          bash
+          ansible
 
-    - name: Install dependencies
-      run: apk add ansible
+    - name: Install pywinrm
+      run: |
+        pip install pywinrm
 
     - name: Setup Hosts file
       working-directory: ansible

--- a/.github/workflows/build_wsl.yml
+++ b/.github/workflows/build_wsl.yml
@@ -41,11 +41,11 @@ jobs:
     - uses: actions/checkout@v3
 
     - uses: Vampire/setup-wsl@v1
+      with:
+        distribution: Alpine
 
     - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt install -y ansible
+      run: apk add ansible
 
     - name: Setup Hosts file
       working-directory: ansible

--- a/.github/workflows/build_wsl.yml
+++ b/.github/workflows/build_wsl.yml
@@ -2,7 +2,7 @@ name: Windows Playbook Checker
 
 defaults:
   run:
-    shell: wsl-bash {0}
+    shell: wsl-sh {0}
 
 on:
   pull_request:

--- a/.github/workflows/build_wsl.yml
+++ b/.github/workflows/build_wsl.yml
@@ -41,15 +41,11 @@ jobs:
     - uses: actions/checkout@v3
 
     - uses: Vampire/setup-wsl@v1
-      with:
-        distribution: Alpine
-        additional-packages:
-          bash
-          ansible
 
-    - name: Install pywinrm
+    - name: Install dependencies
       run: |
-        pip install pywinrm
+        sudo apt-get update
+        sudo apt install -y ansible
 
     - name: Setup Hosts file
       working-directory: ansible

--- a/.github/workflows/build_wsl.yml
+++ b/.github/workflows/build_wsl.yml
@@ -12,10 +12,19 @@ on:
     branches:         
     - master
 
+# Cancel existing runs if user makes another push.
+concurrency:
+  group: "${{ github.ref }}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-wsl:
-    name: Windows 2019
-    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2019, windows-2022]
+    name: Windows
+    runs-on: ${{ matrix.os }}
     steps:
 
     - name: Setup WinRM and Password

--- a/.github/workflows/build_wsl.yml
+++ b/.github/workflows/build_wsl.yml
@@ -48,8 +48,8 @@ jobs:
         sudo apt install -y ansible
 
     - name: Setup Hosts file
+      working-directory: ansible
       run: |
-        cd ansible
         rm -f playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win
         cat <<EOF > playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win
         [windows]
@@ -62,8 +62,8 @@ jobs:
         sed -i -e "s/.*hosts:.*/- hosts: all/g" playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
 
     - name: Run Ansible Playbook
+      working-directory: ansible
       run: |
-        cd ansible
         export ANSIBLE_CONFIG=./ansible.cfg
         # Skip MSVS_2013 until https://github.com/adoptium/infrastructure/issues/2178 is fixed
         ansible-playbook -i playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win -b --skip-tags adoptopenjdk,jenkins,MSVS_2013,reboot playbooks/AdoptOpenJDK_Windows_Playbook/main.yml

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,4 +1,4 @@
-# openjdk-infrastructure guide to frequent modifications and usage
+# Infrastructure guide to frequent modifications and usage
 
 ## Access control in the repository
 The three github teams relevant to this repository are as follows (Note, you
@@ -17,6 +17,18 @@ circumstances such as a clear breakage that has a simple fix available
 then a repository admin may override that requirement to push through
 a change if no reviewers are available, but in such cases a comment
 explaining why must be added to the Pull Request.
+
+## GitHub actions CI jobs
+
+Most Ansible changes are tested automatically with a series of CI jobs:
+
+| Platform | Workflow File | Notes
+|---|---|---|
+| Centos 6 | [build.yml](./.github/workflows/build.yml) | |
+| Alpine 3 | [build.yml](./.github/workflows/build.yml) | |
+| macOS 10.15 | [build_mac.yml](./.github/workflows/build_mac.yml) | |
+| Windows (2019 and 2022) | [build_wsl.yml](./.github/workflows/build_wsl.yml) | Uses Windows Subsystem for Linux to run ansible |
+| Solaris 10 | [build_vagrant.yml](./.github/workflows/build_vagrant.yml) | Uses Vagrant to run a Solaris image inside a macOS host |
 
 ## Running the ansible scripts on local machines
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -36,42 +36,42 @@
     - Debug
     - role: Get_Vendor_Files
       tags: [vendor_files, adoptopenjdk, jenkins]
-    # - Version
-    # - Common
-    # - Windows_Updates
-    # - WMF_5.1
-    # - Jenkins                     # AdoptOpenJDK infrastructure
-    # - CodesignCert
-    # - 7-Zip                       # Mostly extracting other prereqs :-)
-    # - cygwin
-    # - Firefox
-    # - Strawberry_Perl             # Testing
-    # - Freemarker                  # OpenJ9
-    # - GIT
-    # - Java7                       # JDK8 build bootstrap
-    # - Java8                       # JDK9 build bootstrap/ For Gradle
-    # - role: Java_install          # JDK11 build bootstrap
-    #   jdk_version: 10
-    # - role: Java_install          # For Gradle
-    #   jdk_version: 11
-    # - role: Java_install          # JDK16 build bootstrap
-    #   jdk_version: 15
-    # - role: Java_install          # JDK17 build bootstrap
-    #   jdk_version: 16
-    # - role: Java_install
-    #   jdk_version: 17
-    # - ANT                         # Testing
-    # - MSVS_2013
-    # - MSVS_2017                   # OpenJ9
-    # - MSVS_2019                   # OpenJ9
-    # - NVidia_Cuda_Toolkit         # OpenJ9
-    # - NTP_TIME
-    # - Clang_64bit                 # OpenJ9
-    # - Clang_32bit                 # OpenJ9
-    # - nasm                        # OpenJ9
-    # - Rust                        # IcedTea-Web
-    # - IcedTea-Web                 # For Jenkins webstart
-    # - WiX                         # For creating installers
+    - Version
+    - Common
+    - Windows_Updates
+    - WMF_5.1
+    - Jenkins                     # AdoptOpenJDK infrastructure
+    - CodesignCert
+    - 7-Zip                       # Mostly extracting other prereqs :-)
+    - cygwin
+    - Firefox
+    - Strawberry_Perl             # Testing
+    - Freemarker                  # OpenJ9
+    - GIT
+    - Java7                       # JDK8 build bootstrap
+    - Java8                       # JDK9 build bootstrap/ For Gradle
+    - role: Java_install          # JDK11 build bootstrap
+      jdk_version: 10
+    - role: Java_install          # For Gradle
+      jdk_version: 11
+    - role: Java_install          # JDK16 build bootstrap
+      jdk_version: 15
+    - role: Java_install          # JDK17 build bootstrap
+      jdk_version: 16
+    - role: Java_install
+      jdk_version: 17
+    - ANT                         # Testing
+    - MSVS_2013
+    - MSVS_2017                   # OpenJ9
+    - MSVS_2019                   # OpenJ9
+    - NVidia_Cuda_Toolkit         # OpenJ9
+    - NTP_TIME
+    - Clang_64bit                 # OpenJ9
+    - Clang_32bit                 # OpenJ9
+    - nasm                        # OpenJ9
+    - Rust                        # IcedTea-Web
+    - IcedTea-Web                 # For Jenkins webstart
+    - WiX                         # For creating installers
     - shortNames
     - Dragonwell                  # Dragonwell bootstrap image
     - role: Thunderbird

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -36,42 +36,42 @@
     - Debug
     - role: Get_Vendor_Files
       tags: [vendor_files, adoptopenjdk, jenkins]
-    - Version
-    - Common
-    - Windows_Updates
-    - WMF_5.1
-    - Jenkins                     # AdoptOpenJDK infrastructure
-    - CodesignCert
-    - 7-Zip                       # Mostly extracting other prereqs :-)
-    - cygwin
-    - Firefox
-    - Strawberry_Perl             # Testing
-    - Freemarker                  # OpenJ9
-    - GIT
-    - Java7                       # JDK8 build bootstrap
-    - Java8                       # JDK9 build bootstrap/ For Gradle
-    - role: Java_install          # JDK11 build bootstrap
-      jdk_version: 10
-    - role: Java_install          # For Gradle
-      jdk_version: 11
-    - role: Java_install          # JDK16 build bootstrap
-      jdk_version: 15
-    - role: Java_install          # JDK17 build bootstrap
-      jdk_version: 16
-    - role: Java_install
-      jdk_version: 17
-    - ANT                         # Testing
-    - MSVS_2013
-    - MSVS_2017                   # OpenJ9
-    - MSVS_2019                   # OpenJ9
-    - NVidia_Cuda_Toolkit         # OpenJ9
-    - NTP_TIME
-    - Clang_64bit                 # OpenJ9
-    - Clang_32bit                 # OpenJ9
-    - nasm                        # OpenJ9
-    - Rust                        # IcedTea-Web
-    - IcedTea-Web                 # For Jenkins webstart
-    - WiX                         # For creating installers
+    # - Version
+    # - Common
+    # - Windows_Updates
+    # - WMF_5.1
+    # - Jenkins                     # AdoptOpenJDK infrastructure
+    # - CodesignCert
+    # - 7-Zip                       # Mostly extracting other prereqs :-)
+    # - cygwin
+    # - Firefox
+    # - Strawberry_Perl             # Testing
+    # - Freemarker                  # OpenJ9
+    # - GIT
+    # - Java7                       # JDK8 build bootstrap
+    # - Java8                       # JDK9 build bootstrap/ For Gradle
+    # - role: Java_install          # JDK11 build bootstrap
+    #   jdk_version: 10
+    # - role: Java_install          # For Gradle
+    #   jdk_version: 11
+    # - role: Java_install          # JDK16 build bootstrap
+    #   jdk_version: 15
+    # - role: Java_install          # JDK17 build bootstrap
+    #   jdk_version: 16
+    # - role: Java_install
+    #   jdk_version: 17
+    # - ANT                         # Testing
+    # - MSVS_2013
+    # - MSVS_2017                   # OpenJ9
+    # - MSVS_2019                   # OpenJ9
+    # - NVidia_Cuda_Toolkit         # OpenJ9
+    # - NTP_TIME
+    # - Clang_64bit                 # OpenJ9
+    # - Clang_32bit                 # OpenJ9
+    # - nasm                        # OpenJ9
+    # - Rust                        # IcedTea-Web
+    # - IcedTea-Web                 # For Jenkins webstart
+    # - WiX                         # For creating installers
     - shortNames
     - Dragonwell                  # Dragonwell bootstrap image
     - role: Thunderbird

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2013/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2013/tasks/main.yml
@@ -35,4 +35,6 @@
     reboot_timeout: 1800
     shutdown_timeout: 1800
   when: (not vs2013_installed.stat.exists)
-  tags: MSVS_2013
+  tags:
+    - MSVS_2013
+    - reboot

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
@@ -41,4 +41,6 @@
     reboot_timeout: 1800
     shutdown_timeout: 1800
   when: (not vs2017_installed.stat.exists)
-  tags: MSVS_2017
+  tags:
+    - MSVS_2017
+    - reboot

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Test if VS 2017 is installed
   win_stat:
-    path: 'C:\Program Files (x86)\Microsoft Visual Studio\2017'
+    path: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community'
   register: vs2017_installed
   tags: MSVS_2017
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
@@ -48,4 +48,6 @@
     reboot_timeout: 1800
     shutdown_timeout: 1800
   when: (not vs2019_installed.stat.exists)
-  tags: MSVS_2019
+  tags:
+    - MSVS_2019
+    - reboot

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Test if VS 2019 is installed
   win_stat:
-    path: 'C:\Program Files (x86)\Microsoft Visual Studio\2019'
+    path: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community'
   register: vs2019_installed
   tags: MSVS_2019
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Windows_Updates/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Windows_Updates/tasks/main.yml
@@ -16,4 +16,6 @@
     reboot_timeout: 3600
   failed_when: false
   when: update_result.reboot_required
-  tags: Windows_Updates
+  tags:
+    - Windows_Updates
+    - reboot

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
@@ -49,4 +49,6 @@
   win_reboot:
     reboot_timeout: 1800
   when: (not cygwin_installed.stat.exists)
-  tags: cygwin
+  tags:
+    - cygwin
+    - reboot

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/shortNames/scripts/shortName.ps1
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/shortNames/scripts/shortName.ps1
@@ -6,14 +6,14 @@ $shortName=$Args[1]
 $string=(cmd /c dir /x "C:\Program Files (x86)" | grep "$dirName")
 
 # Skip the directory if it doesn't exist
-If ($string -eq $null){
-	echo "Directory not found - skipping"
+If ($null -eq $string){
+	Write-Output "Directory not found - skipping"
 	exit
 }
 
 $result=($string.split(" ")[17])
 
 If ($result -eq ""){
-	echo "Setting Shortname"
+	Write-Output "Setting Shortname"
 	fsutil file setshortname "C:\Program Files (x86)\$dirName" $shortName
 }

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/shortNames/scripts/shortName.ps1
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/shortNames/scripts/shortName.ps1
@@ -4,6 +4,13 @@ $dirName=$Args[0]
 $shortName=$Args[1]
 
 $string=(cmd /c dir /x "C:\Program Files (x86)" | grep "$dirName")
+
+# Skip the directory if it doesn't exist
+If ($string -eq $null){
+	echo "Directory not found - skipping"
+	exit
+}
+
 $result=($string.split(" ")[17])
 
 If ($result -eq ""){

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/shortNames/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/shortNames/tasks/main.yml
@@ -12,6 +12,13 @@
   tags:
     - shortnames
 
+- name: Enable shortnames in Registry
+  win_regedit:
+    path: HKU:\.SYSTEM\CurrentControlSet\Control\Filesystem
+    name: NtfsDisable8dot3NameCreation
+    data: 1
+    type: dword
+
 - name: Enable shortnames on drive C:/
   win_shell: "fsutil 8dot3name set C: 0"
   when: (not enabled_shortnames.stdout)

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/shortNames/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/shortNames/tasks/main.yml
@@ -18,6 +18,9 @@
     name: NtfsDisable8dot3NameCreation
     data: 2
     type: dword
+  when: (not enabled_shortnames.stdout)
+  tags:
+    - shortnames
 
 - name: Enable shortnames on drive C:/
   win_shell: "fsutil 8dot3name set C: 0"

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/shortNames/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/shortNames/tasks/main.yml
@@ -14,9 +14,9 @@
 
 - name: Enable shortnames in Registry
   win_regedit:
-    path: HKU:\SYSTEM\CurrentControlSet\Control\Filesystem
+    path: HKLM:\SYSTEM\CurrentControlSet\Control\Filesystem
     name: NtfsDisable8dot3NameCreation
-    data: 1
+    data: 2
     type: dword
 
 - name: Enable shortnames on drive C:/

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/shortNames/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/shortNames/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: Enable shortnames in Registry
   win_regedit:
-    path: HKU:\.SYSTEM\CurrentControlSet\Control\Filesystem
+    path: HKU:\SYSTEM\CurrentControlSet\Control\Filesystem
     name: NtfsDisable8dot3NameCreation
     data: 1
     type: dword


### PR DESCRIPTION
This will allow everyone to test the playbook using WSL (the Linux CL built into modern windows).  This also allows simpler testing of the Playbooks as we can then use WSL support in GH Actions. This allows Ansible to run 'natively'.

This PR also adds the `reboot` tag to tasks that require a windows restart to be run as well as a modification to the shortnames script to both add a registry key (required for win 2022) and also skip creating a shortname if the original directory doesn't exist.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [x] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
