### PR TITLE
winPB: Add 'changed_when: false' when using shell tasks to query

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Get_Vendor_Files/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Get_Vendor_Files/tasks/main.yml
@@ -22,6 +22,7 @@
   when:
     - not local_vendor_files.stat.exists
   run_once: true
+  changed_when: false
 
 - name: Generate list of remote vendor_files
   command: dotgpg cat {{ item }}

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/WMF_5.1/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/WMF_5.1/tasks/main.yml
@@ -8,6 +8,7 @@
   args:
     executable: powershell
   register: powershell_output
+  changed_when: false
   tags: WMF
 
 - name: Get WMF 5.1 Packages


### PR DESCRIPTION
Ref: #2422 , #2449

The same as #2449 , however this is specific to the Windows PB. 

This is currently blocked by #2178 , as we're unable to use VPC to test the changes.  

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
