### PR TITLE
doc: README updated to include information on installing and using Vagrant and Ansible on a  Windows machine

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -186,6 +186,10 @@ are run on jenkins in the
 
 Any additional help in setting up Vagrant with Virtualbox can be found [here](https://www.vagrantup.com/intro/getting-started/index.html)
 
+## Vagrant setup guide - Windows
+
+To test the ansible scripts, you'll need to install Vagrant and Virtualbox from [here](https://www.vagrantup.com/intro/getting-started/index.html)
+
 ## Vagrant setup guide - macOS
 
 To test the ansible scripts, you'll need to install the following programs.
@@ -249,6 +253,22 @@ In case one or more tasks fail or should not be run in the local environment, se
 ```bash
 ansible-playbook -b AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="install_zulu,jenkins_authorized_key,nagios_add_key,add_zeus_user_key"
 ```
+
+## Executing under vagrant (Windows)
+
+Ansible cannot be installed on a Windows machine, so you should boot a Linux VM using Vagrant and install it there instead:
+1) Copy a Linux Vagrantfile from  the `openjdk-infrastructure/ansible/vagrant` directory into the `openjdk-infrastructure/ansible` directory, and save it without an extension.
+2) Within the `openjdk-infrastructure/ansible` directory:
+
+```bash
+vagrant up
+
+vagrant ssh # Uses default ssh login, user=vagrant, password=vagrant
+```
+3) Install Ansible 2.4 or later (see beginning of the README)
+
+You should now be able to run a playbook using Vagrant.
+
 ## Using Ansible to modify Vagrant VM remote hosts (linux)
 
 The following method runs the ansible playbooks against a Vagrant VM remotely.

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -216,7 +216,7 @@ and also [virtualbox from their web site](https://www.virtualbox.org/wiki/Downlo
 
 To test the ansible scripts, you'll need to install Vagrant and Virtualbox from [here](https://www.vagrantup.com/intro/getting-started/index.html)
 
-## Executing under vagrant
+## Executing under vagrant (Linux/MacOS X)
 
 To test the ansible scripts you can set up a Virtual Machine isolated from your own host system.
 Several `Vagrantfile`s have been provided and the usual `vagrant` commands should get it up and running.
@@ -256,16 +256,25 @@ ansible-playbook -b AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="install_zul
 
 ## Executing under vagrant (Windows)
 
-Ansible cannot be installed on a Windows machine, so you should boot a Linux VM using Vagrant and install it there instead:
-1) Copy a Linux Vagrantfile from  the `openjdk-infrastructure/ansible/vagrant` directory into the `openjdk-infrastructure/ansible` directory, and save it without an extension.
-2) Within the `openjdk-infrastructure/ansible` directory:
+Ansible cannot be installed on a Windows machine, so you should boot a Linux VM using Vagrant and install it there instead.
+
+Within the `openjdk-infrastructure/ansible` directory:
+
+1) Copy a Linux Vagrantfile from  the `openjdk-infrastructure/ansible/vagrant` directory into the `openjdk-infrastructure/ansible` directory, and save it without an extension, for example:
+
+```bash
+copy .\vagrant\Vagrantfile.CentOS7 .
+
+ren Vagrantfile.CentOS7 Vagrantfile
+```
+2) Start up and use the VM:
 
 ```bash
 vagrant up
 
 vagrant ssh # Uses default ssh login, user=vagrant, password=vagrant
 ```
-3) Install Ansible 2.4 or later (see beginning of the README)
+3) Install Ansible 2.4 or later (see beginning of the README).
 
 You should now be able to navigate to the correct directory using:
 

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -186,10 +186,6 @@ are run on jenkins in the
 
 Any additional help in setting up Vagrant with Virtualbox can be found [here](https://www.vagrantup.com/intro/getting-started/index.html)
 
-## Vagrant setup guide - Windows
-
-To test the ansible scripts, you'll need to install Vagrant and Virtualbox from [here](https://www.vagrantup.com/intro/getting-started/index.html)
-
 ## Vagrant setup guide - macOS
 
 To test the ansible scripts, you'll need to install the following programs.
@@ -215,6 +211,10 @@ If you're on Ubuntu we have a playbook that can be used to set up your
 machine to run vagrant in [playbooks/vagrant.yml](playbooks/vagrant.yml) but
 it simply installs Vagrant from https://releases.hashicorp.com/vagrant/2.2.5/vagrant_2.2.5_x86_64.deb
 and also [virtualbox from their web site](https://www.virtualbox.org/wiki/Downloads)
+
+## Vagrant setup guide - Windows
+
+To test the ansible scripts, you'll need to install Vagrant and Virtualbox from [here](https://www.vagrantup.com/intro/getting-started/index.html)
 
 ## Executing under vagrant
 
@@ -267,7 +267,12 @@ vagrant ssh # Uses default ssh login, user=vagrant, password=vagrant
 ```
 3) Install Ansible 2.4 or later (see beginning of the README)
 
-You should now be able to run a playbook using Vagrant.
+You should now be able to navigate to the correct directory using:
+
+```bash
+cd /vagrant/playbooks
+```
+and run a playbook using Vagrant.
 
 ## Using Ansible to modify Vagrant VM remote hosts (linux)
 


### PR DESCRIPTION
Updated the README to include sections for installing Vagrant on a Windows machine, and installing and running Ansible within the Vagrant virtual machine.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
