### PR TITLE
AixPb: Ensure maxuproc is 512 in the playbook

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
@@ -48,7 +48,7 @@
     # installs some gnu packages required by ansible modules
     # Note: AIX File system configuration must be run now as RPM based software
     # cannot expand filesystem space on demand
-    
+
     # - aixfs
     - maxuproc
     - yum

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
@@ -48,7 +48,9 @@
     # installs some gnu packages required by ansible modules
     # Note: AIX File system configuration must be run now as RPM based software
     # cannot expand filesystem space on demand
-    - aixfs
+    
+    # - aixfs
+    - maxuproc
     - yum
 
     # 4. AIX User Admin

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
@@ -50,7 +50,7 @@
     # cannot expand filesystem space on demand
 
     # - aixfs
-    - maxuproc
+    - kernelsettings
     - yum
 
     # 4. AIX User Admin

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/kernelsettings/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/kernelsettings/tasks/main.yml
@@ -1,6 +1,6 @@
 ###############################
-# Ensure maxuproc is set to 512                           
-# Required as of https://github.com/adoptium/infrastructure/issues/2334  
+# Ensure maxuproc is set to 512
+# Required as of https://github.com/adoptium/infrastructure/issues/2334
 ###############################
 ---
 - name: Ensure maxuproc is set to 512

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/kernelsettings/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/kernelsettings/tasks/main.yml
@@ -1,0 +1,8 @@
+###############################
+# Ensure maxuproc is set to 512                           
+# Required as of https://github.com/adoptium/infrastructure/issues/2334  
+###############################
+---
+- name: Ensure maxuproc is set to 512
+  command: chdev -l sys0 -a maxuproc=512
+  tags: kernelsettings

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/maxuproc/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/maxuproc/tasks/main.yml
@@ -1,7 +1,0 @@
-#################################
-# Ensure maxuproc is set to 512 #
-#################################
----
-- name: Ensure maxuproc is set to 512
-  command: chdev -l sys0 -a maxuproc=512
-  tags: maxuproc

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/maxuproc/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/maxuproc/tasks/main.yml
@@ -1,0 +1,7 @@
+#################################
+# Ensure maxuproc is set to 512 #
+#################################
+---
+- name: Ensure maxuproc is set to 512
+  command: chdev -l sys0 -a maxuproc=512
+  tags: maxuproc


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/2334

I've added a role which ensures that the `maxuproc` is set to 512. I've also commented out the `aixfs` role for now until we have a better idea of what to do with that.

@aixtools 
