### PR TITLE
pbTests: Add updateBoxes script.

### DIFF
--- a/ansible/pbTestScripts/README.md
+++ b/ansible/pbTestScripts/README.md
@@ -64,6 +64,6 @@ If specified, the VMs will then be tested by building JDK8 - if all dependencies
 
 If the VMs were chosen *not* to be destroyed, they can be later by running the _vmDestroy.sh_ script, which takes the `Vagrant OS` as an argument. If found, every Vagrant VM with this OS will be destroyed, therefore the user will be asked to confirm they want this. The `--force` option will skip this prompt.
 
-Vagrant boxes can be updated by their provider from time to time. To ensure the current vagrant boxes used on the system are up to date, _updateBoxes.sh_ can be used. This will check and update all current vagrant boxes for the user. Outdated box versions will be removed if the `-r` option, is used. A prompt will ask the user to confirm the removal of a box, and option `-rf` will skip this prompt.
+Vagrant boxes can be updated by their provider from time to time, and using outdated versions can occasionally [cause issues](https://github.com/adoptium/infrastructure/issues/2375#issue-1043540735). To ensure the current vagrant boxes used on the system are up to date, _updateBoxes.sh_ can be used. This will check and update all current vagrant boxes for the user. Outdated box versions will be removed if the `-r` option, is used. A prompt will ask the user to confirm the removal of a box, and option `-rf` will skip this prompt. 
 
 The additional scripts in the _pbTestScripts_ folder are called from `vagrantPlaybookCheck.sh`

--- a/ansible/pbTestScripts/README.md
+++ b/ansible/pbTestScripts/README.md
@@ -64,4 +64,6 @@ If specified, the VMs will then be tested by building JDK8 - if all dependencies
 
 If the VMs were chosen *not* to be destroyed, they can be later by running the _vmDestroy.sh_ script, which takes the `Vagrant OS` as an argument. If found, every Vagrant VM with this OS will be destroyed, therefore the user will be asked to confirm they want this. The `--force` option will skip this prompt.
 
+Vagrant boxes can be updated by their provider from time to time. To ensure the current vagrant boxes used on the system are up to date, _updateBoxes.sh_ can be used. This will check and update all current vagrant boxes for the user. Outdated box versions will be removed if the `-r` option, is used. A prompt will ask the user to confirm the removal of a box, and option `-rf` will skip this prompt.
+
 The additional scripts in the _pbTestScripts_ folder are called from `vagrantPlaybookCheck.sh`

--- a/ansible/pbTestScripts/updateBoxes.sh
+++ b/ansible/pbTestScripts/updateBoxes.sh
@@ -7,10 +7,10 @@ Usage(){
   echo "
 Usage: ./updateBoxes.sh [options]
 
-Bash script to update vagrant boxes and remove old versions.
+Bash script to update vagrant boxes and remove old versions. Running with no parameters will query the system for outdated boxes and update them, but will retain the old boxes.
 
 Options:
-  --remove | -r[f]	Remove outdated boxes. ('-rf' will force remove outdated boxes)
+  --remove | -r[f]	Remove outdated boxes. ('-rf' will make this non-interactive)
   --help | -h		Show this help message.
   "
 }
@@ -41,7 +41,7 @@ if [[ -z "$VBList" ]]; then
 else
   for x in $VBList
   do
-    vagrant box update --box $x
+    vagrant box update --box "$x"
   done
 fi
 

--- a/ansible/pbTestScripts/updateBoxes.sh
+++ b/ansible/pbTestScripts/updateBoxes.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+FORCE=""
+REMOVE=false
+
+Usage(){
+  echo "
+Usage: ./updateBoxes.sh [options]
+
+Bash script to update vagrant boxes and remove old versions.
+
+Options:
+  --remove | -r[f]	Remove outdated boxes. ('-rf' will force remove outdated boxes)
+  --help | -h		Show this help message.
+  "
+}
+
+while [ "$1" != "" ]; do
+  case $1 in
+    -r | --remove )
+      REMOVE=true
+      ;;
+    -rf )
+      REMOVE=true
+      FORCE="--force"
+      ;;
+    -h | --help )
+      Usage; exit 0
+      ;;
+    * )
+      echo "Unrecognised option: $1"; Usage; exit 1
+      ;;
+  esac
+  shift
+done
+
+VBList=$(vagrant box outdated --global | awk '/outdated/{print $2}' | sed "s/'//g")
+
+if [[ -z "$VBList" ]]; then
+  echo "No boxes require updating."
+else
+  for x in $VBList
+  do
+    vagrant box update --box $x
+  done
+fi
+
+if [ $REMOVE  = true ]; then
+  vagrant box prune ${FORCE}  
+else
+  echo "Not checking for old versions of boxes."
+fi


### PR DESCRIPTION
Ref: #2375 , https://ci.adoptopenjdk.net/job/Will-VagrantBoxUpdate/

The new Jenkins job can be found in the above link. While it is still unable to trigger VPC (hence only referencing the issue), I don't believe that will require any script changes, hence the PR. [Run 2](https://ci.adoptopenjdk.net/job/Will-VagrantBoxUpdate/2/console) shows the job working as expected. 

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [x] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
