### PR TITLE
DFs: Add CentOS8 Stream Dockerfile

### DIFF
--- a/ansible/docker/Dockerfile.CentOS8
+++ b/ansible/docker/Dockerfile.CentOS8
@@ -1,0 +1,29 @@
+FROM centos:stream8
+
+ARG user=jenkins
+
+RUN yum -y update; yum -y install epel-release
+RUN yum -y install ansible sudo; yum clean all
+
+COPY . /ansible
+
+RUN echo "localhost ansible_connection=local" > /ansible/hosts
+
+RUN set -eux; \
+ cd /ansible; \
+ ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit"
+
+RUN rm -rf /ansible; yum remove ansible; yum clean all
+
+RUN groupadd -g 1000 ${user}
+RUN useradd -c "Jenkins user" -d /home/${user} -u 1000 -g 1000 -m ${user}
+
+ENV \
+    JDK7_BOOT_DIR="/usr/lib/jvm/java-1.7.0-openjdk" \
+    JDK8_BOOT_DIR="/usr/lib/jvm/java-1.8.0-openjdk" \
+    JDK10_BOOT_DIR="/usr/lib/jvm/jdk-10" \
+    JDK11_BOOT_DIR="/usr/lib/jvm/jdk-11" \
+    JDK13_BOOT_DIR="/usr/lib/jvm/jdk-13" \
+    JDK14_BOOT_DIR="/usr/lib/jvm/jdk-14" \
+    JDKLATEST_BOOT_DIR="/usr/lib/jvm/jdk-14" \
+    JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"


### PR DESCRIPTION
Ref; (possible Fixes): #2478 

Just a quick PR to `cp` the CentOS7 Dockerfile, and then change the `FROM` argument to `centos:stream8`.
 I sort of assume the ENV variables need to be updated too?

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
