### PR TITLE
UnixPb: add fakeroot to centos and ubuntu

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -71,6 +71,7 @@ Additional_Build_Tools_CentOS8:
   - git
   - cmake
   - ccache
+  - fakeroot
 
 Additional_Build_Tools_NOT_CentOS8:
   - lbzip2

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -71,7 +71,6 @@ Additional_Build_Tools_CentOS8:
   - git
   - cmake
   - ccache
-  - fakeroot
 
 Additional_Build_Tools_NOT_CentOS8:
   - lbzip2
@@ -97,3 +96,4 @@ Test_Tool_Packages:
   - xorg-x11-xauth
   - xorg-x11-server-Xorg
   - xorg-x11-server-Xvfb
+  - fakeroot

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
@@ -114,6 +114,7 @@ Test_Tool_Packages:
   - unzip
   - libexpat1-dev
   - libcurl4-openssl-dev
+  - fakeroot
 
 Test_Tool_Packages_x86_64:
   - pulseaudio


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly


ref https://github.com/adoptium/infrastructure/issues/2312