### PR TITLE
ansible: Added Thunderbird role to Windows playbook

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -73,3 +73,5 @@
     - WiX                         # For creating installers
     - shortNames
     - Dragonwell                  # Dragonwell bootstrap image
+    - role: Thunderbird
+      tags: [Thunderbird, jck, adoptopenjdk]

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Thunderbird/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Thunderbird/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+###############
+# Thunderbird #
+###############
+
+- name: Test if Thunderbird is already installed
+  win_stat:
+    path: 'C:\Program Files\Mozilla Thunderbird\thunderbird.exe'
+  register: thunderbird_installed
+
+- name: Check if Thunderbird is already downloaded
+  win_stat:
+    path: 'C:\temp\thunderbird.exe'
+  register: thunderbird_download
+
+- name: Download Thunderbird
+  win_get_url:
+    url: https://ftp.mozilla.org/pub/thunderbird/releases/78.11.0/win64/en-GB/Thunderbird%20Setup%2078.11.0.exe
+    dest: 'C:\temp\thunderbird.exe'
+    checksum: 58479f60339aadef41210f522d380dc13fe2611690e2942e141fd5361393c7da
+    checksum_algorithm: sha256
+  when: (not thunderbird_download.stat.exists) and (not thunderbird_installed.stat.exists)
+
+- name: Install Thunderbird
+  raw: C:\temp\thunderbird.exe -ms
+  when: (not thunderbird_installed.stat.exists)
+
+- name: Set Thunderbird as default
+  win_regedit:
+    path: HKCU:\Software\Clients\Mail
+    name: Default
+    data: Mozilla Thunderbird


### PR DESCRIPTION
This is after request https://bugs.eclipse.org/bugs/show_bug.cgi?id=574777.

I've created a `jck` tag that should be skipped for regular (ie non temurin-compliance) nodes.

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [X] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
