### PR TITLE
AixPb: keep freetype2 and autoconf at desired versions

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/yum/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/yum/tasks/main.yml
@@ -95,7 +95,7 @@
   yum: name={{ item }} state=present update_cache=yes
   with_items:
     - bash
-    - autoconf
+    - autoconf-2.69-1
     - bc
     - bison
     - coreutils
@@ -212,10 +212,10 @@
   when: zconf.stat.exists
   tags: yum
 
-- name: Exclude freetype2 from updating past 2.8-1
+- name: Exclude packages from updating
   lineinfile:
     dest: /opt/freeware/etc/yum/yum.conf
     firstmatch: yes
     insertafter: 'plugins=1'
-    line: 'exclude=freetype2*'
+    line: 'exclude=freetype2* autoconf'
   tags: yum

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/yum/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/yum/tasks/main.yml
@@ -104,7 +104,7 @@
     - cups-libs
     - expect
     - flex
-    - freetype2-devel
+    - freetype2-devel-2.8-1
     - fontconfig-devel
     - gawk
     - git
@@ -210,4 +210,12 @@
     dest: /usr/include/zconf.h
     state: link
   when: zconf.stat.exists
+  tags: yum
+
+- name: Exclude freetype2 from updating past 2.8-1
+  lineinfile:
+    dest: /opt/freeware/etc/yum/yum.conf
+    firstmatch: yes
+    insertafter: 'plugins=1'
+    line: 'exclude=freetype2*'
   tags: yum


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/2364#issuecomment-984629665

The build process only seems to detect freetype on the system when freetype is kept at version 2.8