### PR TITLE
UnixPb: Turn off unnecessary desktop environment

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -129,3 +129,4 @@
     - Security
     - Vendor
     - IPv6
+    - disable_gui

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -129,4 +129,5 @@
     - Security
     - Vendor
     - IPv6
-    - disable_gui
+    - role: disable_gui
+      tags: adoptopenjdk

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/disable_gui/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/disable_gui/tasks/main.yml
@@ -3,16 +3,26 @@
 # Ensure that no desktop environment is running #
 #################################################
 
+- name: Check if desktop is installed
+  stat:
+    path: /usr/share/xsessions
+  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version >= 7) or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= 18)
+  register: desktop_installed
+  tags: disable_gui
+
 - name: Disable GNOME for CentOS 7+ and Ubuntu 18+
   shell: systemctl set-default multi-user
-  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version >= 7) or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= 18)
+  when:
+    - desktop_installed.stat.exists
+    - (ansible_distribution == "CentOS" and ansible_distribution_major_version >= 7) or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= 18)
   register: gui_disabled
   tags: disable_gui
 
 - name: Reboot after disabling gui
   reboot:
     reboot_timeout: 600
-  when: 
-  - gui_disabled.stdout == ''
-  - (ansible_distribution == "CentOS" and ansible_distribution_major_version >= 7) or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= 18)
+  when:
+    - desktop_installed.stat.exists
+    - gui_disabled.stdout == ''
+    - (ansible_distribution == "CentOS" and ansible_distribution_major_version >= 7) or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= 18)
   tags: disable_gui

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/disable_gui/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/disable_gui/tasks/main.yml
@@ -23,6 +23,6 @@
     reboot_timeout: 600
   when:
     - (ansible_distribution == "CentOS" and ansible_distribution_major_version >= "7") or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= "18")
-    - gui_disabled.stdout == ''
     - desktop_installed.stat.exists
+    - gui_disabled.stdout == ''
   tags: disable_gui

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/disable_gui/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/disable_gui/tasks/main.yml
@@ -11,16 +11,15 @@
   tags: disable_gui
 
 - name: Disable GNOME for CentOS 7+ and Ubuntu 18+
-  shell: systemctl set-default multi-user
+  shell: systemctl isolate multi-user.target
+  register: gui_disabled
   when:
     - (ansible_distribution == "CentOS" and ansible_distribution_major_version >= "7") or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= "18")
     - desktop_installed.stat.exists
-  register: gui_disabled
   tags: disable_gui
 
-- name: Reboot after disabling gui
-  reboot:
-    reboot_timeout: 600
+- name: Keep GNOME for CentOS 7+ and Ubuntu 18+ disabled after reboot
+  shell: systemctl set-default multi-user
   when:
     - (ansible_distribution == "CentOS" and ansible_distribution_major_version >= "7") or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= "18")
     - desktop_installed.stat.exists

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/disable_gui/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/disable_gui/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+#################################################
+# Ensure that no desktop environment is running #
+#################################################
+
+- name: Disable GNOME for CentOS 7+ and Ubuntu 18+
+  shell: systemctl set-default multi-user
+  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version >= 7) or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= 18)
+  register: gui_disabled
+  tags: disable_gui
+
+- name: Reboot after disabling gui
+  reboot:
+    reboot_timeout: 600
+  when: gui_disabled.stdout == ''
+  tags: disable_gui

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/disable_gui/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/disable_gui/tasks/main.yml
@@ -12,5 +12,7 @@
 - name: Reboot after disabling gui
   reboot:
     reboot_timeout: 600
-  when: gui_disabled.stdout == ''
+  when: 
+  - gui_disabled.stdout == ''
+  - (ansible_distribution == "CentOS" and ansible_distribution_major_version >= 7) or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= 18)
   tags: disable_gui

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/disable_gui/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/disable_gui/tasks/main.yml
@@ -6,15 +6,15 @@
 - name: Check if desktop is installed
   stat:
     path: /usr/share/xsessions
-  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version >= 7) or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= 18)
+  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version >= "7") or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= "18")
   register: desktop_installed
   tags: disable_gui
 
 - name: Disable GNOME for CentOS 7+ and Ubuntu 18+
   shell: systemctl set-default multi-user
   when:
+    - (ansible_distribution == "CentOS" and ansible_distribution_major_version >= "7") or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= "18")
     - desktop_installed.stat.exists
-    - (ansible_distribution == "CentOS" and ansible_distribution_major_version >= 7) or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= 18)
   register: gui_disabled
   tags: disable_gui
 
@@ -22,7 +22,7 @@
   reboot:
     reboot_timeout: 600
   when:
-    - desktop_installed.stat.exists
+    - (ansible_distribution == "CentOS" and ansible_distribution_major_version >= "7") or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= "18")
     - gui_disabled.stdout == ''
-    - (ansible_distribution == "CentOS" and ansible_distribution_major_version >= 7) or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= 18)
+    - desktop_installed.stat.exists
   tags: disable_gui


### PR DESCRIPTION
ref https://github.com/adoptium/infrastructure/issues/2468

Right now running `systemctl set-default multi-user` only works on centos 7+ and ubuntu18+

Other distros should have similar commands which I will add to this pr shortly