### PR TITLE
Inventory: change testpacket machine name to 2004

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -153,7 +153,7 @@ hosts:
 
       - packet:
           ubuntu1604-x64-1: {ip: 147.75.204.239}
-          ubuntu1604-x64-2: {ip: 147.75.100.127}
+          ubuntu2004-x64-2: {ip: 147.75.100.127}
           win2012r2-x64-1: {ip: 147.75.32.146, user: Admin}
 
       - macincloud:


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

I've renamed test-packet-ubuntu1604-x64-2 to test-packet-ubuntu2004-x64-2 in the inventory.yml file and in jenkins, https://ci.adoptopenjdk.net/computer/test-packet-ubuntu2004-x64-2/ (It was 1804 in jenkins before I changed it)

I think the machine was upgraded to 2004 recently

```
root@test-packet-ubuntu1604-x64-2:~# cat /etc/os-release 
NAME="Ubuntu"
VERSION="20.04.2 LTS (Focal Fossa)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 20.04.2 LTS"
```