### PR TITLE
pbTests: Reset Solaris host key after playbook completion

### DIFF
--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -243,6 +243,13 @@ startVMPlaybook()
 		exit 1
 	fi
 
+	if [ "$OS" == "Solaris10" ]; then
+		# Remove IP from known_hosts as the playbook installs an
+		# alternate sshd which regenerates the host key infra#2244
+		ssh-keygen -R $(cat playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx)
+		ssh_args="$ssh_args -o StrictHostKeyChecking=no"
+	fi
+
 	if [[ "$testNativeBuild" = true ]]; then
 		local buildLogPath="$WORKSPACE/adoptopenjdkPBTests/logFiles/${gitFork}.${gitBranch}.$OS.build_log"
 


### PR DESCRIPTION
Hopefully fixes https://github.com/adoptium/infrastructure/issues/2244

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [x] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/1201/)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
