### PR TITLE
winPB: Correct codesign cert win_file module

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/CodesignCert/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/CodesignCert/tasks/main.yml
@@ -7,6 +7,6 @@
 # See https://github.com/adoptium/infrastructure/blob/cbadc5c45871c22e6a011999bf5ab3a3fdc926cf/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/CodesignCert/tasks/main.yml for the original content.
 
 - name: Remove windows.p12, if present
-  ansible.windows.win_file:
+  win_file:
     path: C:\openjdk\windows.p12
     state: absent


### PR DESCRIPTION
Fixes: #2315, ref: [VPC-1339](https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/1339/) 

Just simple module name change.

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) See above
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
