### PR TITLE
fix: disable new fqcn ansible-lint rule

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -13,6 +13,7 @@ skip_list:
   - '601'  # Don't compare to literal True/False
   - '602'  # Don't compare to empty string
   - 'var-naming' # var-naming File defines variable that violates variable naming standards
+  - 'fqcn-builtins' # Disable error introduced in ansible-lint 6.X (https://github.com/ansible/ansible-lint/pull/1908)
 
 exclude_paths:
   - ./ansible/playbooks/adoptopenjdk_variables.yml # See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1926

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,12 +1,13 @@
+---
 skip_list:
   - '106'  # Role name {} does not match ``^[a-z][a-z0-9_]+$`` pattern
   - '204'  # Lines should be no longer than 160 chars
   - '207'  # Nested jinja pattern
   - '208'  # File permissions unset or incorrect
   - '301'  # Commands should not change things if nothing needs doing
-  - '303'  # Using command rather than module 
+  - '303'  # Using command rather than module
   - '305'  # Use shell only when shell functionality is required
-  - '306'  # Shells that use pipes should set the pipefail option  
+  - '306'  # Shells that use pipes should set the pipefail option
   - '401'  # Git checkouts must contain explicit version
   - '403'  # Package installs should not use latest
   - '501'  # Become_user requires become to work as expected

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/handlers/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart docker service
+  service:
+    name: docker
+    state: restarted
+  when: restart_docker.changed is true

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/tasks/main.yml
@@ -10,12 +10,8 @@
     insertafter: EOF
     create: yes
   register: restart_docker
-
-- name: Restart docker
-  service:
-    name: docker
-    state: restarted
-  when: restart_docker.changed is true
+  notify:
+    - Restart docker service
 
 - name: Send Dockerfiles to remote machine
   copy:


### PR DESCRIPTION
  -  https://github.com/ansible/ansible-lint/pull/1908 add to v6.0.0
  - GH action installing 6.0.2 ansible-lint since mid March which broke lint step
  - yamllint for .ansible-lint file
  - no-handler lint error

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [x] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
