### PR TITLE
unixPB: allow internal azure hosts to reach jckservices

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/jckservices_iptables/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/jckservices_iptables/tasks/main.yml
@@ -48,6 +48,12 @@
     destination_port: 80
     jump: ACCEPT
 
+- name: Allow Azure private network (10.1.x.x)
+  ansible.builtin.iptables:
+    chain: INPUT
+    src_range: 10.1.0.1-10.1.0.254
+    jump: ACCEPT
+
 - name: Setup iptables to only allow JCK hosts
   iptables:
     chain: INPUT

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/jckservices_iptables/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/jckservices_iptables/tasks/main.yml
@@ -49,7 +49,7 @@
     jump: ACCEPT
 
 - name: Allow Azure private network (10.1.x.x)
-  ansible.builtin.iptables:
+  iptables:
     chain: INPUT
     src_range: 10.1.0.1-10.1.0.254
     jump: ACCEPT


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
