### PR TITLE
pbtests: Don't update Debian8 boxes

### DIFF
--- a/ansible/pbTestScripts/updateBoxes.sh
+++ b/ansible/pbTestScripts/updateBoxes.sh
@@ -42,7 +42,7 @@ else
   for x in $VBList
   do
     # Ignore Debian8 for now; See: https://adoptium.slack.com/archives/C53GHCXL4/p1637069847046900
-    if [[ $x != "roboxes/debian8" ]]; then 
+    if [[ "$x" != "roboxes/debian8" ]]; then 
       vagrant box update --box "$x"
     fi
   done

--- a/ansible/pbTestScripts/updateBoxes.sh
+++ b/ansible/pbTestScripts/updateBoxes.sh
@@ -41,7 +41,10 @@ if [[ -z "$VBList" ]]; then
 else
   for x in $VBList
   do
-    vagrant box update --box "$x"
+    # Ignore Debian8 for now; See: https://adoptium.slack.com/archives/C53GHCXL4/p1637069847046900
+    if [[ $x != "roboxes/debian8" ]]; then 
+      vagrant box update --box "$x"
+    fi
   done
 fi
 

--- a/ansible/vagrant/Vagrantfile.Debian8
+++ b/ansible/vagrant/Vagrantfile.Debian8
@@ -37,6 +37,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define :adoptopenjdkD8 do |adoptopenjdkD8|
     adoptopenjdkD8.vm.box = "roboxes/debian8"
+    adoptopenjdkD8.vm.box_version = "3.0.36"
     adoptopenjdkD8.vm.synced_folder ".", "/vagrant"
     adoptopenjdkD8.vm.hostname = "adoptopenjdkD8"
     adoptopenjdkD8.vm.network :private_network, type: "dhcp"


### PR DESCRIPTION
Ref: https://adoptium.slack.com/archives/C53GHCXL4/p1637069847046900

Turns out updating Vagrant boxes was a bad idea... This is a temporary fix whilst I figure out how to fix it :-) 

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) Ye- https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/1340/
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
