### PR TITLE
aixPB: Update inventory with new hostnames (replace 'ojdk' with 'adopt')

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -61,8 +61,8 @@ hosts:
           rhel77-s390x-2: {ip: 148.100.245.197, user: linux1}
 
       - osuosl:
-          aix71-ppc64-1: {ip: 140.211.9.10, description: ojdk01}
-          aix71-ppc64-2: {ip: 140.211.9.12, description: ojdk02}
+          aix71-ppc64-1: {ip: 140.211.9.10, description: p8-aix1-adopt01.osuosl.org}
+          aix71-ppc64-2: {ip: 140.211.9.12, description: p8-aix1-adopt02.osuosl.org}
           centos74-ppc64le-1: {ip: 140.211.168.138}
           centos74-ppc64le-2: {ip: 140.211.168.117}
 
@@ -135,9 +135,14 @@ hosts:
           solaris10u11-sparcv9-1: {}
 
       - osuosl:
-          aix71-ppc64-1: {ip: 140.211.9.99, description: ojdk05}
-          aix72-ppc64-1: {ip: 140.211.9.28, description: p8-aix2-ojdk03.osuosl.org}
-          aix72-ppc64-2: {ip: 140.211.9.36, description: p8-aix2-ojdk04.osuosl.org}
+          aix71-ppc64-1: {ip: 140.211.9.99, description: p9-aix1-adopt05.osuosl.org}
+          aix715-ppc64-2: {ip: 140.211.9.100, description: p9-aix1-adopt06.osuosl.org}
+          aix715-ppc64-3: {ip: 140.211.9.168, description: p8-java1-adopt07.osuosl.org}
+          aix715-ppc64-4: {ip: 140.211.9.169, description: p8-java1-adopt08.osuosl.org}
+          aix72-ppc64-1: {ip: 140.211.9.28, description: p8-aix1-adopt03.osuosl.org}
+          aix72-ppc64-2: {ip: 140.211.9.36, description: p8-aix1-adopt04.osuosl.org}
+          aix724-ppc64-3: {ip: 140.211.9.163, description: p8-java1-adopt09.osuosl.org}
+          aix724-ppc64-4: {ip: 140.211.9.166, description: p8-java1-adopt10.osuosl.org}
           centos74-ppc64le-1: {ip: 140.211.168.228, user: centos}
           centos74-ppc64le-2: {ip: 140.211.168.217, user: centos}
           ubuntu1604-ppc64le-1: {ip: 140.211.168.227, user: ubuntu}


### PR DESCRIPTION
- Add new systems at OSUOSL to inventory - using aix7RT-ppc-N -
- where R is release, T is Technology Level, N is node number

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
