### PR TITLE
UnixPb: Symlink adoptopenjdk install directory to temurin install directory on macos

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
@@ -162,6 +162,9 @@
   file:
     src: /Library/Java/JavaVirtualMachines/temurin-{{ jdk_version }}.jdk
     dest: /Library/Java/JavaVirtualMachines/adoptopenjdk-{{ jdk_version }}.jdk
+    state: link
+    owner: root
+    group: wheel
   when:
     - ansible_distribution == "MacOSX"
     - adoptopenjdk_installed.rc != 0

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
@@ -25,7 +25,7 @@
 
 - name: Set path variable (macOS)
   set_fact:
-    path: "/Library/Java/JavaVirtualMachines/adoptopenjdk-{{ jdk_version }}.jdk"
+    path: "/Library/Java/JavaVirtualMachines/jdk-{{ jdk_version }}"
   when: ansible_distribution == "MacOSX"
   tags: adoptopenjdk_install
 
@@ -155,29 +155,30 @@
     - adoptopenjdk_installed.rc != 0
   tags: adoptopenjdk_install
 
-# Boot JDK will be installed in temurin directory. Playbooks, build and (possibly) test scripts will look for adoptopenjdk directory
+# Boot JDK will be installed in temurin directory. Playbooks, build and (possibly) test scripts will look for an adoptopenjdk directory
 # https://github.com/adoptium/infrastructure/issues/2281#issuecomment-1059322275
 
-- name: Check if JDK was installed to a temurin directory (MacOS)
-  stat:
-    path: /Library/Java/JavaVirtualMachines/temurin-{{ jdk_version }}.jdk
-  register: temurin_dir
+- name: Find bootjdk install directory (MacOS)
+  shell: ls -ld /Library/Java/JavaVirtualMachines/*-{{ jdk_version }}.jdk/ | awk '{print $9}'
+  register: bootjdk_install_dir
   when:
     - ansible_distribution == "MacOSX"
     - adoptopenjdk_installed.rc != 0
   tags: adoptopenjdk_install
 
-- name: Create adoptopenjdk symlink to temurin directory (MacOS)
+- name: Create jdk symlink to bootjdk install directory (MacOS)
   file:
-    src: /Library/Java/JavaVirtualMachines/temurin-{{ jdk_version }}.jdk
-    dest: /Library/Java/JavaVirtualMachines/adoptopenjdk-{{ jdk_version }}.jdk
+    src: '{{ bootjdk_install_dir.stdout }}'
+    dest: '{{ path }}'
     state: link
     owner: root
     group: wheel
+  become: yes
+  become_user: root
+  become_method: sudo
   when:
     - ansible_distribution == "MacOSX"
     - adoptopenjdk_installed.rc != 0
-    - temurin_dir.stat.isdir is true
   tags: adoptopenjdk_install
 
 - name: Install latest release if one not already installed (Solaris)

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
@@ -158,7 +158,16 @@
 # Boot JDK will be installed in temurin directory. Playbooks, build and (possibly) test scripts will look for adoptopenjdk directory
 # https://github.com/adoptium/infrastructure/issues/2281#issuecomment-1059322275
 
-- name: Create adoptopenjdk symlink to temurin directory
+- name: Check if JDK was installed to a temurin directory (MacOS)
+  stat:
+    path: /Library/Java/JavaVirtualMachines/temurin-{{ jdk_version }}.jdk
+  register: temurin_dir
+  when:
+    - ansible_distribution == "MacOSX"
+    - adoptopenjdk_installed.rc != 0
+  tags: adoptopenjdk_install
+
+- name: Create adoptopenjdk symlink to temurin directory (MacOS)
   file:
     src: /Library/Java/JavaVirtualMachines/temurin-{{ jdk_version }}.jdk
     dest: /Library/Java/JavaVirtualMachines/adoptopenjdk-{{ jdk_version }}.jdk
@@ -168,6 +177,7 @@
   when:
     - ansible_distribution == "MacOSX"
     - adoptopenjdk_installed.rc != 0
+    - temurin_dir.stat.isdir is true
   tags: adoptopenjdk_install
 
 - name: Install latest release if one not already installed (Solaris)

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
@@ -155,6 +155,18 @@
     - adoptopenjdk_installed.rc != 0
   tags: adoptopenjdk_install
 
+# Boot JDK will be installed in temurin directory. Playbooks, build and (possibly) test scripts will look for adoptopenjdk directory
+# https://github.com/adoptium/infrastructure/issues/2281#issuecomment-1059322275
+
+- name: Create adoptopenjdk symlink to temurin directory
+  file:
+    src: /Library/Java/JavaVirtualMachines/temurin-{{ jdk_version }}.jdk
+    dest: /Library/Java/JavaVirtualMachines/adoptopenjdk-{{ jdk_version }}.jdk
+  when:
+    - ansible_distribution == "MacOSX"
+    - adoptopenjdk_installed.rc != 0
+  tags: adoptopenjdk_install
+
 - name: Install latest release if one not already installed (Solaris)
   command: wget https://api.adoptopenjdk.net/v3/binary/latest/{{ jdk_version }}/ga/solaris/{{ api_architecture }}/jdk/{{ bootjdk }}/normal/adoptopenjdk?project=jdk -O /tmp/jdk-{{ jdk_version }}.tar.gz
   register: adoptopenjdk_download

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
@@ -159,7 +159,11 @@
 # https://github.com/adoptium/infrastructure/issues/2281#issuecomment-1059322275
 
 - name: Find bootjdk install directory (MacOS)
-  shell: ls -ld /Library/Java/JavaVirtualMachines/*-{{ jdk_version }}.jdk/ | awk '{print $9}'
+  find:
+    paths: /Library/Java/JavaVirtualMachines
+    patterns: "^adoptopenjdk-{{ jdk_version }}.jdk|^temurin-{{ jdk_version }}.jdk"
+    use_regex: yes
+    file_type: directory
   register: bootjdk_install_dir
   when:
     - ansible_distribution == "MacOSX"
@@ -168,7 +172,7 @@
 
 - name: Create jdk symlink to bootjdk install directory (MacOS)
   file:
-    src: '{{ bootjdk_install_dir.stdout }}'
+    src: '{{ bootjdk_install_dir.files[0].path }}'
     dest: '{{ path }}'
     state: link
     owner: root


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/2281#issuecomment-1059322275

Since changing from hotspot to temurin, bootjdks (on MacOS) are installed into `/Library/Java/JavaVirtualMachines/temurin-*.jdk/` rather than `/Library/Java/JavaVirtualMachines/adoptopenjdk-*.jdk/`. The build scripts still look in the former directory, https://github.com/adoptium/temurin-build/blob/c4842313fe56dacd4986e35d34d132db979bf8df/build-farm/platform-specific-configurations/mac.sh#L82 as do the playbooks. Making this link would solve this problem.

This would also ensure idempotency for the `adoptopenjdk_install` role for MacOS