### PR TITLE
unixPB: Add libatomic for RISC-V JDK head cross-compilation

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -25,6 +25,7 @@ Build_Tool_Packages:
   - glibc-devel
   - gmp-devel
   - java-1.8.0-openjdk-devel
+  - libatomic                     # Needed for RISC-V cross compilation
   - libcurl-devel
   - libdwarf-devel                # OpenJ9
   - libpng-devel

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -23,6 +23,7 @@ Build_Tool_Packages:
   - glibc-common
   - glibc-devel
   - gmp-devel
+  - libatomic                     # Needed for RISC-V cross compilation
   - libcurl-devel
   - libffi-devel
   - libpng-devel


### PR DESCRIPTION
RISC-V cross-compilation for JDK17 appears to require `libatomic` available natively on the build host

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/1207/)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
