### PR TITLE
github: unpin vagrant version in actions

### DIFF
--- a/.github/workflows/build_vagrant.yml
+++ b/.github/workflows/build_vagrant.yml
@@ -30,8 +30,9 @@ jobs:
         ssh-keygen -q -f $PWD/id_rsa -t rsa -N ''
         vagrant up
         vagrantPORT=$(vagrant port | grep host | awk '{ print $4 }')
+        ipAddress=$(ipconfig getifaddr en0)
         rm -f playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx
-        echo "[127.0.0.1]:${vagrantPORT}" >> playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx
+        echo "[${ipAddress}]:${vagrantPORT}" >> playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx
         sed -i -e "s/.*hosts:.*/- hosts: all/g" playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
         awk '{print}/^\[defaults\]$/{print "private_key_file = id_rsa"; print "timeout = 30"; print "remote_tmp = $HOME/.ansible/tmp"}' < ansible.cfg > ansible.cfg.tmp && mv ansible.cfg.tmp ansible.cfg
 

--- a/.github/workflows/build_vagrant.yml
+++ b/.github/workflows/build_vagrant.yml
@@ -32,7 +32,7 @@ jobs:
         vagrantPORT=$(vagrant port | grep host | awk '{ print $4 }')
         rm -f playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx
         echo "[127.0.0.1]:${vagrantPORT}" >> playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx
-        echo "207.254.28.13 adoptopenjdkSol10" >> /etc/hosts
+        echo "127.0.0.1 adoptopenjdkSol10" >> /etc/hosts
         sed -i -e "s/.*hosts:.*/- hosts: all/g" playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
         awk '{print}/^\[defaults\]$/{print "private_key_file = id_rsa"; print "timeout = 30"; print "remote_tmp = $HOME/.ansible/tmp"}' < ansible.cfg > ansible.cfg.tmp && mv ansible.cfg.tmp ansible.cfg
 

--- a/.github/workflows/build_vagrant.yml
+++ b/.github/workflows/build_vagrant.yml
@@ -20,10 +20,6 @@ jobs:
       run: |
         brew install ansible
         brew install --cask virtualbox
-        # Pin vagrant at 2.2.15 until https://github.com/hashicorp/vagrant/issues/12408 has been fixed
-        brew uninstall vagrant
-        wget https://raw.githubusercontent.com/Homebrew/homebrew-cask/d81815ea27a778a312fa0e2bbef0d78f9767f45b/Casks/vagrant.rb
-        brew install --cask ./vagrant.rb
 
     - name: Setup Vagrant VM
       run: |

--- a/.github/workflows/build_vagrant.yml
+++ b/.github/workflows/build_vagrant.yml
@@ -30,9 +30,9 @@ jobs:
         ssh-keygen -q -f $PWD/id_rsa -t rsa -N ''
         vagrant up
         vagrantPORT=$(vagrant port | grep host | awk '{ print $4 }')
-        ipAddress=$(ipconfig getifaddr en0)
         rm -f playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx
-        echo "[${ipAddress}]:${vagrantPORT}" >> playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx
+        echo "[127.0.0.1]:${vagrantPORT}" >> playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx
+        echo "207.254.28.13 adoptopenjdkSol10" >> /etc/hosts
         sed -i -e "s/.*hosts:.*/- hosts: all/g" playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
         awk '{print}/^\[defaults\]$/{print "private_key_file = id_rsa"; print "timeout = 30"; print "remote_tmp = $HOME/.ansible/tmp"}' < ansible.cfg > ansible.cfg.tmp && mv ansible.cfg.tmp ansible.cfg
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Now that https://github.com/hashicorp/vagrant/issues/12408 is fixed, we can remove the pinning of an older version.

I suspect this also fixes the instability observed by @sxa in https://github.com/adoptium/infrastructure/issues/2349
