### PR TITLE
inventory: update AIX systems: remove test-ibm:, rename some osuosl systems

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -132,7 +132,7 @@ hosts:
           solaris10u11-sparcv9-1: {}
 
       - osuosl:
-          aix715-ppc64-1: {ip: 140.211.9.99, description: p9-aix1-adopt05.osuosl.org, 7100-05-06-2028} 
+          aix715-ppc64-1: {ip: 140.211.9.99, description: p9-aix1-adopt05.osuosl.org, 7100-05-06-2028}
           aix715-ppc64-2: {ip: 140.211.9.100, description: p9-aix1-adopt06.osuosl.org, 7100-05-06-2028}
           aix715-ppc64-3: {ip: 140.211.9.168, description: p8-java1-adopt07.osuosl.org, 7100-05-06-2028}
           aix715-ppc64-4: {ip: 140.211.9.169, description: p8-java1-adopt08.osuosl.org, 7100-05-06-2028}

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -61,8 +61,8 @@ hosts:
           rhel77-s390x-2: {ip: 148.100.245.197, user: linux1}
 
       - osuosl:
-          aix71-ppc64-1: {ip: 140.211.9.10, description: p8-aix1-adopt01.osuosl.org}
-          aix71-ppc64-2: {ip: 140.211.9.12, description: p8-aix1-adopt02.osuosl.org}
+          aix71-ppc64-1: {ip: 140.211.9.10, description: p8-aix1-adopt01.osuosl.org, 7100-04-04-1717}
+          aix71-ppc64-2: {ip: 140.211.9.12, description: p8-aix1-adopt02.osuosl.org, 7100-04-04-1717}
           centos74-ppc64le-1: {ip: 140.211.168.138}
           centos74-ppc64le-2: {ip: 140.211.168.117}
 
@@ -128,22 +128,18 @@ hosts:
           debian10-riscv64-1: {ip: gdams.ddns.net}
           debian10-riscv64-2: {ip: gdams.ddns.net, port: 2222}
 
-      - ibm:
-          aix71-ppc64-1: {ip: 129.33.196.209, user: b9s010a}
-          aix71-ppc64-2: {ip: 129.33.196.210, user: b9s010a}
-
       - inspira:
           solaris10u11-sparcv9-1: {}
 
       - osuosl:
-          aix71-ppc64-1: {ip: 140.211.9.99, description: p9-aix1-adopt05.osuosl.org}
-          aix715-ppc64-2: {ip: 140.211.9.100, description: p9-aix1-adopt06.osuosl.org}
-          aix715-ppc64-3: {ip: 140.211.9.168, description: p8-java1-adopt07.osuosl.org}
-          aix715-ppc64-4: {ip: 140.211.9.169, description: p8-java1-adopt08.osuosl.org}
-          aix72-ppc64-1: {ip: 140.211.9.28, description: p8-aix1-adopt03.osuosl.org}
-          aix72-ppc64-2: {ip: 140.211.9.36, description: p8-aix1-adopt04.osuosl.org}
-          aix724-ppc64-3: {ip: 140.211.9.163, description: p8-java1-adopt09.osuosl.org}
-          aix724-ppc64-4: {ip: 140.211.9.166, description: p8-java1-adopt10.osuosl.org}
+          aix715-ppc64-1: {ip: 140.211.9.99, description: p9-aix1-adopt05.osuosl.org, 7100-05-06-2028} 
+          aix715-ppc64-2: {ip: 140.211.9.100, description: p9-aix1-adopt06.osuosl.org, 7100-05-06-2028}
+          aix715-ppc64-3: {ip: 140.211.9.168, description: p8-java1-adopt07.osuosl.org, 7100-05-06-2028}
+          aix715-ppc64-4: {ip: 140.211.9.169, description: p8-java1-adopt08.osuosl.org, 7100-05-06-2028}
+          aix72-ppc64-1: {ip: 140.211.9.28, description: p8-aix1-adopt03.osuosl.org, 7200-04-02-2028}
+          aix72-ppc64-2: {ip: 140.211.9.36, description: p8-aix1-adopt04.osuosl.org, 7200-02-05-1938}
+          aix72-ppc64-3: {ip: 140.211.9.163, description: p8-java1-adopt09.osuosl.org, 7X00-TL-SP-YYWW}
+          aix72-ppc64-4: {ip: 140.211.9.166, description: p8-java1-adopt10.osuosl.org, 7X00-TL-SP-YYWW}
           centos74-ppc64le-1: {ip: 140.211.168.228, user: centos}
           centos74-ppc64le-2: {ip: 140.211.168.217, user: centos}
           ubuntu1604-ppc64le-1: {ip: 140.211.168.227, user: ubuntu}


### PR DESCRIPTION
rename aix71-ppc64-1 to aix715-ppc64-1
to be like the other AIX test systems (-2, -3, -4).

 Add current oslevel -s that fits bos.mp64 (kernel) level install to description:
 As AIX 7.2 level is fluid - for consistent naming have all system labels as:
 aix72-ppc64-N (-1, -2, -3, -4)
 Note:
 - aix72-ppc64-1 is at 7200-04-02-2028
 - aix72-ppc64-2 is at 7200-02-05-1938
 - aix72-ppc64-{3,4} are not installed yet (for jenkins usage)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

# Note:
- I (don't think I am) am not able to modify any of bastillion, nagios, or jenkins. If those files are also in this repository - please point me at them - and I'll do my best to update them as well.
