### PR TITLE
VPC: Stop using get.sh '-t' option in testJDK.sh

### DIFF
--- a/ansible/pbTestScripts/testJDK.sh
+++ b/ansible/pbTestScripts/testJDK.sh
@@ -11,7 +11,9 @@ fi
 
 mkdir -p $HOME/testLocation
 [ ! -d $HOME/testLocation/aqa-tests ] && git clone https://github.com/adoptium/aqa-tests.git $HOME/testLocation/aqa-tests
-$HOME/testLocation/aqa-tests/get.sh -t $HOME/testLocation/aqa-tests
+# cd to aqa-tests as required by https://github.com/adoptium/aqa-tests/issues/2691#issue-932959102
+cd $HOME/testLocation/aqa-tests
+$HOME/testLocation/aqa-tests/get.sh
 cd $HOME/testLocation/aqa-tests/TKG || exit 1
 export BUILD_LIST=functional
 $MAKE_COMMAND compile


### PR DESCRIPTION
As of this [PR](https://github.com/adoptium/aqa-tests/pull/2760) , `get.sh` can't use the `-t` option. This is causing all of the platforms that currently are able to build JDKs, to fail when testing the JDKs. According to the issue that PR is in reference to, `get.sh` should be run under `aqa-tests` anyway, so this should _hopefully_ fix the issue.

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) YUP: https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/1326/
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
