### PR TITLE
UnixPb: Build Git using the correct curl directory

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/GIT_Source/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/GIT_Source/tasks/main.yml
@@ -53,24 +53,6 @@
     - ansible_distribution != "FreeBSD"
   tags: git_source
 
-- name: Ensure curl-devel is installed on RHEL 6 before compiling git
-  package: "name=curl-devel state=latest"
-  when:
-    - (ansible_distribution == "RedHat" and ansible_distribution_major_version == "6")
-  tags:
-    # TODO: Package installs should not use latest
-    - skip_ansible_lint
-    - git_source
-
-- name: Ensure libcurl-devel is installed on CentOS 6 before compiling git
-  package: "name=libcurl-devel state=latest"
-  when:
-    - (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6")
-  tags:
-    # TODO: Package installs should not use latest
-    - skip_ansible_lint
-    - git_source
-
 - name: Find Curl directory
   shell: ls -ld /usr/local/curl-* | awk '{print $9}'
   register: curl_install_dir


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Since https://github.com/adoptium/infrastructure/pull/2343, on CentOS6 the version of curl which is installed is 7.79.1, so the correct curl directory must be passed when compiling Git
