### PR TITLE
UnixPB: Remove DST_Root_CA_X3 cert for Deb8

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
@@ -110,6 +110,21 @@
     force: yes
   tags: patch_update
 
+- name: Remove expired cert \"DST Root CA X3\"
+  block:
+    - name: Deselect certificate from ca-certificates.conf
+      replace:
+        path: /etc/ca-certificates.conf
+        replace: "!DST_Root_CA_X3.crt"
+        regexp: "^(.*)?/DST_Root_CA_X3.crt"
+        backup: yes
+
+    - name: Refresh ca-certificates
+      command: "update-ca-certificates --fresh"
+
+  when: (ansible_distribution_major_version == "8") and (ansible_architecture == "x86_64")
+  tags: patch_update
+
 ############################
 # Build Packages and tools #
 ############################


### PR DESCRIPTION
Ref: [VPC-1345](https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/OS=Debian8,label=vagrant/1345/console)

The LetsEncrypt DST_Root_CA_X3 ca-certificate [expired on the 30th of September](https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/). This doesn't appear to be an issue for newer distributions of Debian, but it affects Debian8. To fix, according to [OpenSSL](https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/), machines running OpenSSL-1.0.2 need to remove this certificate from their trust store, in `/etc/ca-certificates.conf`, and then refresh them. 

Only thing I'm not 100% sure of, is the `regexp` field for the `replace` module. This will work for the Vagrant box, as the listing is `mozilla/DST_Root_CA_X3.crt`; however, I'm not sure if it can appear as just `DST_Root_CA_X3.crt`, on other systems?

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access): See above
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
