### PR TITLE
Github: change python and ansible install to yum

### DIFF
--- a/ansible/docker/Dockerfile.CentOS6
+++ b/ansible/docker/Dockerfile.CentOS6
@@ -6,16 +6,8 @@ ARG user=jenkins
 RUN sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-Base.repo; \
     sed -i -e 's!#baseurl=http://mirror.centos.org/centos/\$releasever!baseurl=https://vault.centos.org/6.10/!g' /etc/yum.repos.d/CentOS-Base.repo; \
     yum -y update; yum clean all; \
-    yum -y install gcc openssl-devel bzip2-devel sqlite-devel sudo wget; \
-    cd /usr/src; \
-    wget -q https://www.python.org/ftp/python/3.6.10/Python-3.6.10.tgz; \
-    tar xzf Python-3.6.10.tgz; \
-    cd Python-3.6.10; \
-    ./configure --enable-optimizations; \
-    make install; \
-    rm /usr/src/Python-3.6.10.tgz; \
-    pip3 install --upgrade pip; \
-    pip3 install ansible
+    yum -y install gcc openssl-devel bzip2-devel sqlite-devel sudo wget python3 epel-release; \
+    yum -y install ansible
 
 COPY . /ansible
 
@@ -26,7 +18,7 @@ RUN set -eux; \
  ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit"; \
  ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --tags="riscv"
 
-RUN rm -rf /ansible; pip3 uninstall ansible; yum clean all
+RUN rm -rf /ansible; yum remove -y ansible; yum clean all
 
 RUN groupadd -g 1000 ${user}
 RUN useradd -c "Jenkins user" -d /home/${user} -u 1000 -g 1000 -m ${user}


### PR DESCRIPTION
- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/2301

The centos 6 docker build and push github check has been failing when it tries to install ansible, https://github.com/adoptium/infrastructure/pull/2300/checks?check_run_id=3442260626 for example. I've changed it to a simple yum install. I've tested this on one of the dockerhost machine, the changes build without fail
