### PR TITLE
inventory: Reallocate build-macstadium-macos1014-x64-3 to test

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -53,7 +53,6 @@ hosts:
       - macstadium:
           macos1014-x64-1: {ip: 208.83.1.170, user: Administrator}
           macos1014-x64-2: {ip: 207.254.28.76, user: Administrator}
-          macos1014-x64-3: {ip: 207.254.71.202, user: Administrator}
           macos11-arm64-1: {ip: 207.254.31.15, user: Administrator}
           macos11-arm64-2: {ip: 207.254.31.16, user: Administrator}
 
@@ -168,6 +167,7 @@ hosts:
           macos1014-x64-1: {ip: 207.254.29.43, user: administrator}
           macos1014-x64-2: {ip: 207.254.29.44, user: administrator}
           macos1014-x64-3: {ip: 207.254.28.237, user: administrator}
+          macos1014-x64-4: {ip: 207.254.71.202, user: Administrator}
           macos1015-x64-1: {ip: 207.254.28.171, user: administrator}
           macos11-arm64-1: {ip: 199.7.163.51, user: Administrator}
           macos11-arm64-2: {ip: 199.7.163.52, user: Administrator}


### PR DESCRIPTION
Fixes https://github.com/adoptium/infrastructure/issues/2475

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [x] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
