### PR TITLE
unixPB: Add changed_when fields to shell modules, in gcc roles

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_48/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_48/tasks/main.yml
@@ -6,6 +6,7 @@
   shell: /usr/bin/gcc-4.8 >/dev/null 2>&1
   ignore_errors: yes
   register: gcc_installed
+  changed_when: false
   tags:
     - gcc-4.8
     # TODO: write a condition when NOT to run this step

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_7/tasks/main.yml
@@ -8,6 +8,7 @@
   ignore_errors: yes
   register: gcc7_installed
   when: ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
+  changed_when: false
   tags: gcc_7
 
 - name: Configure gcc75 tarball extension on non-armv7l

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_9/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_9/tasks/main.yml
@@ -10,6 +10,7 @@
   when:
     - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS" )
     - (ansible_architecture == "x86_64" or ansible_architecture == "aarch64")
+  changed_when: false
   tags: gcc_9
 
 # Unable to check the checksum of the binary as it'll be different for each architecture's tar.xz file


### PR DESCRIPTION
Ref: #2422 

As per my comment in the [referenced issue](https://github.com/adoptium/infrastructure/issues/2422#issuecomment-1008772277), these queries are not changing the machine state, so they shouldn't report `changed`. 

I prioritized these GCC roles, so they accurately reflect the new GCC-10 role from #2420.  

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
