### PR TITLE
UnixPb: Enable ipv6 on docker on dockerhost machines

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/tasks/main.yml
@@ -9,11 +9,13 @@
     line: '{ "ipv6": true, "fixed-cidr-v6": "fd00::/80" }'
     insertafter: EOF
     create: yes
+  register: restart_docker
 
 - name: Restart docker
   service:
     name: docker
     state: restarted
+  when: restart_docker.changed is true
 
 - name: Send Dockerfiles to remote machine
   copy:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/tasks/main.yml
@@ -3,6 +3,18 @@
 # Build basic test images for each distribution #
 #################################################
 
+- name: Enable ipv6 on Dockerhost
+  lineinfile:
+    path: /etc/docker/daemon.json
+    line: '{ "ipv6": true, "fixed-cidr-v6": "fd00::/80" }'
+    insertafter: EOF
+    create: yes
+
+- name: Restart docker
+  service:
+    name: docker
+    state: restarted
+
 - name: Send Dockerfiles to remote machine
   copy:
     src: Dockerfiles/


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/2517#issuecomment-1084815153

Ipv6 needs to be enabled in the docker engine on our dockerhost machines in order for certain ipv6 net tests, in jdk_net, to pass on containers on these dockerhost machine