### PR TITLE
UnixPB: fix dockerstatic build on centos8

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.cent8
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.cent8
@@ -1,5 +1,9 @@
 FROM centos:8
 
+# Update mirror to vault.centos.org after EOL 2021-12-31
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 RUN dnf -y update && dnf install -y perl openssh-server unzip wget epel-release
 RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -P ""
 # Get java8


### PR DESCRIPTION
	- when enabled check on dockerstatic dockerfile found issue: 
	https://github.com/adoptium/infrastructure/runs/5970485601?check_suite_focus=true
	
`Step 2/23 : RUN dnf -y update && dnf install -y perl openssh-server unzip wget epel-release
 ---> Running in 4732eaff2945
CentOS Linux 8 - AppStream                      108  B/s |  38  B     00:00    
Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
The command '/bin/sh -c dnf -y update && dnf install -y perl openssh-server unzip wget epel-release' returned a non-zero code: 1` 


         - fixed with https://github.com/adoptium/infrastructure/runs/5970875795?check_suite_focus=true
         - mirror update for centos8


Ref: https://github.com/adoptium/infrastructure/issues/2183
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [x ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
