### PR TITLE
AIXPb: Ensure AIX repos are enabled

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/yum/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/yum/tasks/main.yml
@@ -68,6 +68,18 @@
     - yum
     - vendor_files
 
+- name: Ensure AIX_Toolbox repo is enabled
+  shell: yum-config-manager --enable AIX_Toolbox
+  tags: yum
+
+- name: Ensure AIX_Toolbox_noarch repo is enabled
+  shell: yum-config-manager --enable AIX_Toolbox_noarch
+  tags: yum
+
+- name: Ensure AIX_Toolbox_71 repo is enabled
+  shell: yum-config-manager --enable AIX_Toolbox_71
+  tags: yum
+
 - name: Yum update
   yum:
     update_cache: yes


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/2126

Discovered the `yum-config-manager` command which, amongst other things, allows a user to enable and disable repos. Tested on ojdk06. Works as expected
