### PR TITLE
ansible: Change ownership of jenkins' ~/.ssh/known_hosts

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Jenkins_User/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Jenkins_User/tasks/main.yml
@@ -81,6 +81,13 @@
     state: present
   tags: [jenkins_user, adoptopenjdk]
 
+- name: Change ownership of jenkins' ~/.ssh/known_hosts
+  file:
+    path: "{{ home_folder }}/.ssh/known_hosts"
+    owner: "{{ Jenkins_Username }}"
+    mode: 0644
+  tags: [jenkins_user, adoptopenjdk]
+
 - name: Add Jenkins user to the audio group
   user: name={{ Jenkins_Username }}
     groups=audio


### PR DESCRIPTION
Signed-off-by: Frederic Gurr <frederic.gurr@eclipse-foundation.org>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
