### PR TITLE
unixPB: Install gcc 10.3 into /usr/local/gcc10

### DIFF
--- a/ansible/pbTestScripts/testJDK.sh
+++ b/ansible/pbTestScripts/testJDK.sh
@@ -7,7 +7,7 @@ if [[ "$(uname)" == "FreeBSD" ]]; then
 	export TEST_JDK_HOME=$HOME/jdk
 else
 	ls -ld $HOME/openjdk-build/workspace/build/src/build/*/images/jdk*
- 	export TEST_JDK_HOME=$(ls -1d $HOME/openjdk-build/workspace/build/src/build/*/images/jdk* |egrep -v 'jre|-image|static-libs'
+ 	export TEST_JDK_HOME=$(ls -1d $HOME/openjdk-build/workspace/build/src/build/*/images/jdk* |egrep -v 'jre|-image|static-libs')
 fi
 
 echo DEBUG: TEST_JDK_HOME = $TEST_JDK_HOME

--- a/ansible/pbTestScripts/testJDK.sh
+++ b/ansible/pbTestScripts/testJDK.sh
@@ -6,8 +6,11 @@ if [[ $(uname) == "FreeBSD" ]]; then
 	cp -r $HOME/openjdk-build/workspace/build/src/build/*/jdk* $HOME
 	export TEST_JDK_HOME=$HOME/jdk
 else
-	export TEST_JDK_HOME=$(find $HOME/openjdk-build/workspace/build/src/build/*/images/ -maxdepth 1 -type d -name "jdk*"|grep -v ".*jre.*"|grep -v ".*-image")
+	ls -ld $HOME/openjdk-build/workspace/build/src/build/*/images/jdk*
+ 	export TEST_JDK_HOME=$(ls -1d $HOME/openjdk-build/workspace/build/src/build/*/images/jdk* |egrep -v 'jre|-image|static-libs'
 fi
+
+echo DEBUG: TEST_JDK_HOME = $TEST_JDK_HOME
 
 mkdir -p $HOME/testLocation
 [ ! -d $HOME/testLocation/aqa-tests ] && git clone https://github.com/adoptium/aqa-tests.git $HOME/testLocation/aqa-tests

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -59,7 +59,9 @@
     - gcc_48
     - role: gcc_7                 # OpenJ9
       tags: [build_tools, build_tools_openj9]
-    - role: gcc_9
+    - role: gcc_9                 # Dragonwell
+      tags: [build_tools]
+    - role: gcc_10                # JDK17+
       tags: [build_tools]
     - role: Xcode
       when: ansible_distribution == "MacOSX"
@@ -109,7 +111,7 @@
         - ansible_distribution != "Solaris"
         - ansible_architecture != "riscv64"
       tags: build_tools
-    - role: adoptopenjdk_install # JDK18 Build Bootstrap
+    - role: adoptopenjdk_install  # JDK18 Build Bootstrap
       jdk_version: 17
       when:
         - ansible_distribution != "Alpine"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_10/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_10/tasks/main.yml
@@ -1,0 +1,42 @@
+---
+##########
+# gcc_10 #
+##########
+
+- name: Check if gcc 10.3 is installed on RHEL/CentOS/Ubuntu16
+  shell: /usr/local/gcc10/bin/gcc-10.3 --version 2>&1 > /dev/null
+  ignore_errors: yes
+  register: gcc10_installed
+  when: ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
+  tags: gcc_10
+
+# Unable to check the checksum of the binary as it'll be different for each architecture's tar.xz file
+- name: Download AdoptOpenJDK gcc-10.3 binary
+  get_url:
+    url: https://ci.adoptopenjdk.net/userContent/gcc/gcc103.{{ ansible_architecture }}.tar.xz
+    dest: '/tmp/ansible-adoptopenjdk-gcc-10.tar.xz'
+    force: no
+    mode: 0644
+  when:
+    - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
+    - gcc10_installed.rc != 0
+  tags: gcc_10
+
+- name: Extract AdoptOpenJDK gcc-10 binary to /usr/local/gcc10
+  unarchive:
+    src: /tmp/ansible-adoptopenjdk-gcc-10.tar.xz
+    dest: /usr/local/
+    copy: False
+  when:
+    - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
+    - gcc10_installed.rc != 0
+  tags: gcc_10
+
+- name: Remove downloaded gcc 10 binary tarball
+  file:
+    path: '/tmp/ansible-adoptopenjdk-gcc-10.tar.xz'
+    state: absent
+  when:
+    - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
+    - gcc10_installed.rc != 0
+  tags: gcc_10

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_10/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_10/tasks/main.yml
@@ -8,6 +8,7 @@
   ignore_errors: yes
   register: gcc10_installed
   when: ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
+  changed_when: False
   tags: gcc_10
 
 # Unable to check the checksum of the binary as it'll be different for each architecture's tar.xz file


### PR DESCRIPTION
Fixes #2386 

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/1365) / [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/313)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Change to testVPC.sh was due to a bug when building later JDKs which made the process pick up the `static-libs` directory instead of the JDK, which causd a test failure (described in the comments below)
