### PR TITLE
Fix manifest command in jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,7 +79,7 @@ def dockerManifest() {
             export TARGET="adoptopenjdk/ubuntu1604_build_image"
             ARMV7L=$TARGET:linux-armv7l
             docker manifest create $TARGET $ARMV7L
-            docker manifest annotate $TARGET $ARMV7L --arch armv7l --os linux
+            docker manifest annotate $TARGET $ARMV7L --arch arm --os linux
             docker manifest push $TARGET
         '''
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [ ] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

fixes:

```bash
docker manifest annotate adoptopenjdk/ubuntu1604_build_image adoptopenjdk/ubuntu1604_build_image:linux-armv7l --arch armv7l --os linux
manifest entry for image has unsupported os/arch combination: linux/armv7l
```

