### PR TITLE
vagrant: Configure hosts & hostname in Sol10 VF

### DIFF
--- a/.github/workflows/build_vagrant.yml
+++ b/.github/workflows/build_vagrant.yml
@@ -20,10 +20,6 @@ jobs:
       run: |
         brew install ansible
         brew install --cask virtualbox
-        # Pin vagrant at 2.2.15 until https://github.com/hashicorp/vagrant/issues/12408 has been fixed
-        brew uninstall vagrant
-        wget https://raw.githubusercontent.com/Homebrew/homebrew-cask/d81815ea27a778a312fa0e2bbef0d78f9767f45b/Casks/vagrant.rb
-        brew install --cask ./vagrant.rb
 
     - name: Setup Vagrant VM
       run: |

--- a/ansible/vagrant/Vagrantfile.Solaris10
+++ b/ansible/vagrant/Vagrantfile.Solaris10
@@ -14,6 +14,10 @@ if [ -r /vagrant/SolarisStudio12.3-solaris-x86-pkg ]; then
 	sudo /vagrant/SolarisStudio12.3-solaris-x86-pkg/solarisstudio.sh --non-interactive --javahome /opt/csw/java/jdk/jdk8/
 fi
 yes | sudo pkgrm CSWpkgutil
+
+# Configure host/hostname, to stop "Unable to resolve host" issue with 'sudo'
+sudo bash -c "echo '127.0.0.1 adoptopenjdkSol10' >> /etc/hosts"
+sudo bash -c "echo 'adoptopenjdkSol10' > /etc/hostname"
 SCRIPT
 
 # 2 = version of configuration file for Vagrant 1.1+ leading up to 2.0.x


### PR DESCRIPTION
Fixes: #2349 , Ref: [VPC-1336](https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/1336/)

This resolves the issue that VPC has been having, in that updating  `sudo` to the latest version, causes it to stop working. The error message says: 
```
sudo: unable to resolve host adoptopenjdkSol10: node name or service name not known\r\r\nsudo: error initializing audit plugin sudoers_audit\r\r\n", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error
```
For some reason, the 'unable to resolve host' message had never caused `sudo` to fail, however with the newest update (`1.9.8p2`) it does. When I set `adoptopenjdkSol10` as the hostname, and add it to `/etc/hosts`, the error no longer occurs.

This PR should fix both the GitHub check and VPC, as they use the same Vagrantfile.

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
