### PR TITLE
github: pin vagrant executor to macos-10.15

### DIFF
--- a/.github/workflows/build_vagrant.yml
+++ b/.github/workflows/build_vagrant.yml
@@ -19,6 +19,7 @@ jobs:
     - name: Install dependencies
       run: |
         brew install ansible
+        brew install --cask vagrant
         brew install --cask virtualbox
 
     - name: Setup Vagrant VM

--- a/.github/workflows/build_vagrant.yml
+++ b/.github/workflows/build_vagrant.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-solaris:
     name: Solaris
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
 
     - uses: actions/checkout@v2
@@ -19,7 +19,6 @@ jobs:
     - name: Install dependencies
       run: |
         brew install ansible
-        brew install --cask vagrant
         brew install --cask virtualbox
 
     - name: Setup Vagrant VM


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

`macos-latest` now provides macOS 11 which doesn't have vagrant pre-installed. This PR pins the macOS version to fix the CI failure