### PR TITLE
inventory: Add three extra Marist Cloud test machines

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -172,6 +172,9 @@ hosts:
 
       - marist:
           sles12-s390x-1: {ip: 148.100.86.128}
+          sles15-s390x-1: {ip: 148.100.84.159, user: linux1, description: test machine in marist cloud}
+          rhel7-s390x-1: {ip: 148.100.84.26, user: linux1, description: test machine in marist cloud}
+          rhel8-s390x-1: {ip: 148.100.84.52, user: linux1, description: test machine in marist cloud}
           ubuntu1604-s390x-1: {ip: 148.100.113.20, user: ubuntu}
           ubuntu1804-s390x-1: {ip: 148.100.113.30, user: ubuntu}
           ubuntu1804-s390x-2: {ip: 148.100.113.46, user: ubuntu}


### PR DESCRIPTION
Provisioned via the new prototype Marist Cloud interface. This will expand our available test coverage to RHEL8 and SLES15 (And also RHEL7 since the current RHEL7 build machine was deactiveated - by label - for testing)

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly (In Bastillion, will run playbook via AWX once this is in before adding to jenkins)
