### PR TITLE
unixPB: Remove openjdk-7-jdk from Ubuntu as it is no longer in the repositories

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -147,12 +147,6 @@
   when:
     - ansible_distribution_major_version == "16"
 
-- name: Install additional Packages specific to Ubuntu 16 (Not armv7l)
-  package: "name=openjdk-7-jdk state=latest"
-  when:
-    - ansible_distribution_major_version == "16"
-    - ansible_architecture != "armv7l"
-
 - name: Install additional Packages specific to Ubuntu 18
   package: "name={{ item }} state=latest"
   with_items: "{{ Additional_Packages_Ubuntu18 }}"


### PR DESCRIPTION
Ubuntu 16 users will now just have to source their own JDK7, or use the installed JDK8 as the boot JDK

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/1212/)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
