### PR TITLE
jenkinsfile: switch dockerfile push to use jenkins tooling

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,10 +53,11 @@ pipeline {
 
 def dockerBuild(architecture, distro, dockerfile) {
     git poll: false, url: 'https://github.com/adoptium/infrastructure.git'
-    sh label: '', script: "docker build -t adoptopenjdk/${distro}_build_image:linux-$architecture -f ansible/docker/$dockerfile ."
+    dockerImage = docker.build("adoptopenjdk/${distro}_build_image:linux-$architecture",
+        "-f ansible/docker/$dockerfile .")
     // dockerhub is the ID of the credentials stored in Jenkins 
     docker.withRegistry('https://index.docker.io/v1/', 'dockerhub') {
-        sh label: '', script: "docker push adoptopenjdk/${distro}_build_image:linux-$architecture"
+        dockerImage.push()
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly


fixes: https://github.com/adoptium/infrastructure/issues/2432
