### PR TITLE
Stop using devtoolset-2 to provide GCC4.8

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -27,7 +27,6 @@
     - Common
     - Python2.7                   # CentOS6
     - Providers                   # AdoptOpenJDK Infrastructure
-    - autoconf
     - curl
     - Jenkins_User                # AdoptOpenJDK Infrastructure
     - role: freemarker            # OpenJ9

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
@@ -79,24 +79,6 @@
     - ! (ansible_distribution_major_version == "7" and ansible_architecture == "s390x")
   tags: build_tools
 
-- name: Add devtools-2 to yum repo list for gcc 4.8
-  get_url:
-    url: https://people.centos.org/tru/devtools-2/devtools-2.repo
-    dest: /etc/yum.repos.d/devtools-2.repo
-    timeout: 25
-    checksum: sha256:a8ebeb4bed624700f727179e6ef771dafe47651131a00a78b342251415646acc
-  when:
-    - ansible_distribution_major_version == "6"
-  tags: build_tools
-
-- name: Install gcc4.8
-  package: "name={{ item }} state=latest"
-  with_items: "{{ gcc48_devtoolset_compiler }}"
-  when:
-    - ansible_distribution_major_version == "6"
-  tags: build_tools
-
-
 - name: Install CentOS SCL x86_64 repo for gcc7.3
   package: "name=centos-release-scl state=latest"
   when:
@@ -117,42 +99,6 @@
   with_items: "{{ Additional_Build_Tools_CentOS_x86 }}"
   when:
     - ansible_architecture == "x86_64"
-  tags: build_tools
-
-- name: Create symlink for /opt/rh/devtoolset-2/root/usr/bin/gcc to gcc
-  file:
-    src: /opt/rh/devtoolset-2/root/usr/bin/gcc
-    dest: /usr/bin/gcc
-    force: true
-    owner: root
-    group: root
-    state: link
-  when:
-    - ansible_distribution_major_version == "6"
-  tags: build_tools
-
-- name: Create symlink for /opt/rh/devtoolset-2/root/usr/bin/g++ to g++
-  file:
-    src: /opt/rh/devtoolset-2/root/usr/bin/g++
-    dest: /usr/bin/g++
-    force: true
-    owner: root
-    group: root
-    state: link
-  when:
-    - ansible_distribution_major_version == "6"
-  tags: build_tools
-
-- name: Create symlink for /opt/rh/devtoolset-2/root/usr/bin/c++ to c++
-  file:
-    src: /opt/rh/devtoolset-2/root/usr/bin/c++
-    dest: /usr/bin/c++
-    force: true
-    owner: root
-    group: root
-    state: link
-  when:
-    - ansible_distribution_major_version == "6"
   tags: build_tools
 
 ##############################

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -54,11 +54,6 @@ Build_Tool_Packages:
   - xz
   - zip
 
-gcc48_devtoolset_compiler:
-  - devtoolset-2-gcc
-  - devtoolset-2-binutils
-  - devtoolset-2-gcc-c++
-
 Additional_Build_Tools_CentOS7:
   - libstdc++-static
   - ccache

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/GIT_Source/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/GIT_Source/tasks/main.yml
@@ -27,15 +27,7 @@
     - skip_ansible_lint
 
 - name: Download git source
-  get_url:
-    url: https://www.kernel.org/pub/software/scm/git/git-2.15.0.tar.xz
-    dest: /tmp/git-2.15.0.tar.xz
-    mode: 0440
-    checksum: sha256:107116489f10b758b51af1c5dbdb9a274917b0fb67dc8eaefcdabc7bc3eb3e6a
-  retries: 3
-  delay: 5
-  register: git_download
-  until: git_download is not failed
+  shell: curl -o /tmp/git-2.15.0.tar.xz https://www.kernel.org/pub/software/scm/git/git-2.15.0.tar.xz
   when:
     - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.15', operator='lt') )
     - ansible_distribution != "FreeBSD"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/GIT_Source/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/GIT_Source/tasks/main.yml
@@ -27,19 +27,7 @@
     - skip_ansible_lint
 
 - name: Download git source
-  shell: curl -o /tmp/git-2.15.0.tar.xz https://www.kernel.org/pub/software/scm/git/git-2.15.0.tar.xz
-  when:
-    - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.15', operator='lt') )
-    - ansible_distribution != "FreeBSD"
-  tags: git_source
-
-- name: Extract git source
-  unarchive:
-    src: /tmp/git-2.15.0.tar.xz
-    dest: /tmp/
-    extra_opts:
-      - --no-same-owner
-    copy: False
+  shell: curl -L https://www.kernel.org/pub/software/scm/git/git-2.15.0.tar.xz | tar xofJ - -C /tmp
   when:
     - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.15', operator='lt') )
     - ansible_distribution != "FreeBSD"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Python2.7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Python2.7/tasks/main.yml
@@ -16,11 +16,7 @@
     - python2.7
 
 - name: Install Python2.7 to /usr/local/python2
-  unarchive:
-    src: https://ci.adoptopenjdk.net/userContent/usrlocalPython27.tar.xz
-    dest: /usr/local/
-    remote_src: yes
-    mode: 0755
+  shell: curl https://ci.adoptopenjdk.net/userContent/usrlocalPython27.tar.xz | (cd /usr/local && tar xpfJ -)
   retries: 3
   delay: 5
   register: python_download

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
@@ -122,12 +122,7 @@
 # CentOS6 needs it's own task so it can use a different python interpreter.
 # See: https://github.com/adoptium/infrastructure/issues/1877
 - name: Install latest release if not already installed (CentOS6)
-  unarchive:
-    src: https://api.adoptopenjdk.net/v3/binary/latest/{{ jdk_version }}/ga/linux/{{ api_architecture }}/jdk/{{ bootjdk }}/normal/adoptopenjdk?project=jdk
-    dest: /usr/lib/jvm
-    remote_src: yes
-  vars:
-    - ansible_python_interpreter: /usr/local/python2/bin/python2.7
+  shell: curl https://api.adoptopenjdk.net/v3/binary/latest/{{ jdk_version }}/ga/linux/{{ api_architecture }}/jdk/{{ bootjdk }}/normal/adoptopenjdk?project=jdk | tar xpfz - -C /usr/lib/jvm
   retries: 3
   delay: 5
   register: adoptopenjdk_download

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/autoconf/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/autoconf/tasks/main.yml
@@ -13,12 +13,7 @@
   tags: autoconf-2.69
 
 - name: Download Autoconf v2.69
-  get_url:
-    url: https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz
-    dest: /tmp/autoconf-2.69.tar.gz
-    force: no
-    mode: 0755
-    checksum: sha256:954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969
+  shell: curl -o /tmp/autoconf-2.69.tar.gz https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz
   when:
     - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS")
     - ansible_distribution_major_version == "6"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_7/tasks/main.yml
@@ -22,11 +22,7 @@
 
 # Unable to check the checksum of the binary as it'll be different for each architecture's tar.xz file
 - name: Download AdoptOpenJDK gcc-7.5.0 binary
-  get_url:
-    url: https://ci.adoptopenjdk.net/userContent/gcc/gcc750+ccache.{{ ansible_architecture }}.tar{{ gccsuffix }}
-    dest: '/tmp/ansible-adoptopenjdk-gcc-7.tar{{ gccsuffix }}'
-    force: no
-    mode: 0644
+  shell: curl -o /tmp/ansible-adoptopenjdk-gcc-7.tar{{ gccsuffix }} https://ci.adoptopenjdk.net/userContent/gcc/gcc750+ccache.{{ ansible_architecture }}.tar{{ gccsuffix }}
   when:
     - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
     - gcc7_installed.rc != 0

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gmake/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gmake/tasks/main.yml
@@ -26,10 +26,7 @@
   tags: goodmake_source
 
 - name: Download make {{ makeVersion }} source
-  get_url:
-    url: https://ftp.gnu.org/gnu/make/make-{{ makeVersion }}.tar.gz
-    dest: /tmp/make-{{ makeVersion }}.tar.gz
-    mode: 0440
+  shell: curl  -o /tmp/make-{{ makeVersion }}.tar.gz https://ftp.gnu.org/gnu/make/make-{{ makeVersion }}.tar.gz
   when:
     - ((((ansible_distribution == "SLES" or ansible_distribution == "openSUSE") and ansible_distribution_major_version == "12") or
       (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "14")) and


### PR DESCRIPTION
DRAFT as I don't necessarily want to merge this, but I want to see if it unblocks the playbook execution on CentOS6 (Let's Encrypt failure from people.centos.com)

I don't *think* 4.8 is needed any more for any releases, as the lines that used it (JDK8/J9/s390x) are superceded by later directives in [build.sh](https://github.com/adoptium/temurin-build/blob/0829acbf6e6118b8afe50e5a554e2c144cfa7999/build-farm/platform-specific-configurations/linux.sh#L39)

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/1246/)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
