### PR TITLE
pbTests: Replace gsub in awk command

### DIFF
--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -3,8 +3,8 @@ set -eu
 
 setJDKVars() {
 	wget -q https://api.adoptopenjdk.net/v3/info/available_releases
-	JDK_MAX=$(awk -F: '/tip_version/{gsub("[, ]","",$2); print$2}' < available_releases)
-	JDK_GA=$(awk -F: '/most_recent_feature_release/{gsub("[, ]","",$2); print$2}' < available_releases)
+	JDK_MAX=$(awk -F: '/tip_version/{print$2}' < available_releases | tr -d ,)
+	JDK_GA=$(awk -F: '/most_recent_feature_release/{print$2}' < available_releases | tr -d ,)
 	rm available_releases
 }
 

--- a/ansible/pbTestScripts/buildJDKWin.sh
+++ b/ansible/pbTestScripts/buildJDKWin.sh
@@ -3,8 +3,8 @@ set -eu
 
 setJDKVars() {
 	wget -q https://api.adoptopenjdk.net/v3/info/available_releases
-	JDK_MAX=$(awk -F: '/tip_version/{gsub("[, ]","",$2); print$2}' < available_releases)
-	JDK_GA=$(awk -F: '/most_recent_feature_release/{gsub("[, ]","",$2); print$2}' < available_releases)
+	JDK_MAX=$(awk -F: '/tip_version/{print$2}' < available_releases | tr -d ,)
+	JDK_GA=$(awk -F: '/most_recent_feature_release/{print$2}' < available_releases | tr -d ,)
 	rm available_releases
 }
 


### PR DESCRIPTION
Ref: [VPC-1350](https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/1350/OS=Solaris10,label=vagrant/console) , #2405 

With the work being done to create a new Solaris10 Vagrantfile, we're finding out some quirks about the old box. The old box had a bunch of tools installed in `/usr/xpg4/bin`, which are apparently a variant of commands (such as awk, grep, etc.) that will comply with a different standard: 'POSIX.2/POSIX.2a/SUS/SUSv2/XPG4' , according to [this thread](https://www.unix.com/solaris/164073-what-difference-between-xpg4-bin-usr-bin.html).

While the new box also has this, the changes to the `awk` command that this PR does, will work for the standard `awk` in `/usr/bin/awk` as well, making the scripts more portable and easier to read.

Note: I can't test this on the new Solaris box until #2405 is ready and merged; however I can test this on all the other platforms, to prove it's validity.   See [VPC-1351](https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/1351/)

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) [VPC-1351](https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/1351/)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
