### PR TITLE
inventory: Remove scaleway armv7l machines

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -70,8 +70,6 @@ hosts:
           centos8-armv8-1: {ip: 139.178.86.243, description: Altra}
 
       - scaleway:
-          ubuntu1604-armv7-1: {ip: 212.47.233.28}
-          ubuntu1604-armv7-2: {ip: 212.47.246.7}
           ubuntu1604-x64-1: {ip: 51.15.46.107}
 
       - siteox:
@@ -95,9 +93,6 @@ hosts:
       - packet:
           ubuntu2004-armv8-1: {ip: 139.178.82.146, description: Ampere eMag}
           ubuntu2004-x64-1: {ip: 139.178.85.251, description: AMD EPYC}
-
-      - scaleway:
-          ubuntu1604-armv7-1: {ip: 51.158.73.136}
 
       - skytap:
           ubuntu2004-ppc64le-1: {ip: 20.61.136.212}


### PR DESCRIPTION
Scaleway armv7l machines have [not been available for a while](https://github.com/adoptium/infrastructure/issues/2192) but were still in our inventory. They have now been removed from jenkins, bastillion and nagios, so this is the only remaining place to remove them from.

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
