### PR TITLE
Playbooks: Add java 17 bootstrap to Unix, Windows and AIX playbooks

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
@@ -93,6 +93,9 @@
     - role: bootjdk
       jdk: 16
       tags: bootjdk16
+    - role: bootjdk
+      jdk: 17
+      tags: bootjdk17
 
     # 7. Modify /etc/hosts file to include ipv4 address and fqdn
 

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/bootjdk/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/bootjdk/tasks/main.yml
@@ -12,7 +12,9 @@
     src: https://api.adoptopenjdk.net/v3/binary/latest/{{ jdk }}/ga/aix/ppc64/jdk/{{ bootjdk }}/normal/adoptopenjdk?project=jdk
     dest: /usr
     remote_src: yes
-  when: java_installed.stat.isdir is not defined and jdk != 17
+  when:
+    - java_installed.stat.isdir is not defined
+    - jdk != 17
 
 - name: Transfer and Extract AdoptOpenJDK {{ jdk }}
   unarchive:

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/bootjdk/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/bootjdk/tasks/main.yml
@@ -19,7 +19,7 @@
     src: https://api.adoptopenjdk.net/v3/binary/latest/{{ jdk }}/ea/aix/ppc64/jdk/{{ bootjdk }}/normal/adoptopenjdk?project=jdk
     dest: /usr
     remote_src: yes
-  when: 
+  when:
     - java_installed.stat.isdir is not defined
     - jdk == 17
 

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/bootjdk/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/bootjdk/tasks/main.yml
@@ -12,7 +12,14 @@
     src: https://api.adoptopenjdk.net/v3/binary/latest/{{ jdk }}/ga/aix/ppc64/jdk/{{ bootjdk }}/normal/adoptopenjdk?project=jdk
     dest: /usr
     remote_src: yes
-  when: java_installed.stat.isdir is not defined
+  when: java_installed.stat.isdir is not defined and jdk != 17
+
+- name: Transfer and Extract AdoptOpenJDK {{ jdk }}
+  unarchive:
+    src: https://api.adoptopenjdk.net/v3/binary/latest/{{ jdk }}/ea/aix/ppc64/jdk/{{ bootjdk }}/normal/adoptopenjdk?project=jdk
+    dest: /usr
+    remote_src: yes
+  when: java_installed.stat.isdir is not defined and jdk == 17
 
 # jdk8 directories do not have a hyphen
 - name: Find java 8 directory

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/bootjdk/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/bootjdk/tasks/main.yml
@@ -19,7 +19,9 @@
     src: https://api.adoptopenjdk.net/v3/binary/latest/{{ jdk }}/ea/aix/ppc64/jdk/{{ bootjdk }}/normal/adoptopenjdk?project=jdk
     dest: /usr
     remote_src: yes
-  when: java_installed.stat.isdir is not defined and jdk == 17
+  when: 
+    - java_installed.stat.isdir is not defined
+    - jdk == 17
 
 # jdk8 directories do not have a hyphen
 - name: Find java 8 directory

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -107,6 +107,7 @@
         - ansible_distribution != "Solaris"
         - ansible_architecture != "riscv64"
       tags: build_tools
+    - role: adoptopenjdk_install # JDK18 Build Bootstrap
       jdk_version: 17
       when:
         - ansible_distribution != "Alpine"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -107,6 +107,12 @@
         - ansible_distribution != "Solaris"
         - ansible_architecture != "riscv64"
       tags: build_tools
+      jdk_version: 17
+      when:
+        - ansible_distribution != "Alpine"
+        - ansible_distribution != "Solaris"
+        - ansible_architecture != "riscv64"
+      tags: build_tools, java17
     - role: Nagios_Plugins        # AdoptOpenJDK Infrastructure
       tags: [nagios_plugins, adoptopenjdk]
     - role: Nagios_Master_Config  # AdoptOpenJDK Infrastructure

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -112,7 +112,7 @@
         - ansible_distribution != "Alpine"
         - ansible_distribution != "Solaris"
         - ansible_architecture != "riscv64"
-      tags: build_tools, java17
+      tags: build_tools
     - role: Nagios_Plugins        # AdoptOpenJDK Infrastructure
       tags: [nagios_plugins, adoptopenjdk]
     - role: Nagios_Master_Config  # AdoptOpenJDK Infrastructure

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -58,6 +58,8 @@
       jdk_version: 15
     - role: Java_install          # JDK17 build bootstrap
       jdk_version: 16
+    - role: Java_install
+      jdk_version: 17
     - ANT                         # Testing
     - MSVS_2013
     - MSVS_2017                   # OpenJ9


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/2337
