### PR TITLE
unixPB: Fix typo in ccache name in CentOS playbook

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -61,7 +61,7 @@ gcc48_devtoolset_compiler:
 
 Additional_Build_Tools_CentOS7:
   - libstdc++-static
-  - cacche
+  - ccache
 
 Additional_Build_Tools_CentOS8:
   - glibc-locale-source


### PR DESCRIPTION
When I merged I had misread the comment in https://github.com/adoptium/infrastructure/pull/2241 as the ccache CentOS7 VPC problem being an expected failure. But it looks like it was almost certainly a typo, so fixing ...

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
