### PR TITLE
UnixPb: Add condition which skips brew upgrade on macos versions 10.13 or older

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
@@ -60,7 +60,7 @@
   become_user: "{{ ansible_user }}"
   homebrew:
     upgrade_all: yes
-  when: macos_version.stdout.split('.')[1] > "13"
+  when: "{{ macos_version.stdout.split('.')[0] }}.{{ macos_version.stdout.split('.')[1] }} is version('10.13', '>')"
   tags:
     - brew_upgrade
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
@@ -8,9 +8,13 @@
   shell: sw_vers -productVersion
   register: macos_version
 
+- name: Set macos version 
+  set_fact:
+    macos_version_number: "{{ macos_version.stdout.split('.')[0] }}.{{ macos_version.stdout.split('.')[1] }}"
+
 - name: Display macOS Version
   debug:
-    var: macos_version
+    var: macos_version_number
 
 - name: Configure system-wide Bash profile
   become: yes
@@ -60,7 +64,7 @@
   become_user: "{{ ansible_user }}"
   homebrew:
     upgrade_all: yes
-  when: "{{ macos_version.stdout.split('.')[0] }}.{{ macos_version.stdout.split('.')[1] }} is version('10.13', '>')"
+  when: macos_version_number is version('10.13', '>')"
   tags:
     - brew_upgrade
 
@@ -113,7 +117,7 @@
   homebrew: "name={{ item }} state=present"
   with_items: "{{ Build_Tool_Packages_NOT_10_12 }}"
   when:
-    - not (macos_version.stdout | regex_search("10.12"))
+    - not (macos_version_number | regex_search("10.12"))
   tags: build_tools
 
 - name: Install Build Tool Casks

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
@@ -64,7 +64,7 @@
   become_user: "{{ ansible_user }}"
   homebrew:
     upgrade_all: yes
-  when: macos_version_number is version('10.13', '>')"
+  when: "macos_version_number is version('10.13', '>')"
   tags:
     - brew_upgrade
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
@@ -60,6 +60,7 @@
   become_user: "{{ ansible_user }}"
   homebrew:
     upgrade_all: yes
+  when: macos_version.stdout.split('.')[1] > "13"
   tags:
     - brew_upgrade
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
@@ -8,7 +8,7 @@
   shell: sw_vers -productVersion
   register: macos_version
 
-- name: Set macos version 
+- name: Set macos version
   set_fact:
     macos_version_number: "{{ macos_version.stdout.split('.')[0] }}.{{ macos_version.stdout.split('.')[1] }}"
 


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Ref https://github.com/adoptium/infrastructure/issues/1910#issuecomment-879759594

On our Macos machines which have an OS of 10.13 or older, the playbooks hit an error when trying to upgrade the packages on the machine using brew

```
fatal: [test-macstadium-macos1013-x64-1]: FAILED! => {"changed": false, "msg": "Warning: You are using macOS 10.13.\n
We (and Apple) do not provide support for this old version.\n
You will encounter build failures with some formulae.\nPlease create pull requests instead of asking for help on Homebrew's GitHub,\nTwitter or any other official channels. You are responsible for resolving\n
any issues you experience while you are running this\n
old version.\n\n

Error: Your Command Line Tools are too outdated.\nUpdate them from Software Update in the App Store or run:\n  softwareupdate --all --install --force\n\n

If that doesn't show you an update run:\n
  sudo rm -rf /Library/Developer/CommandLineTools\n
  sudo xcode-select --install\n\n

Alternatively, manually download them from:\n
  https://developer.apple.com/download/more/."}
```

This should help stop playbook breakages in the meantime 