### PR TITLE
UnixPB: Skip xcode role if apple id variables are not defined

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode/tasks/main.yml
@@ -10,9 +10,9 @@
   set_fact:
     apple_variables: yes
   when:
-   - Apple_ID_User is defined
-   - Apple_ID_Password is defined
-   - FASTLANE_SESSION is defined
+    - Apple_ID_User is defined
+    - Apple_ID_Password is defined
+    - FASTLANE_SESSION is defined
 
 - debug:
     msg: "Apple ID variables are not defined. Xcode will need to be installed manually.

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode/tasks/main.yml
@@ -6,82 +6,98 @@
 # List of available versions: $ xcversion list
 # See https://xcodereleases.com for an Xcode support matrix.
 ---
-- name: Ensure Ruby is installed for xcode-install
-  become: yes
-  become_user: "{{ ansible_user }}"
-  homebrew:
-    name: ruby@2.7 # no 3.0 yet for fastlane (https://github.com/fastlane/fastlane/issues/17931)
-    state: present
-
-- name: Configure Bash profile extension for Ruby
-  become: yes
-  copy:
-    content: |
-      if [ -d "/usr/local/opt/ruby@2.7/bin" ]; then
-          export PATH=/usr/local/opt/ruby@2.7/bin:$PATH
-          export PATH=`gem environment gemdir`/bin:$PATH
-      fi
-    dest: /etc/profile.d/ruby
-    owner: root
-    group: wheel
-
-- name: Reset SSH connection to ensure that shell/profile changes take effect
-  shell: sleep 1; pkill -u {{ ansible_ssh_user }} sshd
-  async: 3
-  poll: 2
-
-- name: Ensure xcode-install and its dependencies are installed
-  become: yes # for system-wide installation
-  gem:
-    name: "{{ item }}"
-    state: latest
-    user_install: no
-  environment:
-    PATH: /usr/local/opt/ruby@2.7/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
-  loop:
-    - fastlane # explicitly list fastlane to get latest version
-    - xcode-install
-
-- name: Set xcversion location for x86_64
+- name: Check if Apple ID variables are defined
   set_fact:
-    xcversion: /usr/local/lib/ruby/gems/2.7.0/bin/xcversion
+    apple_variables: yes
   when:
-    - ansible_architecture == "x86_64"
+   - Apple_ID_User is defined
+   - Apple_ID_Password is defined
+   - FASTLANE_SESSION is defined
 
-- name: Set xcversion location for arm64
-  set_fact:
-    xcversion: xcversion
-  when:
-    - ansible_architecture == "arm64"
+- debug:
+    msg: "Apple ID variables are not defined. Xcode will need to be installed manually. 
+          Ensure that Apple_ID_User, Apple_ID_Password and FASTLANE_SESSION are defined. Skipping Xcode installation"
+  when: apple_variables is not defined
 
-# On ARM, we can use 12.x because compiling on ARM requires at least Xcode 12.
-- name: Install Xcode on Apple Silicon Macs
-  shell: "{{ xcversion }} install 12.4 --retry-download-count=10"
-  when: ansible_architecture == "arm64"
-  environment:
-    XCODE_INSTALL_USER: "{{ Apple_ID_User }}"
-    XCODE_INSTALL_PASSWORD: "{{ Apple_ID_Password }}"
-    FASTLANE_SESSION: "{{ FASTLANE_SESSION }}"
-    FASTLANE_DONT_STORE_PASSWORD: 1
+- name: Install Xcode
+  block:
+  - name: Ensure Ruby is installed for xcode-install
+    become: yes
+    become_user: "{{ ansible_user }}"
+    homebrew:
+      name: ruby@2.7 # no 3.0 yet for fastlane (https://github.com/fastlane/fastlane/issues/17931)
+      state: present
 
-# 10.x is our default version on Intel. It requires 10.14.3+. As a consequence, some test machines
-# with older macOS won't have Xcode installed.
-- name: Install Xcode on Intel Macs
-  shell: "{{ xcversion }} install 10.3 --retry-download-count=10"
-  when: ansible_architecture == "x86_64" and ansible_distribution_version is version('10.14.3', operator='>=')
-  environment:
-    XCODE_INSTALL_USER: "{{ Apple_ID_User }}"
-    XCODE_INSTALL_PASSWORD: "{{ Apple_ID_Password }}"
-    FASTLANE_SESSION: "{{ FASTLANE_SESSION }}"
-    FASTLANE_DONT_STORE_PASSWORD: 1
+  - name: Configure Bash profile extension for Ruby
+    become: yes
+    copy:
+      content: |
+        if [ -d "/usr/local/opt/ruby@2.7/bin" ]; then
+            export PATH=/usr/local/opt/ruby@2.7/bin:$PATH
+            export PATH=`gem environment gemdir`/bin:$PATH
+        fi
+      dest: /etc/profile.d/ruby
+      owner: root
+      group: wheel
 
-- name: Cleanup Xcode installation files
-  shell: "{{ xcversion }} cleanup"
-  environment:
-    XCODE_INSTALL_USER: "{{ Apple_ID_User }}"
-    XCODE_INSTALL_PASSWORD: "{{ Apple_ID_Password }}"
-    FASTLANE_SESSION: "{{ FASTLANE_SESSION }}"
-    FASTLANE_DONT_STORE_PASSWORD: 1
+  - name: Reset SSH connection to ensure that shell/profile changes take effect
+    shell: sleep 1; pkill -u {{ ansible_ssh_user }} sshd
+    async: 3
+    poll: 2
 
-- name: Set Xcode switch path to "/Applications/Xcode.app"
-  shell: sudo xcode-select --switch "/Applications/Xcode.app"
+  - name: Ensure xcode-install and its dependencies are installed
+    become: yes # for system-wide installation
+    gem:
+      name: "{{ item }}"
+      state: latest
+      user_install: no
+    environment:
+      PATH: /usr/local/opt/ruby@2.7/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+    loop:
+      - fastlane # explicitly list fastlane to get latest version
+      - xcode-install
+
+  - name: Set xcversion location for x86_64
+    set_fact:
+      xcversion: /usr/local/lib/ruby/gems/2.7.0/bin/xcversion
+    when:
+      - ansible_architecture == "x86_64"
+
+  - name: Set xcversion location for arm64
+    set_fact:
+      xcversion: xcversion
+    when:
+      - ansible_architecture == "arm64"
+
+  # On ARM, we can use 12.x because compiling on ARM requires at least Xcode 12.
+  - name: Install Xcode on Apple Silicon Macs
+    shell: "{{ xcversion }} install 12.4 --retry-download-count=10"
+    when: ansible_architecture == "arm64"
+    environment:
+      XCODE_INSTALL_USER: "{{ Apple_ID_User }}"
+      XCODE_INSTALL_PASSWORD: "{{ Apple_ID_Password }}"
+      FASTLANE_SESSION: "{{ FASTLANE_SESSION }}"
+      FASTLANE_DONT_STORE_PASSWORD: 1
+
+  # 10.x is our default version on Intel. It requires 10.14.3+. As a consequence, some test machines
+  # with older macOS won't have Xcode installed.
+  - name: Install Xcode on Intel Macs
+    shell: "{{ xcversion }} install 10.3 --retry-download-count=10"
+    when: ansible_architecture == "x86_64" and ansible_distribution_version is version('10.14.3', operator='>=')
+    environment:
+      XCODE_INSTALL_USER: "{{ Apple_ID_User }}"
+      XCODE_INSTALL_PASSWORD: "{{ Apple_ID_Password }}"
+      FASTLANE_SESSION: "{{ FASTLANE_SESSION }}"
+      FASTLANE_DONT_STORE_PASSWORD: 1
+
+  - name: Cleanup Xcode installation files
+    shell: "{{ xcversion }} cleanup"
+    environment:
+      XCODE_INSTALL_USER: "{{ Apple_ID_User }}"
+      XCODE_INSTALL_PASSWORD: "{{ Apple_ID_Password }}"
+      FASTLANE_SESSION: "{{ FASTLANE_SESSION }}"
+      FASTLANE_DONT_STORE_PASSWORD: 1
+
+  - name: Set Xcode switch path to "/Applications/Xcode.app"
+    shell: sudo xcode-select --switch "/Applications/Xcode.app"
+  when: apple_variables is defined

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode/tasks/main.yml
@@ -15,7 +15,7 @@
    - FASTLANE_SESSION is defined
 
 - debug:
-    msg: "Apple ID variables are not defined. Xcode will need to be installed manually. 
+    msg: "Apple ID variables are not defined. Xcode will need to be installed manually.
           Ensure that Apple_ID_User, Apple_ID_Password and FASTLANE_SESSION are defined. Skipping Xcode installation"
   when: apple_variables is not defined
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode/tasks/main.yml
@@ -21,83 +21,83 @@
 
 - name: Install Xcode
   block:
-  - name: Ensure Ruby is installed for xcode-install
-    become: yes
-    become_user: "{{ ansible_user }}"
-    homebrew:
-      name: ruby@2.7 # no 3.0 yet for fastlane (https://github.com/fastlane/fastlane/issues/17931)
-      state: present
+    - name: Ensure Ruby is installed for xcode-install
+      become: yes
+      become_user: "{{ ansible_user }}"
+      homebrew:
+        name: ruby@2.7 # no 3.0 yet for fastlane (https://github.com/fastlane/fastlane/issues/17931)
+        state: present
 
-  - name: Configure Bash profile extension for Ruby
-    become: yes
-    copy:
-      content: |
-        if [ -d "/usr/local/opt/ruby@2.7/bin" ]; then
-            export PATH=/usr/local/opt/ruby@2.7/bin:$PATH
-            export PATH=`gem environment gemdir`/bin:$PATH
-        fi
-      dest: /etc/profile.d/ruby
-      owner: root
-      group: wheel
+    - name: Configure Bash profile extension for Ruby
+      become: yes
+      copy:
+        content: |
+          if [ -d "/usr/local/opt/ruby@2.7/bin" ]; then
+              export PATH=/usr/local/opt/ruby@2.7/bin:$PATH
+              export PATH=`gem environment gemdir`/bin:$PATH
+          fi
+        dest: /etc/profile.d/ruby
+        owner: root
+        group: wheel
 
-  - name: Reset SSH connection to ensure that shell/profile changes take effect
-    shell: sleep 1; pkill -u {{ ansible_ssh_user }} sshd
-    async: 3
-    poll: 2
+    - name: Reset SSH connection to ensure that shell/profile changes take effect
+      shell: sleep 1; pkill -u {{ ansible_ssh_user }} sshd
+      async: 3
+      poll: 2
 
-  - name: Ensure xcode-install and its dependencies are installed
-    become: yes # for system-wide installation
-    gem:
-      name: "{{ item }}"
-      state: latest
-      user_install: no
-    environment:
-      PATH: /usr/local/opt/ruby@2.7/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
-    loop:
-      - fastlane # explicitly list fastlane to get latest version
-      - xcode-install
+    - name: Ensure xcode-install and its dependencies are installed
+      become: yes # for system-wide installation
+      gem:
+        name: "{{ item }}"
+        state: latest
+        user_install: no
+      environment:
+        PATH: /usr/local/opt/ruby@2.7/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+      loop:
+        - fastlane # explicitly list fastlane to get latest version
+        - xcode-install
 
-  - name: Set xcversion location for x86_64
-    set_fact:
-      xcversion: /usr/local/lib/ruby/gems/2.7.0/bin/xcversion
-    when:
-      - ansible_architecture == "x86_64"
+    - name: Set xcversion location for x86_64
+      set_fact:
+        xcversion: /usr/local/lib/ruby/gems/2.7.0/bin/xcversion
+      when:
+        - ansible_architecture == "x86_64"
 
-  - name: Set xcversion location for arm64
-    set_fact:
-      xcversion: xcversion
-    when:
-      - ansible_architecture == "arm64"
+    - name: Set xcversion location for arm64
+      set_fact:
+        xcversion: xcversion
+      when:
+        - ansible_architecture == "arm64"
 
-  # On ARM, we can use 12.x because compiling on ARM requires at least Xcode 12.
-  - name: Install Xcode on Apple Silicon Macs
-    shell: "{{ xcversion }} install 12.4 --retry-download-count=10"
-    when: ansible_architecture == "arm64"
-    environment:
-      XCODE_INSTALL_USER: "{{ Apple_ID_User }}"
-      XCODE_INSTALL_PASSWORD: "{{ Apple_ID_Password }}"
-      FASTLANE_SESSION: "{{ FASTLANE_SESSION }}"
-      FASTLANE_DONT_STORE_PASSWORD: 1
+    # On ARM, we can use 12.x because compiling on ARM requires at least Xcode 12.
+    - name: Install Xcode on Apple Silicon Macs
+      shell: "{{ xcversion }} install 12.4 --retry-download-count=10"
+      when: ansible_architecture == "arm64"
+      environment:
+        XCODE_INSTALL_USER: "{{ Apple_ID_User }}"
+        XCODE_INSTALL_PASSWORD: "{{ Apple_ID_Password }}"
+        FASTLANE_SESSION: "{{ FASTLANE_SESSION }}"
+        FASTLANE_DONT_STORE_PASSWORD: 1
 
-  # 10.x is our default version on Intel. It requires 10.14.3+. As a consequence, some test machines
-  # with older macOS won't have Xcode installed.
-  - name: Install Xcode on Intel Macs
-    shell: "{{ xcversion }} install 10.3 --retry-download-count=10"
-    when: ansible_architecture == "x86_64" and ansible_distribution_version is version('10.14.3', operator='>=')
-    environment:
-      XCODE_INSTALL_USER: "{{ Apple_ID_User }}"
-      XCODE_INSTALL_PASSWORD: "{{ Apple_ID_Password }}"
-      FASTLANE_SESSION: "{{ FASTLANE_SESSION }}"
-      FASTLANE_DONT_STORE_PASSWORD: 1
+    # 10.x is our default version on Intel. It requires 10.14.3+. As a consequence, some test machines
+    # with older macOS won't have Xcode installed.
+    - name: Install Xcode on Intel Macs
+      shell: "{{ xcversion }} install 10.3 --retry-download-count=10"
+      when: ansible_architecture == "x86_64" and ansible_distribution_version is version('10.14.3', operator='>=')
+      environment:
+        XCODE_INSTALL_USER: "{{ Apple_ID_User }}"
+        XCODE_INSTALL_PASSWORD: "{{ Apple_ID_Password }}"
+        FASTLANE_SESSION: "{{ FASTLANE_SESSION }}"
+        FASTLANE_DONT_STORE_PASSWORD: 1
 
-  - name: Cleanup Xcode installation files
-    shell: "{{ xcversion }} cleanup"
-    environment:
-      XCODE_INSTALL_USER: "{{ Apple_ID_User }}"
-      XCODE_INSTALL_PASSWORD: "{{ Apple_ID_Password }}"
-      FASTLANE_SESSION: "{{ FASTLANE_SESSION }}"
-      FASTLANE_DONT_STORE_PASSWORD: 1
+    - name: Cleanup Xcode installation files
+      shell: "{{ xcversion }} cleanup"
+      environment:
+        XCODE_INSTALL_USER: "{{ Apple_ID_User }}"
+        XCODE_INSTALL_PASSWORD: "{{ Apple_ID_Password }}"
+        FASTLANE_SESSION: "{{ FASTLANE_SESSION }}"
+        FASTLANE_DONT_STORE_PASSWORD: 1
 
-  - name: Set Xcode switch path to "/Applications/Xcode.app"
-    shell: sudo xcode-select --switch "/Applications/Xcode.app"
+    - name: Set Xcode switch path to "/Applications/Xcode.app"
+      shell: sudo xcode-select --switch "/Applications/Xcode.app"
   when: apple_variables is defined


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/1910#issuecomment-1060625222

Often times the Apple ID variables, Apple_ID_User, Apple_ID_Password, FASTLANE_SESSION, are not defined during a playbook run. I am not sure where these variables are kept. AWX does not have access to them despite having access to the secrets repo.

In any case, the playbook should not halt if these variables are not present
