### PR TITLE
AIXpb: ensure support package `yum_utils` is installed

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
@@ -33,6 +33,7 @@
 
     # 2. AIX BOS configuration
 
+    - security
     - syslogs
     - crontab
     # TBD: additional tasks below that need to be promoted to

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/security/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/security/tasks/main.yml
@@ -1,0 +1,26 @@
+#########################################################################
+# Playbook to setup basic AIX hardening
+  # Deactivate inetd - to stop all services such as telnet, ftp, rexecd
+  # remove cas_agent, if installed. Not needed in modern systems
+#########################################################################
+---
+- name: Disable inetd on boot
+  shell: /usr/sbin/chrctcp -S -d inetd
+  ignore_errors: yes
+  changed_when: False
+  tags: aixsec
+
+- name: Update RBAC to include new authorizations
+  block:
+    - name: Look for CAS Agent
+      shell:
+        lslpp -L cas.agent
+      ignore_errors: yes
+      changed_when: false
+      register: cas
+    - name: Uninstall CAS Agent
+      shell:
+        installp -ug cas.agent
+      when: cas.rc == 0
+      ignore_errors: yes
+  tags: aixsec

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/yum/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/yum/tasks/main.yml
@@ -46,6 +46,10 @@
     - name: Install/update rpm.rte
       command: installp -aYgd /tmp/yum/rpm.rte rpm.rte
 
+    # This is needed so that yum can find dependencies supplied by AIX BOS
+    - name: Update RPM database to include AIX BOS support
+      command: /usr/sbin/updtvpkg
+
     - name: Transfer yum bundle package
       get_url:
         url: ftp://public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/ezinstall/ppc/yum_bundle.tar
@@ -64,40 +68,33 @@
         state: absent
         path: /tmp/yum
 
+    - name: Update yum installation
+      yum:
+        update_cache: yes
+        name: '*'
+        state: latest
+
+    - name: Install yum-utils
+      yum: name=yum-utils state=present
+      tags:
+        - yum
+
+    - name: Ensure AIX_Toolbox repo is enabled
+      shell: yum-config-manager --enable AIX_Toolbox
+      tags: yum
+
+    - name: Ensure AIX_Toolbox_noarch repo is enabled
+      shell: yum-config-manager --enable AIX_Toolbox_noarch
+      tags: yum
+
+    - name: Ensure AIX_Toolbox_71 repo is enabled
+      shell: yum-config-manager --enable AIX_Toolbox_71
+      tags: yum
   when: _yum.stat.islnk is not defined
   tags:
     - yum
-    - vendor_files
 
-- name: Install yum-utils
-  yum: name=yum-utils state=present update_cache=yes
-  tags:
-    - yum
-
-- name: Ensure AIX_Toolbox repo is enabled
-  shell: yum-config-manager --enable AIX_Toolbox
-  tags: yum
-
-- name: Ensure AIX_Toolbox_noarch repo is enabled
-  shell: yum-config-manager --enable AIX_Toolbox_noarch
-  tags: yum
-
-- name: Ensure AIX_Toolbox_71 repo is enabled
-  shell: yum-config-manager --enable AIX_Toolbox_71
-  tags: yum
-
-- name: Yum update
-  yum:
-    update_cache: yes
-    name: '*'
-    state: latest
-    exclude: cmake*
-  tags:
-    - yum
-    #TODO: Package installs should not use latest
-    - skip_ansible_lint
-
-- name: Install yum package support
+- name: Install OSS dev run-time-env using yum
   yum: name={{ item }} state=present update_cache=yes
   with_items:
     - bash
@@ -218,10 +215,24 @@
   when: zconf.stat.exists
   tags: yum
 
-- name: Exclude packages from updating
+- name: Exclude packages from yum (main)
   lineinfile:
     dest: /opt/freeware/etc/yum/yum.conf
     firstmatch: yes
     insertafter: 'plugins=1'
-    line: 'exclude=freetype2* autoconf'
+    line: 'exclude=autoconf cmake* freetype2*'
   tags: yum
+
+- name: Update AIXToolbox to latest using yum
+  yum:
+    update_cache: yes
+    name: '*'
+    state: latest
+    exclude:
+      autoconf*
+      cmake*
+      freetype2*
+  tags:
+    - yum
+    #TODO: Package installs should not use latest
+    - skip_ansible_lint

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/yum/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/yum/tasks/main.yml
@@ -63,10 +63,16 @@
       file:
         state: absent
         path: /tmp/yum
+
   when: _yum.stat.islnk is not defined
   tags:
     - yum
     - vendor_files
+
+- name: Install yum-utils
+  yum: name=yum-utils state=present update_cache=yes
+  tags:
+    - yum
 
 - name: Ensure AIX_Toolbox repo is enabled
   shell: yum-config-manager --enable AIX_Toolbox
@@ -95,7 +101,7 @@
   yum: name={{ item }} state=present update_cache=yes
   with_items:
     - bash
-    - autoconf
+    - autoconf-2.69-1
     - bc
     - bison
     - coreutils
@@ -104,7 +110,7 @@
     - cups-libs
     - expect
     - flex
-    - freetype2-devel
+    - freetype2-devel-2.8-1
     - fontconfig-devel
     - gawk
     - git
@@ -210,4 +216,12 @@
     dest: /usr/include/zconf.h
     state: link
   when: zconf.stat.exists
+  tags: yum
+
+- name: Exclude packages from updating
+  lineinfile:
+    dest: /opt/freeware/etc/yum/yum.conf
+    firstmatch: yes
+    insertafter: 'plugins=1'
+    line: 'exclude=freetype2* autoconf'
   tags: yum

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/yum/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/yum/tasks/main.yml
@@ -3,14 +3,15 @@
 # if they were installed via rpm unless yum exists #
 ####################################################
 ---
-- name: Confirm yum is installed - /usr/bin/yum
+
+- name: Check if yum is installed - /usr/bin/yum
   stat:
     path: /usr/bin/yum
   register: _yum
   tags: yum
 
 # Use set -o pipefail -o to quiet AnsibleLint
-- name: Uninstall conflicting packages
+- name: Remove conflicting packages before install yum
   shell: set -o pipefail | rpm -e --nodeps $(rpm -qa | grep -E "cloud-init|perl|openssl") 2>/dev/null
   ignore_errors: True
   when: _yum.stat.islnk is not defined
@@ -20,7 +21,7 @@
     # TODO: rpm used in place of yum or rpm_key module
     - skip_ansible_lint
 
-####################################
+##############################################################################
 # Install yum and update to latest #
 # Previous version of this downloaded and executed
 #   url: ftp://public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/ezinstall/ppc/yum.sh
@@ -28,7 +29,7 @@
 # but require a alturnative python to be installed
 # eg, http://download.aixtools.net/tools/aixtools.python.py36.3.6.12.0.I
 # and ansible.cfg needs 'ansible_python_interpreter = /opt/bin/python3.6'
-####################################
+##############################################################################
 - name: Install yum from AIXToolbox
   block:
     - name: Ensure dest exists
@@ -36,12 +37,20 @@
         state: directory
         path: /tmp/yum
 
-    - name: Transfer rpm.rte
+    - name: Assign URL strings
+      set_fact:
+        yum_downloads:
+          - "https://public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/INSTALLP/ppc/rpm.rte"
+          - "https://public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/ezinstall/ppc/yum_bundle.tar"
+
+    - name: Download rpm.rte and yum bundle
       get_url:
-        url: ftp://public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/INSTALLP/ppc/rpm.rte
+        url: "{{ item }}"
         mode: 0644
         validate_certs: false
         dest: /tmp/yum
+      with_items:
+        "{{ yum_downloads }}"
 
     - name: Install/update rpm.rte
       command: installp -aYgd /tmp/yum/rpm.rte rpm.rte
@@ -50,15 +59,11 @@
     - name: Update RPM database to include AIX BOS support
       command: /usr/sbin/updtvpkg
 
-    - name: Transfer yum bundle package
-      get_url:
-        url: ftp://public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/ezinstall/ppc/yum_bundle.tar
-        mode: 0644
-        validate_certs: false
-        dest: /tmp/yum
-
     - name: Unpack yum bundle
-      command: tar -xf /tmp/yum/yum_bundle.tar -C /tmp/yum
+      command:
+        cmd: /usr/bin/tar -xf /tmp/yum/yum_bundle.tar -C /tmp/yum
+        # Bootstrapping these tools - neither zip nor gtar is not available
+        warn: false
 
     - name: Install yum bundle
       command: rpm -i /tmp/yum/*.rpm
@@ -67,8 +72,13 @@
       file:
         state: absent
         path: /tmp/yum
+  when: _yum.stat.islnk is not defined
+  tags:
+    - yum
 
-    - name: Update yum installation
+- name: Update yum installation
+  block:
+    - name: Update YUM
       yum:
         update_cache: yes
         name: '*'
@@ -76,23 +86,22 @@
 
     - name: Install yum-utils
       yum: name=yum-utils state=present
-      tags:
-        - yum
 
     - name: Ensure AIX_Toolbox repo is enabled
       shell: yum-config-manager --enable AIX_Toolbox
-      tags: yum
 
     - name: Ensure AIX_Toolbox_noarch repo is enabled
       shell: yum-config-manager --enable AIX_Toolbox_noarch
-      tags: yum
 
     - name: Ensure AIX_Toolbox_71 repo is enabled
       shell: yum-config-manager --enable AIX_Toolbox_71
-      tags: yum
-  when: _yum.stat.islnk is not defined
   tags:
     - yum
+
+##############################################################################
+# YUM AIXToolbox integration is installed
+# Proceed with additional packages
+##############################################################################
 
 - name: Install OSS dev run-time-env using yum
   yum: name={{ item }} state=present update_cache=yes
@@ -129,6 +138,90 @@
     - zsh
   tags: yum
 
+##########################################################################
+# Adoptium builds do not work properly with the latest cmake @AIXToolbox #
+##########################################################################
+# NOTE: Cannot use yum module here as it will pull in cmake 3.16 which we do not want
+- name: Install cmake 3.14.3 prerequisites
+  command:
+    cmd: rpm -i "{{ item }}"
+    creates: /opt/freeware/etc/rpm/macros.cmake
+  with_items:
+    - https://public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/RPMS/ppc-7.1/cmake/cmake-filesystem-3.14.3-1.aix7.1.ppc.rpm
+    - https://public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/RPMS/ppc-7.1/cmake/cmake-rpm-macros-3.14.3-1.aix7.1.ppc.rpm
+  tags:
+    - rpm_install
+    - yum
+    - cmake
+
+# See https://github.com/AdoptOpenJDK/openjdk-build/issues/2492 for why we are locking this
+- name: Install cmake 3.14.3 (See https://github.com/AdoptOpenJDK/openjdk-build/issues/2492)
+  yum: name=cmake-3.14.3 state=present update_cache=yes
+  tags:
+    - rpm_install
+    - yum
+    - cmake
+##############################################################################
+# TASK [yum : Install cmake 3.14.3 (See https://github.com/AdoptOpenJDK/openjdk-build/issues/2492)]
+# fatal: [x077]: FAILED! => {"changed": false, "msg": "No package matching 'cmake-3.14.3' found available, installed or updated", "rc": 126, "results": ["No package matching 'cmake-3.14.3' found available, installed or updated"]}
+## If you get this message - you need to remove 'cmake*' from /opt/freeware/etc/yum/yum.conf
+##############################################################################
+
+- name: Ensure perl from /opt/freeware/bin is the default in /usr/bin
+  shell: mv /usr/bin/perl /usr/bin/perl.old && ln -s /opt/freeware/bin/perl /usr/bin/
+  ignore_errors: True
+  tags:
+    - rpm_install
+    - yum
+
+# Create zlib.h and zconf.h links - See https://github.com/adoptium/infrastructure/issues/1952
+- name: copy zlib.h and zconf.h (See https://github.com/adoptium/infrastructure/issues/1952)
+  copy:
+    src: "/opt/freeware/include/{{ item }}"
+    dest: "/usr/include/"
+    force: true
+    remote_src: true
+  with_items:
+    - zconf.h
+    - zlib.h
+  tags:
+    - yum
+
+##############################################################################
+# Prevent accidental updates to 'locked' packages
+##############################################################################
+- name: Exclude packages from yum (main)
+  lineinfile:
+    dest: /opt/freeware/etc/yum/yum.conf
+    firstmatch: yes
+    insertafter: 'plugins=1'
+    line: 'exclude=autoconf cmake* freetype2*'
+  tags:
+    - yum
+    - cmake
+    - freetype2
+
+##############################################################################
+# Update Packages (not locked) to latest level
+##############################################################################
+- name: Update AIXToolbox to latest using yum
+  yum:
+    update_cache: yes
+    name: '*'
+    state: latest
+    exclude:
+      autoconf*
+      cmake*
+      freetype2*
+  tags:
+    - yum
+    #TODO: Package installs should not use latest
+    - skip_ansible_lint
+
+##############################################################################
+# Remove OSS Packages that triage has shown to make builds non-portable
+##############################################################################
+
 - name: Remove packages - in case installed historically, or by accident
   yum: name={{ item }} state=absent
   with_items:
@@ -148,91 +241,3 @@
   tags:
     - yum
     - adoptopenjdk
-
-#######################################################
-# Additional Tools not available directly through yum #
-#######################################################
-- name: Confirm cmake prereqs have been installed
-  stat:
-    path: /opt/freeware/etc/rpm/macros.cmake
-  register: cmake_prereqs
-  tags:
-    - rpm_install
-    - yum
-    - cmake
-
-# NOTE: Cannot use yum module here as it will pull in cmake 3.16 which we do not want
-- name: Install cmake 3.14.3 prerequisites if needed (Will generate yum warning)
-  command: rpm -i https://public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/RPMS/ppc-7.1/cmake/cmake-rpm-macros-3.14.3-1.aix7.1.ppc.rpm  https://public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/RPMS/ppc-7.1/cmake/cmake-filesystem-3.14.3-1.aix7.1.ppc.rpm
-  tags:
-    - rpm_install
-    - yum
-    - cmake
-  when: not cmake_prereqs.stat.exists
-
-# See https://github.com/AdoptOpenJDK/openjdk-build/issues/2492 for why we are locking this
-- name: Install cmake 3.14.3 (3.16 has problems)
-  yum: name=cmake-3.14.3 state=present update_cache=yes
-  tags:
-    - rpm_install
-    - yum
-    - cmake
-
-- name: Ensure perl from /opt/freeware/bin is the default in /usr/bin
-  shell: mv /usr/bin/perl /usr/bin/perl.old && ln -s /opt/freeware/bin/perl /usr/bin/
-  ignore_errors: True
-  tags:
-    - rpm_install
-    - yum
-
-# Create zlib.h and zconf.h links - See https://github.com/adoptium/infrastructure/issues/1952
-
-- name: Checking for /opt/freeware/include/zlib.h
-  stat:
-    path: /opt/freeware/include/zlib.h
-  register: zlib
-  tags: yum
-
-- name: Checking for /opt/freeware/include/zconf.h
-  stat:
-    path: /opt/freeware/include/zconf.h
-  register: zconf
-  tags: yum
-
-- name: Link /usr/include/zlib.h to /opt/freeware/include/zlib.h
-  file:
-    src: /opt/freeware/include/zlib.h
-    dest: /usr/include/zlib.h
-    state: link
-  when: zlib.stat.exists
-  tags: yum
-
-- name: Link /usr/include/zconf.h to /opt/freeware/include/zconf.h
-  file:
-    src: /opt/freeware/include/zconf.h
-    dest: /usr/include/zconf.h
-    state: link
-  when: zconf.stat.exists
-  tags: yum
-
-- name: Exclude packages from yum (main)
-  lineinfile:
-    dest: /opt/freeware/etc/yum/yum.conf
-    firstmatch: yes
-    insertafter: 'plugins=1'
-    line: 'exclude=autoconf cmake* freetype2*'
-  tags: yum
-
-- name: Update AIXToolbox to latest using yum
-  yum:
-    update_cache: yes
-    name: '*'
-    state: latest
-    exclude:
-      autoconf*
-      cmake*
-      freetype2*
-  tags:
-    - yum
-    #TODO: Package installs should not use latest
-    - skip_ansible_lint


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

* IBM OSS (aka AIXTOOLBox) recently updated their yum support and installation. No longer is `yum_utils` included in the default install and update - while the playbook depends on it availability to complete later steps.
* This PR ensures `yum_utils` is available.
