### PR TITLE
inventory: remove older (pre 10.14) macos systems

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -154,14 +154,10 @@ hosts:
           win2012r2-x64-1: {ip: 147.75.32.146, user: Admin}
 
       - macincloud:
-          macos1010-x64-1: {ip: 74.80.250.151, user: admin, description: TBD}
-          macos1010-x64-2: {ip: 74.80.250.173, user: admin, description: TBD}
           macos1201-x64-1: {ip: 216.39.74.137, user: admin, description: DXT437}
           macos1201-x64-2: {ip: 216.39.74.140, user: admin, description: DXT440}
 
       - macstadium:
-          macos1012-x64-1: {ip: 208.83.1.46, user: administrator}
-          macos1013-x64-1: {ip: 208.83.1.19, user: administrator}
           macos1014-x64-1: {ip: 207.254.29.43, user: administrator}
           macos1014-x64-2: {ip: 207.254.29.44, user: administrator}
           macos1014-x64-3: {ip: 207.254.28.237, user: administrator}


### PR DESCRIPTION
As per PMC call this week, decomission the original macincloud 10.10 systems, and also the ones we have from macstadium that are at a lower level from the one listed on our [supported platforms page](https://adoptium.net/supported_platforms.html).

Fixes https://github.com/adoptium/infrastructure/issues/2496

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
