### PR TITLE
unixPB: remove gcc-7 from ubuntu armv7l playbook

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -117,13 +117,6 @@
     - ansible_architecture == "aarch64"
   tags: build_tools
 
-- name: Install additional build tools for x86
-  package: "name={{ item }} state=latest"
-  with_items: "{{ Additional_Build_Tools_armv7l }}"
-  when:
-    - ansible_architecture == "armv7l"
-  tags: build_tools
-
 - name: Install additional build tools for Ubuntu 20 +
   package: "name={{ item }} state=latest"
   with_items: "{{ Additional_Build_Tools_Ubuntu20 }}"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
@@ -98,10 +98,6 @@ Additional_Build_Tools_s390x:
 Additional_Build_Tools_aarch64:
   - libpng-dev
 
-Additional_Build_Tools_armv7l:
-  - gcc-7                         # Needed as pre-built version causes crashes
-  - g++-7                         # Needed as pre-built version causes crashes
-
 Additional_Build_Tools_Ubuntu20:
   - cmake
   - ccache


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Fixes: https://github.com/adoptium/infrastructure/issues/2262