### PR TITLE
inventory: add new macincloud Monterey/x64 systems

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -161,6 +161,8 @@ hosts:
       - macincloud:
           macos1010-x64-1: {ip: 74.80.250.151, user: admin, description: TBD}
           macos1010-x64-2: {ip: 74.80.250.173, user: admin, description: TBD}
+          macos1201-x64-1: {ip: 216.39.74.137, user: admin, description: DXT437}
+          macos1201-x64-2: {ip: 216.39.74.140, user: admin, description: DXT440}
 
       - macstadium:
           macos1012-x64-1: {ip: 208.83.1.46, user: administrator}


### PR DESCRIPTION
Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly - jenkins and nagios will be done once the playbook deployments have been completed.

The expectation is the the older two macincloud systems will be removed once these new ones are activated since they are running old operating systems, so this effectively fixes: https://github.com/adoptium/infrastructure/issues/2476 and https://github.com/adoptium/infrastructure/issues/1922