### PR TITLE
UnixPb: Set xcode switch path to full path on build machines

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode/tasks/main.yml
@@ -82,3 +82,6 @@
     XCODE_INSTALL_PASSWORD: "{{ Apple_ID_Password }}"
     FASTLANE_SESSION: "{{ FASTLANE_SESSION }}"
     FASTLANE_DONT_STORE_PASSWORD: 1
+
+- name: Set Xcode switch path to "/Applications/Xcode.app"
+  shell: sudo xcode-select --switch "/Applications/Xcode.app"


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/temurin-build/pull/2876 and https://adoptium.slack.com/archives/C09NW3L2J/p1646743526526249

The xcode switch path can be set to "/Applications/Xcode.app" for jdk8, 11 and 17+. Hence this can be set as the default path in the playbooks, without having to execute the commands in the build scripts