### PR TITLE
Install boot JDk16 for bootstrapping JDK17 builds.

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
@@ -82,10 +82,9 @@
 
     - bootjdk7
     - bootjdk8
-    - bootjdk9
     - bootjdk10
     - bootjdk11
-    - bootjdk12
+    - bootjdk16
 
     # 7. Modify /etc/hosts file to include ipv4 address and fqdn
 

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/bootjdk16/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/bootjdk16/tasks/main.yml
@@ -1,0 +1,36 @@
+#################
+# OpenJ9 JDK 16 #
+#################
+---
+- name: Check for Java16 availability
+  stat:
+    path: /usr/java16_64
+  register: java16
+  tags: java16
+
+- name: Transfer and Extract AdoptOpenJDK 16
+  unarchive:
+    src: https://api.adoptopenjdk.net/v3/binary/latest/16/ga/aix/ppc64/jdk/{{ bootjdk }}/normal/adoptopenjdk?project=jdk
+    dest: /usr
+    remote_src: yes
+  when: java16.stat.isdir is not defined
+  tags: java16
+
+- name: Find java16 directory
+  find:
+    file_type: directory
+    paths: /usr
+    patterns: 'jdk-16*'
+  when: java16.stat.isdir is not defined
+  register: java16_files_matched
+  tags: java16
+
+- name: Symlink to java16_64
+  file:
+    src: "{{ item.path }}"
+    dest: /usr/java16_64
+    state: link
+  with_items:
+    - "{{ java16_files_matched.files }}"
+  when: java16.stat.isdir is not defined
+  tags: java16

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -100,6 +100,13 @@
         - ansible_distribution != "Solaris"
         - ansible_architecture != "riscv64"
       tags: build_tools
+    - role: adoptopenjdk_install  # JDK17 Build Bootstrap
+      jdk_version: 16
+      when:
+        - ansible_distribution != "Alpine"
+        - ansible_distribution != "Solaris"
+        - ansible_architecture != "riscv64"
+      tags: build_tools
     - role: Nagios_Plugins        # AdoptOpenJDK Infrastructure
       tags: [nagios_plugins, adoptopenjdk]
     - role: Nagios_Master_Config  # AdoptOpenJDK Infrastructure

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -56,6 +56,8 @@
       jdk_version: 11
     - role: Java_install          # JDK16 build bootstrap
       jdk_version: 15
+    - role: Java_install          # JDK17 build bootstrap
+      jdk_version: 16
     - ANT                         # Testing
     - MSVS_2013
     - MSVS_2017                   # OpenJ9


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

VPC not run yet due to VPC failing.

Related AIX enhancement request to maek the role parameterised as per other platforms has been raised at https://github.com/adoptium/infrastructure/issues/2239