### PR TITLE
unixPB: add two new dockerstatic container for fedora34/35

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.f34
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.f34
@@ -1,0 +1,30 @@
+FROM fedora:34
+
+RUN yum -y update && yum install -y perl openssh-server unzip wget
+RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -P ""
+# Get java8
+RUN wget -q 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O /tmp/jdk8.tar.gz
+RUN mkdir -p /usr/lib/jvm/jdk8 && tar -xpzf /tmp/jdk8.tar.gz -C /usr/lib/jvm/jdk8 --strip-components=1
+# Install ant 1.10.12
+RUN wget -q -O /tmp/ant.zip 'https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.12-bin.zip'
+RUN wget -q -O /tmp/ant-contrib.tgz  https://sourceforge.net/projects/ant-contrib/files/ant-contrib/ant-contrib-1.0b2/ant-contrib-1.0b2-bin.tar.gz
+RUN echo "7e6fbcc3563df4bd87c883ad86a161a71da2774e0ed71a1b3aad82cbff1a7656ed9a0acb5ce40652129376dfd79f1ef74ec3369c1067d412a63062fea62ceccd  /tmp/ant.zip" > /tmp/ant.sha512
+RUN echo "0fd2771dca2b8b014a4cb3246715b32e20ad5d26754186d82eee781507a183d5e63064890b95eb27c091c93c1209528a0b18a6d7e6901899319492a7610e74ad  /tmp/ant-contrib.tgz" >> /tmp/ant.sha512
+RUN sha512sum --check --strict /tmp/ant.sha512
+RUN ln -s /usr/local/apache-ant-1.10.12/bin/ant /usr/bin/ant
+RUN unzip -q -d /usr/local /tmp/ant.zip
+RUN tar xpfz /tmp/ant-contrib.tgz -C /usr/local/apache-ant-1.10.12/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
+# Clear up space
+RUN rm /tmp/jdk8.tar.gz /tmp/ant.zip /tmp/ant-contrib.tgz
+# Set up jenkins user
+RUN useradd -m -d /home/jenkins jenkins
+RUN mkdir /home/jenkins/.ssh
+RUN echo "Jenkins_User_SSHKey" > /home/jenkins/.ssh/authorized_keys
+RUN chown -R jenkins /home/jenkins/.ssh
+RUN chmod -R og-rwx /home/jenkins/.ssh
+# RUN service ssh start
+CMD ["/usr/sbin/sshd","-D"]
+RUN yum install -y git curl make gcc xorg-x11-server-Xvfb libXrender libXi libXtst procps glibc-langpack-en fontconfig which hostname fakeroot
+# ENTRYPOINT /usr/lib/jvm/jdk8/bin/java
+EXPOSE 22
+# Start with docker run -p 2222:22 UUID

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.f35
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.f35
@@ -1,0 +1,30 @@
+FROM fedora:35
+
+RUN yum -y update && yum install -y perl openssh-server unzip wget
+RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -P ""
+# Get java8
+RUN wget -q 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O /tmp/jdk8.tar.gz
+RUN mkdir -p /usr/lib/jvm/jdk8 && tar -xpzf /tmp/jdk8.tar.gz -C /usr/lib/jvm/jdk8 --strip-components=1
+# Install ant 1.10.12
+RUN wget -q -O /tmp/ant.zip 'https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.12-bin.zip'
+RUN wget -q -O /tmp/ant-contrib.tgz  https://sourceforge.net/projects/ant-contrib/files/ant-contrib/ant-contrib-1.0b2/ant-contrib-1.0b2-bin.tar.gz
+RUN echo "7e6fbcc3563df4bd87c883ad86a161a71da2774e0ed71a1b3aad82cbff1a7656ed9a0acb5ce40652129376dfd79f1ef74ec3369c1067d412a63062fea62ceccd  /tmp/ant.zip" > /tmp/ant.sha512
+RUN echo "0fd2771dca2b8b014a4cb3246715b32e20ad5d26754186d82eee781507a183d5e63064890b95eb27c091c93c1209528a0b18a6d7e6901899319492a7610e74ad  /tmp/ant-contrib.tgz" >> /tmp/ant.sha512
+RUN sha512sum --check --strict /tmp/ant.sha512
+RUN ln -s /usr/local/apache-ant-1.10.12/bin/ant /usr/bin/ant
+RUN unzip -q -d /usr/local /tmp/ant.zip
+RUN tar xpfz /tmp/ant-contrib.tgz -C /usr/local/apache-ant-1.10.12/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
+# Clear up space
+RUN rm /tmp/jdk8.tar.gz /tmp/ant.zip /tmp/ant-contrib.tgz
+# Set up jenkins user
+RUN useradd -m -d /home/jenkins jenkins
+RUN mkdir /home/jenkins/.ssh
+RUN echo "Jenkins_User_SSHKey" > /home/jenkins/.ssh/authorized_keys
+RUN chown -R jenkins /home/jenkins/.ssh
+RUN chmod -R og-rwx /home/jenkins/.ssh
+# RUN service ssh start
+CMD ["/usr/sbin/sshd","-D"]
+RUN yum install -y git curl make gcc xorg-x11-server-Xvfb libXrender libXi libXtst procps glibc-langpack-en fontconfig which hostname fakeroot
+# ENTRYPOINT /usr/lib/jvm/jdk8/bin/java
+EXPOSE 22
+# Start with docker run -p 2222:22 UUID

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/README.md
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/README.md
@@ -11,6 +11,7 @@ The DockerStatic ansible role provides allows us to automate the setup of our do
 * [docker-packet-ubuntu2004-armv8-1](https://ci.adoptopenjdk.net/computer/docker-packet-ubuntu2004-armv8-1/)
 * [dockerhost-equinix-ubuntu2004-armv8-1](https://ci.adoptopenjdk.net/computer/dockerhost-equinix-ubuntu2004-armv8-1/)
 
+
 ## Setting up a new DockerStatic container
 
 If you would like to setup an individual container on one of these machines, follow these instructions:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/tasks/main.yml
@@ -33,6 +33,8 @@
     - u2004
     - u2104
     - f33
+    - f34
+    - f35
     - alp311
     - alp312
     - alp313
@@ -73,13 +75,23 @@
   tags: startcontainers
   ignore_errors: yes
 
+- name: Start fedora 34 container if not already started
+  command: docker run --restart unless-stopped -p 2232:22 --cpus=2.0 --memory=6G --detach --name   f34.2232 aqa_f34
+  tags: startcontainers
+  ignore_errors: yes
+
+- name: Start fedora 35 container if not already started
+  command: docker run --restart unless-stopped -p 2233:22 --cpus=2.0 --memory=6G --detach --name   f34.2233 aqa_f35
+  tags: startcontainers
+  ignore_errors: yes
+
 - name: Start Alpine 3.11 container if not already started
   command: docker run --restart unless-stopped -p 2228:22 --cpus=2.0 --memory=6G --detach --name alp311.2228 aqa_alp311
   tags: startcontainers, startallcontainers
   ignore_errors: yes
 
 - name: Start Alpine 3.12 container if not already started
-  command: docker run --restart unless-stopped -p 2229:22 --cpus=2.0 --memory=6G --detach --name alp312.2228 aqa_alp312
+  command: docker run --restart unless-stopped -p 2229:22 --cpus=2.0 --memory=6G --detach --name alp312.2229 aqa_alp312
   tags: startcontainers
   ignore_errors: yes
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode/tasks/main.yml
@@ -14,7 +14,8 @@
     - Apple_ID_Password is defined
     - FASTLANE_SESSION is defined
 
-- debug:
+- name: Display Information when apple_variables is not defined
+  debug:
     msg: "Apple ID variables are not defined. Xcode will need to be installed manually.
           Ensure that Apple_ID_User, Apple_ID_Password and FASTLANE_SESSION are defined. Skipping Xcode installation"
   when: apple_variables is not defined


### PR DESCRIPTION
	- use port 2232 and 2233 on host
	- use ant 1.10.12
	- fix ansible-lint error  [unnamed-task: All tasks should be named] (https://github.com/adoptium/infrastructure/runs/5884567208?check_suite_focus=true#step:5:133)

Ref: https://github.com/adoptium/infrastructure/issues/2183

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [x] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
