### PR TITLE
Fixes #2507 - UnixPB : Fedora Compatible Playbooks

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Fedora.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Fedora.yml
@@ -1,0 +1,236 @@
+---
+##########
+# Fedora #
+##########
+
+#########################################
+# Configure Repos and Update the system #
+#########################################
+# No Additional Repos Required on typical base Fedora 35 Install
+
+
+- name: YUM upgrade all packages
+  yum:
+    name: '*'
+    state: latest
+  tags: patch_update
+
+# TODO: We should find a better way of doing this in the future, for some reason these deps aren't in the aarch64 rhel 7 repos.
+- name: Install missing Rhel7 aarch64 deps from Centos Mirror
+  yum: "name={{ packages }} state=present"
+  vars:
+    packages:
+      - http://mirror.centos.org/altarch/7/os/aarch64/Packages/libdwarf-devel-20130207-4.el7.aarch64.rpm
+      - http://mirror.centos.org/altarch/7/os/aarch64/Packages/libmpc-devel-1.0.1-3.el7.aarch64.rpm
+      - http://mirror.centos.org/altarch/7/os/aarch64/Packages/xorg-x11-server-common-1.20.4-10.el7.aarch64.rpm
+      - http://mirror.centos.org/altarch/7/os/aarch64/Packages/xorg-x11-server-Xvfb-1.20.4-10.el7.aarch64.rpm
+  when:
+    - (ansible_distribution_major_version == "7" and ansible_architecture == "aarch64")
+  tags: build_tools, test_tools
+
+############################
+# Build Packages and tools #
+############################
+- name: Call Build Packages and Tools Task
+  include_tasks: build_packages_and_tools.yml
+
+##########################
+# Additional build tools #
+##########################
+- name: Install additional build tools if NOT RHEL 8
+  package: "name={{ item }} state=latest"
+  with_items: "{{ Additional_Build_Tools_NOT_RHEL8 }}"
+  when:
+    - (ansible_distribution_major_version != "8" and ansible_distribution != "Fedora")
+  tags: build_tools
+
+- name: Install additional build tools for RHEL 7
+  package: "name={{ item }} state=latest"
+  with_items: "{{ Additional_Build_Tools_RHEL7 }}"
+  when:
+    - (ansible_distribution_major_version == "7" and ansible_architecture != "aarch64")
+  tags: build_tools
+
+- name: Install additional build tools for RHEL 7 on ppc64le
+  package: "name={{ item }} state=latest"
+  with_items: "{{ Additional_Build_Tools_RHEL7_PPC64LE }}"
+  when:
+    - ansible_distribution_major_version == "7"
+    - ansible_architecture == "ppc64le"
+  tags: build_tools
+
+- name: Install numactl-devel excluding RHEL 7 on s390x
+  package: "name=numactl-devel state=latest"
+  when:
+    - not (ansible_distribution_major_version == "7" and ansible_architecture == "s390x")
+  tags: build_tools
+
+- name: Install additional build tools for RHEL on x86
+  package: "name={{ item }} state=latest"
+  with_items: "{{ Additional_Build_Tools_RHEL_x86 }}"
+  when:
+    - ansible_architecture == "x86_64"
+    - not (ansible_distribution_major_version == "35" and ansible_distribution == "Fedora" )
+  tags: build_tools
+
+- name: Install additional build tools for RHEL on ppc64
+  package: "name={{ item }} state=latest"
+  with_items: "{{ Additional_Build_Tools_RHEL_ppc64 }}"
+  when:
+    - ansible_architecture == "ppc64"
+  tags: build_tools
+
+- name: Install additional build tools for RHEL on s390x
+  package: "name={{ item }} state=latest"
+  with_items: "{{ Additional_Build_Tools_RHEL_s390x }}"
+  when:
+    - ansible_architecture == "s390x"
+  tags: build_tools
+
+- name: Install additional build tools for RHEL 8
+  package: "name={{ item }} state=latest"
+  with_items: "{{ Additional_Build_Tools_RHEL8 }}"
+  when:
+    - (ansible_distribution_major_version == "8")
+  tags: build_tools
+
+- name: Install additional build tools for FEDORA 35
+  package: "name={{ item }} state=latest"
+  with_items: "{{ Additional_Build_Tools_FEDORA35 }}"
+  when:
+    - (ansible_distribution_major_version == "35" and ansible_distribution == "Fedora")
+  tags: build_tools
+
+#################
+# xorg Packages #
+#################
+- name: Install xorg-x11-server-Xorg if host is x86_64
+  yum: name=xorg-x11-server-Xorg state=installed
+  when: (ansible_architecture == "x86_64")
+  tags: test_tools
+
+- name: Install xorg-x11-server-common if host is s390x
+  yum: name=xorg-x11-server-common state=installed
+  when: (ansible_architecture == "s390x")
+  tags: test_tools
+
+################
+# Install Java #
+################
+- name: Install Java (Not RedHat 6 on ppc64)
+  package: "name={{ item }} state=latest"
+  with_items: "{{ Java_NOT_RHEL6_PPC64 }}"
+  when:
+    - not (ansible_distribution_major_version == "6" and ansible_architecture == "ppc64")
+    - not (ansible_distribution_major_version == "8")
+    - not (ansible_distribution_major_version == "35" and ansible_distribution == "Fedora")
+
+- name: Install Java when RedHat 6 on ppc64
+  package: "name={{ item }} state=latest"
+  with_items: "{{ Java_RHEL6_PPC64 }}"
+  when: (ansible_distribution_major_version == "6" and ansible_architecture == "ppc64")
+
+- name: Install Java when RedHat 8
+  package: "name={{ item }} state=latest"
+  with_items: "{{ Java_RHEL8 }}"
+  when: (ansible_distribution_major_version == "8")
+
+- name: Install Java when Fedora 35
+  package: "name={{ item }} state=latest"
+  with_items: "{{ Java_FED35 }}"
+  when: (ansible_distribution_major_version == "35" and ansible_distribution != "Fedora")
+
+####################
+# Set default Java #
+####################
+
+- name: Find Default JRE
+  stat:
+    path: /usr/lib/jvm/jre-1.8.0
+  register: jre_path
+  tags: default_java
+
+- name: Find Default JDK
+  stat:
+    path: /usr/lib/jvm/java-1.8.0
+  register: jdk_path
+  tags: default_java
+
+- name: Set Default JRE (RHEL 6)
+  alternatives:
+    name: java
+    path: "/usr/lib/jvm/jre-1.8.0-openjdk.{{ ansible_architecture }}/bin/java"
+  when:
+    - ansible_distribution_major_version == "6"
+  tags: default_java
+
+- name: Set Default JRE (RHEL 7 and later)
+  alternatives:
+    name: java
+    path: "{{ jre_path.stat.lnk_source }}/bin/java"
+  when:
+    - ansible_distribution_major_version > "6"
+  tags: default_java
+
+- name: Set Default JDK (RHEL 6)
+  alternatives:
+    name: javac
+    path: "/usr/lib/jvm/java-1.8.0-openjdk.{{ ansible_architecture }}/bin/javac"
+  when:
+    - ansible_distribution_major_version == "6"
+  tags: default_java
+
+- name: Set Default JDK (RHEL 7 and later)
+  alternatives:
+    name: javac
+    path: "{{ jdk_path.stat.lnk_source }}/bin/javac"
+  when:
+    - ansible_distribution_major_version > "6"
+  tags: default_java
+
+###########
+# Locales #
+###########
+
+- name: Install 'glibc-common' package
+  package:
+    name: glibc-common
+    state: present
+  tags: locales
+
+# Skipping linting as no alternative to shell can be used (lint error 305)
+- name: Get locale list
+  shell: locale -a
+  register: localeList
+  changed_when: False
+  tags:
+    - locales
+    - skip_ansible_lint
+
+- name: Create Japanese locale
+  locale_gen:
+    name: ja_JP.UTF-8
+    state: present
+  when: localeList.stdout|lower is not search("ja_jp\.utf8")
+  tags: locales
+
+- name: Create Korean locale
+  locale_gen:
+    name: ko_KR.UTF-8
+    state: present
+  when: localeList.stdout|lower is not search("ko_kr\.utf8")
+  tags: locales
+
+- name: Create Chinese locale
+  locale_gen:
+    name: zh_CN.UTF-8
+    state: present
+  when: localeList.stdout|lower is not search("zh_cn\.utf8")
+  tags: locales
+
+- name: Create Taiwanese locale
+  locale_gen:
+    name: zh_TW.UTF-8
+    state: present
+  when: localeList.stdout|lower is not search("zh_tw\.utf8")
+  tags: locales

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/build_packages_and_tools.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/build_packages_and_tools.yml
@@ -28,6 +28,7 @@
     - ansible_distribution != "FreeBSD"
     - ansible_distribution != "RedHat"
     - ansible_distribution != "CentOS"
+    - ansible_distribution != "Fedora"
   tags: build_tools
 
 - name: Install Test Tool Packages

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Fedora.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Fedora.yml
@@ -1,0 +1,127 @@
+---
+##########
+# RedHat #
+##########
+
+# Command Build Tool Packages
+Build_Tool_Packages:
+  - alsa-lib-devel
+  - autoconf
+  - bind-utils
+  - bison                         # OpenJ9
+  - bzip2
+  - ca-certificates
+  - cpio
+  - curl
+  - cups-devel
+  - elfutils-libelf-devel
+  - flex                          # OpenJ9
+  - fontconfig-devel
+  - freetype-devel
+  - gcc
+  - gcc-c++
+  - gettext
+  - glibc
+  - glibc-common
+  - glibc-devel
+  - gmp-devel
+  - libcurl-devel
+  - libffi-devel
+  - libpng-devel
+  - libXext-devel
+  - libXi-devel                   # JDK12+ compilation
+  - libXrandr-devel               # JDK12+ compilation
+  - libXrender-devel
+  - libXt-devel
+  - libXtst-devel
+  - make
+  - mesa-libGL-devel
+  - mpfr-devel
+  - openssl-devel
+  - perl-devel
+  - pkgconfig
+  - systemtap-sdt-devel
+  - unzip
+  - wget
+  - xz
+  - zip
+
+Additional_Build_Tools_NOT_RHEL8:
+  - libdwarf-devel                # now in CodeReady Linux Builder (CRB) repo
+  - libmpc-devel                  # now in CodeReady Linux Builder (CRB) repo
+  - ntp
+
+Additional_Build_Tools_FEDORA35:
+  - glibc.i686                    # a dependency required for executing a 32-bit C binary
+  - glibc-devel.i686              # a dependency required for executing a 32-bit C binary
+  - libstdc++.i686                # a dependency required for executing a 32-bit C binary
+  - libdwarf-devel                # now in CodeReady Linux Builder (CRB) repo
+  - libmpc-devel                  # now in CodeReady Linux Builder (CRB) repo
+  - glibc-locale-source
+  - glibc-langpack-ja             # required for creating Japanese locales
+  - glibc-langpack-ko             # required for creating Korean locales
+  - glibc-langpack-zh             # required for creating Chinese locales
+  - git
+  - cmake
+  - ccache
+  - chrony
+  - openssl
+
+Additional_Build_Tools_RHEL8:
+  - glibc-locale-source
+  - glibc-langpack-ja             # required for creating Japanese locales
+  - glibc-langpack-ko             # required for creating Korean locales
+  - glibc-langpack-zh             # required for creating Chinese locales
+  - git
+  - cmake
+  - ccache
+
+Additional_Build_Tools_RHEL7:
+  - libstdc++-static
+  - ccache
+
+Additional_Build_Tools_RHEL7_PPC64LE:
+  - libstdc++
+
+Additional_Build_Tools_RHEL_x86:
+  - glibc.i686                    # a dependency required for executing a 32-bit C binary
+  - glibc-devel.i686              # a dependency required for executing a 32-bit C binary
+  - libstdc++.i686                # a dependency required for executing a 32-bit C binary
+
+Additional_Build_Tools_RHEL_ppc64:
+  - glibc.ppc                     # a dependency required for executing a 32-bit C binary
+  - glibc-devel.ppc               # a dependency required for executing a 32-bit C binary
+  - libstdc++.ppc                 # a dependency required for executing a 32-bit C binary
+
+Additional_Build_Tools_RHEL_s390x:
+  - glibc.s390                    # a dependency required for executing a 32-bit C binary
+  - glibc-devel.s390              # a dependency required for executing a 32-bit C binary
+  - libstdc++.s390                # a dependency required for executing a 32-bit C binary
+
+Java_RHEL8:
+  - java-1.8.0-openjdk-devel
+
+Java_FED35:
+  - java-1.8.0-openjdk-devel
+
+Java_NOT_RHEL6_PPC64:             # Not RHEL8 either
+  - java-1.7.0-openjdk-devel
+  - java-1.8.0-openjdk-devel
+
+Java_RHEL6_PPC64:
+  - java-1.7.0-ibm-devel
+  - java-1.8.0-ibm-devel
+
+Test_Tool_Packages:
+  - acl
+  - perl
+  - perl-Digest-SHA
+  - perl-Time-HiRes
+  - perl-Test-Simple
+  - xorg-x11-xauth
+  - xorg-x11-server-Xvfb
+  - zlib-devel
+  - perl-devel
+  - expat-devel
+  - libcurl-devel
+  - mercurial

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Fedora.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Fedora.yml
@@ -55,6 +55,7 @@ Additional_Build_Tools_FEDORA35:
   - glibc.i686                    # a dependency required for executing a 32-bit C binary
   - glibc-devel.i686              # a dependency required for executing a 32-bit C binary
   - libstdc++.i686                # a dependency required for executing a 32-bit C binary
+  - libstdc++-static              # a dependency required for executing a 32-bit C binary
   - libdwarf-devel                # now in CodeReady Linux Builder (CRB) repo
   - libmpc-devel                  # now in CodeReady Linux Builder (CRB) repo
   - glibc-locale-source

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_10/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_10/tasks/main.yml
@@ -7,7 +7,7 @@
   shell: /usr/local/gcc10/bin/gcc-10.3 --version 2>&1 > /dev/null
   ignore_errors: yes
   register: gcc10_installed
-  when: ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
+  when: ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
   changed_when: False
   tags: gcc_10
 
@@ -19,7 +19,7 @@
     force: no
     mode: 0644
   when:
-    - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
+    - ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
     - gcc10_installed.rc != 0
   tags: gcc_10
 
@@ -29,7 +29,7 @@
     dest: /usr/local/
     copy: False
   when:
-    - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
+    - ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
     - gcc10_installed.rc != 0
   tags: gcc_10
 
@@ -38,6 +38,6 @@
     path: '/tmp/ansible-adoptopenjdk-gcc-10.tar.xz'
     state: absent
   when:
-    - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
+    - ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
     - gcc10_installed.rc != 0
   tags: gcc_10

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_7/tasks/main.yml
@@ -7,7 +7,7 @@
   shell: /usr/local/gcc/bin/gcc-7.5 --version 2>&1 > /dev/null
   ignore_errors: yes
   register: gcc7_installed
-  when: ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
+  when: ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
   changed_when: false
   tags: gcc_7
 
@@ -29,7 +29,7 @@
     force: no
     mode: 0644
   when:
-    - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
+    - ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
     - gcc7_installed.rc != 0
   tags: gcc_7
 
@@ -39,7 +39,7 @@
     dest: /usr/local/
     copy: False
   when:
-    - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
+    - ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
     - gcc7_installed.rc != 0
   tags: gcc_7
 
@@ -48,7 +48,7 @@
     path: '/tmp/ansible-adoptopenjdk-gcc-7.tar{{ gccsuffix }}'
     state: absent
   when:
-    - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
+    - ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
     - gcc7_installed.rc != 0
   tags: gcc_7
 
@@ -59,7 +59,7 @@
     path: /usr/local/bin/ccache
   register: ccache_symlink
   when:
-    - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
+    - ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
   tags: gcc_7
 
 - name: Create symlink for ccache
@@ -68,6 +68,6 @@
     dest: /usr/local/bin/ccache
     state: link
   when:
-    - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
+    - ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
     - not ccache_symlink.stat.exists
   tags: gcc_7

--- a/ansible/vagrant/Vagrantfile.Fedora35
+++ b/ansible/vagrant/Vagrantfile.Fedora35
@@ -1,0 +1,26 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+$script = <<SCRIPT
+# Put the host machine's IP into the authorised_keys file on the VM
+if [ -r /vagrant/id_rsa.pub ]; then
+        mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys
+fi
+SCRIPT
+
+# 2 = version of configuration file for Vagrant 1.1+ leading up to 2.0.x
+Vagrant.configure("2") do |config|
+
+  config.vm.define :adoptopenjdkF35 do |adoptopenjdkF35|
+    adoptopenjdkF35.vm.box = "generic/fedora35"
+    adoptopenjdkF35.vm.synced_folder ".", "/vagrant"
+    adoptopenjdkF35.vm.hostname = "adoptopenjdkF35"
+    adoptopenjdkF35.vm.network :private_network, type: "dhcp"
+    adoptopenjdkF35.vm.provision "shell", inline: $script, privileged: false
+  end
+  config.vm.provider "virtualbox" do |v|
+    v.gui = false
+    v.memory = 2560
+    v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
+  end
+end


### PR DESCRIPTION
<!--
Fixes #2507 - Makes the UnixPB, compatible with Fedora 35.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
