### PR TITLE
unixPB: install GNU sed on Alpine

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Alpine.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Alpine.yml
@@ -36,7 +36,7 @@ Build_Tool_Packages:
   - linux-headers
   - numactl
   - numactl-dev                   # OpenJ9
-  - sed
+  - sed                           # JDK8u requires GNU sed
   - unzip
   - wget
   - which

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Alpine.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Alpine.yml
@@ -36,6 +36,7 @@ Build_Tool_Packages:
   - linux-headers
   - numactl
   - numactl-dev                   # OpenJ9
+  - sed
   - unzip
   - wget
   - which


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Currently, Alpine comes installed with a version of sed that isn't compatible with the JDK8u build scripts:

```bash
bash-5.1# sed --version
This is not GNU sed version 4.0
```

This PR switches sed to be the GNU sed version:

```bash
bash-5.1# sed --version
sed (GNU sed) 4.8
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Jay Fenlason, Tom Lord, Ken Pizzini,
Paolo Bonzini, Jim Meyering, and Assaf Gordon.

This sed program was built without SELinux support.

GNU sed home page: <https://www.gnu.org/software/sed/>.
General help using GNU software: <https://www.gnu.org/gethelp/>.
E-mail bug reports to: <bug-sed@gnu.org>.
```