### PR TITLE
VFs: Update yum repos for C8

### DIFF
--- a/ansible/vagrant/Vagrantfile.CentOS8
+++ b/ansible/vagrant/Vagrantfile.CentOS8
@@ -2,6 +2,14 @@
 # vi: set ft=ruby :
 
 $script = <<SCRIPT
+# CentOS8 is EOL, need to replace AppStream / BaseOS yum repos
+# See https://github.com/adoptium/infrastructure/issues/2462
+for RepoName in BaseOS AppStream
+do
+  sudo sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-Linux-${RepoName}.repo
+  sudo sed -i -e '$ a baseurl=http://vault.centos.org/\$contentdir/\$releasever/'"${RepoName}"'/\$basearch/os/' /etc/yum.repos.d/CentOS-Linux-${RepoName}.repo
+done
+
 sudo yum -y update
 sudo yum install -y libselinux-python
 sudo yum install -y ansible

--- a/ansible/vagrant/Vagrantfile.CentOS8
+++ b/ansible/vagrant/Vagrantfile.CentOS8
@@ -4,7 +4,7 @@
 $script = <<SCRIPT
 # CentOS8 is EOL, need to replace AppStream / BaseOS yum repos
 # See https://github.com/adoptium/infrastructure/issues/2462
-for RepoName in BaseOS AppStream
+for RepoName in BaseOS AppStream PowerTools
 do
   sudo sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-Linux-${RepoName}.repo
   sudo sed -i -e '$ a baseurl=http://vault.centos.org/\$contentdir/\$releasever/'"${RepoName}"'/\$basearch/os/' /etc/yum.repos.d/CentOS-Linux-${RepoName}.repo


### PR DESCRIPTION
Fixes: #2462 

Updates the `baseurl` for the BaseOS and Appstream repos in CentOS8, as CentOS8 is now EOL. 

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access). [VPC-1391](https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/1391/)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
