### PR TITLE
pbTests: Add check to see if fork exists

### DIFF
--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -101,8 +101,21 @@ cloneRepo() {
 		echo "Found existing openjdk-build folder"
 		cd $WORKSPACE/openjdk-build && git pull
 	else
-		echo "Cloning new openjdk-build folder"
-		git clone -b ${GIT_BRANCH} --single-branch https://github.com/${GIT_FORK}/openjdk-build $WORKSPACE/openjdk-build
+		echo "Cloning new openjdk-build/temurin-build folder"
+
+		local isRepoTemurin=$(curl https://api.github.com/repos/$GIT_FORK/temurin-build | grep "Not Found")
+		local isRepoOpenjdk=$(curl https://api.github.com/repos/$GIT_FORK/openjdk-build | grep "Not Found")
+
+		if [[ -z "$isRepoTemurin" ]]; then
+			GIT_REPO="https://github.com/${GIT_FORK}/temurin-build"
+		elif [[ -z "$isRepoOpenjdk" ]]; then
+			GIT_REPO="https://github.com/${GIT_FORK}/openjdk-build"
+		else
+			echo "Fork not found"
+			exit 1
+		fi
+
+		git clone -b ${GIT_BRANCH} --single-branch $GIT_REPO $WORKSPACE/openjdk-build
 	fi
 }
 

--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -111,7 +111,7 @@ cloneRepo() {
 		elif [[ -z "$isRepoOpenjdk" ]]; then
 			GIT_REPO="https://github.com/${GIT_FORK}/openjdk-build"
 		else
-			echo "Fork not found"
+			echo "Repository not found - the fork must be named temurin-build or openjdk-build"
 			exit 1
 		fi
 

--- a/ansible/pbTestScripts/buildJDKWin.sh
+++ b/ansible/pbTestScripts/buildJDKWin.sh
@@ -98,7 +98,7 @@ cloneRepo() {
 		elif [[ -z "$isRepoOpenjdk" ]]; then
 			GIT_REPO="https://github.com/${GIT_FORK}/openjdk-build"
 		else
-			echo "Fork not found"
+			echo "Repository not found - the fork must be named temurin-build or openjdk-build"
 			exit 1
 		fi
 

--- a/ansible/pbTestScripts/buildJDKWin.sh
+++ b/ansible/pbTestScripts/buildJDKWin.sh
@@ -89,7 +89,20 @@ cloneRepo() {
 		cd $WORKSPACE/openjdk-build && git pull
 	else
 		echo "Cloning new openjdk-build directory"
-		git clone -b ${GIT_BRANCH} --single-branch https://github.com/${GIT_FORK}/openjdk-build $WORKSPACE/openjdk-build
+
+		local isRepoTemurin=$(curl https://api.github.com/repos/$GIT_FORK/temurin-build | grep "Not Found")
+		local isRepoOpenjdk=$(curl https://api.github.com/repos/$GIT_FORK/openjdk-build | grep "Not Found")
+
+		if [[ -z "$isRepoTemurin" ]]; then
+			GIT_REPO="https://github.com/${GIT_FORK}/temurin-build"
+		elif [[ -z "$isRepoOpenjdk" ]]; then
+			GIT_REPO="https://github.com/${GIT_FORK}/openjdk-build"
+		else
+			echo "Fork not found"
+			exit 1
+		fi
+
+		git clone -b ${GIT_BRANCH} --single-branch $GIT_REPO $WORKSPACE/openjdk-build
 	fi
 }
 # Set defaults

--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -177,6 +177,18 @@ setupWorkspace()
 	local gitDirectory=${workFolder}/${gitFork}-${gitBranch}
 	mkdir -p ${workFolder}/logFiles
 
+	isRepoInfra=$(curl https://api.github.com/repos/$gitFork/infrastructure | grep "Not Found")
+	isRepoOpenjdk=$(curl https://api.github.com/repos/$gitFork/openjdk-infrastructure | grep "Not Found")
+
+	if [[ -z "$isRepoInfra" ]]; then
+		gitRepo="https://github.com/${gitFork}/infrastructure"
+	elif [[ -z "$isRepoOpenjdk" ]]; then
+		gitRepo="https://github.com/${gitFork}/openjdk-infrastructure"
+	else
+		echo "Fork not found"
+		exit 1
+	fi
+
 	if [[ "$cleanWorkspace" = true && -d ${gitDirectory} ]]; then
 		echo "Cleaning old workspace"
 		rm -rf ${gitDirectory}
@@ -185,7 +197,7 @@ setupWorkspace()
 	fi
 
 	if [ ! -d "${gitDirectory}" ]; then
-		git clone -b ${gitBranch} --single-branch https://github.com/${gitFork}/openjdk-infrastructure ${gitDirectory}
+		git clone -b ${gitBranch} --single-branch ${gitRepo} ${gitDirectory}
 	else
 		cd ${gitDirectory}
 		git pull

--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -185,7 +185,7 @@ setupWorkspace()
 	elif [[ -z "$isRepoOpenjdk" ]]; then
 		gitRepo="https://github.com/${gitFork}/openjdk-infrastructure"
 	else
-		echo "Fork not found"
+		echo "Repository not found - the fork must be named openjdk-infrastructure or infrastructure"
 		exit 1
 	fi
 

--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -177,8 +177,8 @@ setupWorkspace()
 	local gitDirectory=${workFolder}/${gitFork}-${gitBranch}
 	mkdir -p ${workFolder}/logFiles
 
-	isRepoInfra=$(curl https://api.github.com/repos/$gitFork/infrastructure | grep "Not Found")
-	isRepoOpenjdk=$(curl https://api.github.com/repos/$gitFork/openjdk-infrastructure | grep "Not Found")
+	local isRepoInfra=$(curl https://api.github.com/repos/$gitFork/infrastructure | grep "Not Found")
+	local isRepoOpenjdk=$(curl https://api.github.com/repos/$gitFork/openjdk-infrastructure | grep "Not Found")
 
 	if [[ -z "$isRepoInfra" ]]; then
 		gitRepo="https://github.com/${gitFork}/infrastructure"


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/2295

I've added a check to determine whether the fork is labelled either `openjdk-infrastructure` or `infrastructure`.

This code works when run separately, but not when I add it to the vagrantPlaybookCheck.sh script; the script seems to get caught on the curl commands. Hence I'm keeping this as a WIP for now
