### PR TITLE
UnixPb: Install packages from repositories instead of compiling when necessary

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -124,6 +124,13 @@
     - ansible_architecture == "armv7l"
   tags: build_tools
 
+- name: Install additional build tools for Ubuntu 20 +
+  package: "name={{ item }} state=latest"
+  with_items: "{{ Additional_Build_Tools_Ubuntu20+ }}"
+  when:
+    - ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= "20"
+  tags: build_tools
+
 #########################
 # Additional Test Tools #
 #########################

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -126,7 +126,7 @@
 
 - name: Install additional build tools for Ubuntu 20 +
   package: "name={{ item }} state=latest"
-  with_items: "{{ Additional_Build_Tools_Ubuntu20+ }}"
+  with_items: "{{ Additional_Build_Tools_Ubuntu20 }}"
   when:
     - ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= "20"
   tags: build_tools

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -61,12 +61,16 @@ gcc48_devtoolset_compiler:
 
 Additional_Build_Tools_CentOS7:
   - libstdc++-static
+  - cacche
 
 Additional_Build_Tools_CentOS8:
   - glibc-locale-source
   - glibc-langpack-ja             # required for creating Japanese locales
   - glibc-langpack-ko             # required for creating Korean locales
   - glibc-langpack-zh             # required for creating Chinese locales
+  - git
+  - cmake
+  - ccache
 
 Additional_Build_Tools_NOT_CentOS8:
   - lbzip2

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -54,9 +54,13 @@ Additional_Build_Tools_RHEL8:
   - glibc-langpack-ja             # required for creating Japanese locales
   - glibc-langpack-ko             # required for creating Korean locales
   - glibc-langpack-zh             # required for creating Chinese locales
+  - git
+  - cmake
+  - ccache
 
 Additional_Build_Tools_RHEL7:
   - libstdc++-static
+  - ccache
 
 Additional_Build_Tools_RHEL7_PPC64LE:
   - libstdc++

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
@@ -15,6 +15,7 @@ Build_Tool_Packages:
   - g++
   - gcc
   - gettext
+  - git
   - libasound2-dev
   - libcups2-dev
   - libcurl4-openssl-dev
@@ -100,6 +101,10 @@ Additional_Build_Tools_aarch64:
 Additional_Build_Tools_armv7l:
   - gcc-7                         # Needed as pre-built version causes crashes
   - g++-7                         # Needed as pre-built version causes crashes
+
+Additional_Build_Tools_Ubuntu20+:
+  - cmake
+  - ccache
 
 Test_Tool_Packages:
   - acl

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
@@ -102,7 +102,7 @@ Additional_Build_Tools_armv7l:
   - gcc-7                         # Needed as pre-built version causes crashes
   - g++-7                         # Needed as pre-built version causes crashes
 
-Additional_Build_Tools_Ubuntu20+:
+Additional_Build_Tools_Ubuntu20:
   - cmake
   - ccache
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ccache/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ccache/tasks/main.yml
@@ -9,6 +9,7 @@
 
 - name: Check if ccache is already installed
   shell: ccache --version >/dev/null
+  ignore_errors: yes
   register: ccache_status
   tags: ccache
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ccache/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ccache/tasks/main.yml
@@ -8,15 +8,14 @@
   tags: ccache
 
 - name: Check if ccache is already installed
-  stat:
-    path: /usr/local/bin/ccache
+  shell: ccache --version >/dev/null
   register: ccache_status
   tags: ccache
 
 - name: Download ccache.tar.gz
   command: wget -O /tmp/ccache.tar.gz https://github.com/ccache/ccache/releases/download/v{{ ccacheVersion }}/ccache-{{ ccacheVersion }}.tar.gz
     warn=False
-  when: ccache_status.stat.isdir is not defined
+  when: ccache_status.rc != 0
   tags: ccache
 
 - name: Extract ccache
@@ -24,20 +23,20 @@
     src: /tmp/ccache.tar.gz
     dest: /tmp
     copy: False
-  when: ccache_status.stat.isdir is not defined
+  when: ccache_status.rc != 0
   tags: ccache
 
 - name: Running ./configure & make for CCACHE
   shell: cd /tmp/ccache-{{ ccacheVersion }} && ./configure && make clean && make -j {{ ansible_processor_vcpus }} && make install
   when:
-    - ccache_status.stat.isdir is not defined
+    - ccache_status.rc != 0
     - ansible_distribution != "FreeBSD"
   tags: ccache
 
 - name: Running ./configure & make for CCACHE for FreeBSD
   shell: cd /tmp/ccache-{{ ccacheVersion }} && ./configure && make -j {{ ansible_processor_vcpus }} && gmake install
   when:
-    - ccache_status.stat.isdir is not defined
+    - ccache_status.rc != 0
     - ansible_distribution == "FreeBSD"
   tags: ccache
 


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/2091

The unix playbook compiles Git, Cmake and Ccache to versions 2.15, 3.11.4, 3.4.2, respectively. On OS's whose default repos offer these packages at versions equal to or greater than the compiled versions, I have made it so that these packages are downloaded from there instead. See https://github.com/adoptium/infrastructure/issues/2091#issuecomment-869578801

The packages are installed from the repos in the `Common` role, which occurs before any of the roles in which these packages would otherwise be compiled, so theres no risk of duplicate installation. However, the `ccache` role checks for an already installed version of ccache by checking the `/usr/local/bin/ccache` directory. It needs to be made sure that the ccache downloaded from a repository installs to this directory.

Am in the process of making the changes to Debian
