### PR TITLE
docker: add support for Alpine aarch64 image #2497

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -72,7 +72,8 @@ have at the moment:
 |---|---|---|---|---|
 | [Centos7](./ansible/docker/Dockerfile.CentOS7) | [`adoptopenjdk/centos7_build_image`](https://hub.docker.com/r/adoptopenjdk/centos7_build_image) | linux on x64, arm64, ppc64le, armv7l | [Jenkins](https://ci.adoptopenjdk.net/job/centos7_docker_image_updater/) | Yes
 | [Centos6](./ansible/docker/Dockerfile.CentOS6) | [`adoptopenjdk/centos6_build_image`](https://hub.docker.com/r/adoptopenjdk/centos6_build_image)| linux/amd64 | [GH Actions](.github/workflows/build.yml) | Yes
-| [Alpine3](./ansible/docker/Dockerfile.Alpine3) | [`adoptopenjdk/alpine3_build_image`](https://hub.docker.com/r/adoptopenjdk/alpine3_build_image) | linux/amd64 | [GH Actions](.github/workflows/build.yml) | Yes
+| [Alpine3](./ansible/docker/Dockerfile.Alpine3) | [`adoptopenjdk/alpine3_build_image`](https://hub.docker.com/r/adoptopenjdk/alpine3_build_image) | linux/x64 | [GH Actions](.github/workflows/build.yml) | Yes
+| [Alpine3](./ansible/docker/Dockerfile.Alpine3) | [`adoptopenjdk/alpine3_build_image`](https://hub.docker.com/r/adoptopenjdk/alpine3_build_image) | linux/arm64 | [Jenkins](https://ci.adoptopenjdk.net/job/centos7_docker_image_updater/) | Yes
 | [Windows2016_Base](./ansible/docker/Dockerfile.Windows2016_Base) | [`adoptopenjdk/windows2016_build_image:base`](https://hub.docker.com/r/adoptopenjdk/windows2016_build_image)| windows/amd64 | [GH Actions](.github/workflows/build_windows.yml) | No
 | [Windows2016_VS2017](./ansible/docker/Dockerfile.Windows2016_VS2017) | [`adoptopenjdk/windows2016_build_image:vs2017`](https://hub.docker.com/r/adoptopenjdk/windows2016_build_image)| windows/amd64 | [GH Actions](.github/workflows/build_windows.yml) | No
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,6 +35,14 @@ pipeline {
                         dockerBuild('armv7l', 'ubuntu1604', 'Dockerfile.Ubuntu1604')
                     }
                 }
+                stage('Alpine3 aarch64') {
+                    agent {
+                        label "dockerBuild&&linux&&aarch64"
+                    }
+                    steps {
+                        dockerBuild('aarch64', 'alpine3', 'Dockerfile.Alpine3')
+                    }
+                }
             }
         }
         stage('Docker Manifest') {
@@ -81,6 +89,12 @@ def dockerManifest() {
             ARMV7L=$TARGET:linux-armv7l
             docker manifest create $TARGET $ARMV7L
             docker manifest annotate $TARGET $ARMV7L --arch arm --os linux
+            docker manifest push $TARGET
+            # Alpine3
+            export TARGET="adoptopenjdk/alpine3_build_image"
+            ARM64=$TARGET:linux-arm64
+            docker manifest create $TARGET $ARM64
+            docker manifest annotate $TARGET $ARM64 --arch arm64 --os linux
             docker manifest push $TARGET
         '''
     }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _infrastructure as code_.
 
 The end result should be **immutable** hosts, which can be destroyed and reproduced from Ansible playbooks. See
 our [Contribution
-Guidelines](https://www.github.com/adoptopenjdk/openjdk-infrastructure/CONTRIBUTING.md)
+Guidelines](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md)
 on how we implement these goals.
 
 ## Can we Chaos Monkey it

--- a/ansible/docker/Dockerfile.Alpine3
+++ b/ansible/docker/Dockerfile.Alpine3
@@ -12,8 +12,9 @@ RUN set -eux; \
  rm -rf /ansible; apk del ansible
 
 ENV \
+    JDK7_BOOT_DIR="/usr/lib/jvm/zulu8" \ 
     JDK8_BOOT_DIR="/usr/lib/jvm/zulu8" \
-    JDK11_BOOT_DIR="/usr/lib/jvm/zulu11" \
+    JDK10_BOOT_DIR="/usr/lib/jvm/zulu11" \
     JDK14_BOOT_DIR="/usr/lib/jvm/zulu14" \
     JDK15_BOOT_DIR="/usr/lib/jvm/zulu15" \
     JDKLATEST_BOOT_DIR="/usr/lib/jvm/zulu15" \

--- a/ansible/docker/Dockerfile.Alpine3
+++ b/ansible/docker/Dockerfile.Alpine3
@@ -1,6 +1,10 @@
 FROM alpine:3
 
-RUN apk update; apk add ansible
+RUN apk update \
+    && apk upgrade \
+    && apk add ansible
+
+USER jenkins
 
 COPY . /ansible
 
@@ -8,8 +12,11 @@ RUN echo "localhost ansible_connection=local" > /ansible/hosts
 
 RUN set -eux; \
  cd /ansible; \
- ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit"; \
+ ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit, test_tools"; \
  rm -rf /ansible; apk del ansible
+
+RUN addgroup -g 1000 ${user}
+RUN adduser -h /home/${user} -S ${user} -G ${user}
 
 ENV \
     JDK7_BOOT_DIR="/usr/lib/jvm/zulu8" \ 

--- a/ansible/docker/Dockerfile.Alpine3
+++ b/ansible/docker/Dockerfile.Alpine3
@@ -29,4 +29,4 @@ ENV \
     JDK17_BOOT_DIR="/usr/lib/jvm/zulu17" \
     JDK18_BOOT_DIR="/usr/lib/jvm/zulu18" \
     JDKLATEST_BOOT_DIR="/usr/lib/jvm/zulu18" \
-    JAVA_HOME="/usr/lib/jvm/zulu18"
+    JAVA_HOME="/usr/lib/jvm/zulu8"

--- a/ansible/docker/Dockerfile.Alpine3
+++ b/ansible/docker/Dockerfile.Alpine3
@@ -10,7 +10,7 @@ RUN echo "localhost ansible_connection=local" > /ansible/hosts
 
 RUN set -eux; \
  cd /ansible; \
- ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit, test_tools"; \
+ ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit"; \
  rm -rf /ansible; apk del ansible
 
 ENV \

--- a/ansible/docker/Dockerfile.Alpine3
+++ b/ansible/docker/Dockerfile.Alpine3
@@ -4,8 +4,6 @@ RUN apk update \
     && apk upgrade \
     && apk add ansible
 
-ARG user=jenkins
-
 COPY . /ansible
 
 RUN echo "localhost ansible_connection=local" > /ansible/hosts
@@ -14,9 +12,6 @@ RUN set -eux; \
  cd /ansible; \
  ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit, test_tools"; \
  rm -rf /ansible; apk del ansible
-
-RUN addgroup -g 1000 ${user}
-RUN adduser -h /home/${user} -S ${user} -G ${user}
 
 ENV \
     JDK7_BOOT_DIR="/usr/lib/jvm/zulu8" \ 

--- a/ansible/docker/Dockerfile.Alpine3
+++ b/ansible/docker/Dockerfile.Alpine3
@@ -12,9 +12,8 @@ RUN set -eux; \
  rm -rf /ansible; apk del ansible
 
 ENV \
-    JDK7_BOOT_DIR="/usr/lib/jvm/zulu8" \ 
     JDK8_BOOT_DIR="/usr/lib/jvm/zulu8" \
-    JDK10_BOOT_DIR="/usr/lib/jvm/zulu11" \
+    JDK11_BOOT_DIR="/usr/lib/jvm/zulu11" \
     JDK14_BOOT_DIR="/usr/lib/jvm/zulu14" \
     JDK15_BOOT_DIR="/usr/lib/jvm/zulu15" \
     JDKLATEST_BOOT_DIR="/usr/lib/jvm/zulu15" \

--- a/ansible/docker/Dockerfile.Alpine3
+++ b/ansible/docker/Dockerfile.Alpine3
@@ -15,6 +15,7 @@ ENV \
     JDK7_BOOT_DIR="/usr/lib/jvm/zulu8" \ 
     JDK8_BOOT_DIR="/usr/lib/jvm/zulu8" \
     JDK10_BOOT_DIR="/usr/lib/jvm/zulu11" \
+    JDK11_BOOT_DIR="/usr/lib/jvm/zulu11" \
     JDK14_BOOT_DIR="/usr/lib/jvm/zulu14" \
     JDK15_BOOT_DIR="/usr/lib/jvm/zulu15" \
     JDKLATEST_BOOT_DIR="/usr/lib/jvm/zulu15" \

--- a/ansible/docker/Dockerfile.Alpine3
+++ b/ansible/docker/Dockerfile.Alpine3
@@ -25,5 +25,8 @@ ENV \
     JDK11_BOOT_DIR="/usr/lib/jvm/zulu11" \
     JDK14_BOOT_DIR="/usr/lib/jvm/zulu14" \
     JDK15_BOOT_DIR="/usr/lib/jvm/zulu15" \
-    JDKLATEST_BOOT_DIR="/usr/lib/jvm/zulu15" \
-    JAVA_HOME="/usr/lib/jvm/zulu8"
+    JDK16_BOOT_DIR="/usr/lib/jvm/zulu16" \
+    JDK17_BOOT_DIR="/usr/lib/jvm/zulu17" \
+    JDK18_BOOT_DIR="/usr/lib/jvm/zulu18" \
+    JDKLATEST_BOOT_DIR="/usr/lib/jvm/zulu18" \
+    JAVA_HOME="/usr/lib/jvm/zulu18"

--- a/ansible/docker/Dockerfile.Alpine3
+++ b/ansible/docker/Dockerfile.Alpine3
@@ -4,7 +4,7 @@ RUN apk update \
     && apk upgrade \
     && apk add ansible
 
-USER jenkins
+ARG user=jenkins
 
 COPY . /ansible
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Alpine.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Alpine.yml
@@ -137,3 +137,73 @@
   when:
     - not zulu15_installed.stat.exists
   tags: build_tools
+
+
+- name: Check if zulu-16 is already installed in the target location
+  stat: path=/usr/lib/jvm/zulu16
+  register: zulu16_installed
+  tags: build_tools
+
+- name: Install latest zulu-16 release if not already installed
+  unarchive:
+    src: https://cdn.azul.com/zulu/bin/zulu16.32.15-ca-jdk16.0.2-linux_musl_aarch64.tar.gz
+    dest: /usr/lib/jvm/
+    remote_src: yes
+  when:
+    - not zulu16_installed.stat.exists
+  tags: build_tools
+
+- name: Create symlink to point at zulu-16
+  file:
+    src: /usr/lib/jvm/zulu16.32.15-ca-jdk16.0.2-linux_musl_aarch64
+    dest: /usr/lib/jvm/zulu16
+    state: link
+  when:
+    - not zulu16_installed.stat.exists
+  tags: build_tools
+
+- name: Check if zulu-17 is already installed in the target location
+  stat: path=/usr/lib/jvm/zulu17
+  register: zulu17_installed
+  tags: build_tools
+
+- name: Install latest zulu-17 release if not already installed
+  unarchive:
+    src: https://cdn.azul.com/zulu/bin/zulu17.32.13-ca-jdk17.0.2-linux_musl_aarch64.tar.gz
+    dest: /usr/lib/jvm/
+    remote_src: yes
+  when:
+    - not zulu17_installed.stat.exists
+  tags: build_tools
+
+- name: Create symlink to point at zulu-17
+  file:
+    src: /usr/lib/jvm/zulu17.32.13-ca-jdk17.0.2-linux_musl_aarch64
+    dest: /usr/lib/jvm/zulu17
+    state: link
+  when:
+    - not zulu17_installed.stat.exists
+  tags: build_tools
+
+- name: Check if zulu-18 is already installed in the target location
+  stat: path=/usr/lib/jvm/zulu18
+  register: zulu18_installed
+  tags: build_tools
+
+- name: Install latest zulu-18 release if not already installed
+  unarchive:
+    src: https://cdn.azul.com/zulu/bin/zulu18.28.13-ca-jdk18.0.0-linux_musl_aarch64.tar.gz
+    dest: /usr/lib/jvm/
+    remote_src: yes
+  when:
+    - not zulu18_installed.stat.exists
+  tags: build_tools
+
+- name: Create symlink to point at zulu-18
+  file:
+    src: /usr/lib/jvm/zulu18.28.13-ca-jdk18.0.0-linux_musl_aarch64
+    dest: /usr/lib/jvm/zulu18
+    state: link
+  when:
+    - not zulu18_installed.stat.exists
+  tags: build_tools

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Alpine.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Alpine.yml
@@ -27,188 +27,188 @@
 - name: Install JDK for aarch64
   when: ansible_architecture == "x86_64"
   block:
-  - name: Check if zulu-7 is already installed in the target location
-    stat: path=/usr/lib/jvm/zulu7
-    register: zulu7_installed
-    tags: build_tools
+    - name: Check if zulu-7 is already installed in the target location
+      stat: path=/usr/lib/jvm/zulu7
+      register: zulu7_installed
+      tags: build_tools
 
-  - name: Install latest zulu-7 release if not already installed
-    unarchive:
-      src: https://cdn.azul.com/zulu/bin/zulu7.52.0.11-ca-jdk7.0.332-linux_x64.tar.gz
-      dest: /usr/lib/jvm/
-      remote_src: yes
-    when:
-      - not zulu7_installed.stat.exists
-    tags: build_tools
+    - name: Install latest zulu-7 release if not already installed
+      unarchive:
+        src: https://cdn.azul.com/zulu/bin/zulu7.52.0.11-ca-jdk7.0.332-linux_x64.tar.gz
+        dest: /usr/lib/jvm/
+        remote_src: yes
+      when:
+        - not zulu7_installed.stat.exists
+      tags: build_tools
 
-  - name: Create symlink to point at zulu-7
-    file:
-      src: /usr/lib/jvm/zulu7.52.0.11-ca-jdk7.0.332-linux_x64
-      dest: /usr/lib/jvm/zulu7
-      state: link
-    when:
-      - not zulu7_installed.stat.exists
-    tags: build_tools
+    - name: Create symlink to point at zulu-7
+      file:
+        src: /usr/lib/jvm/zulu7.52.0.11-ca-jdk7.0.332-linux_x64
+        dest: /usr/lib/jvm/zulu7
+        state: link
+      when:
+        - not zulu7_installed.stat.exists
+      tags: build_tools
 
-  - name: Check if zulu-8 is already installed in the target location
-    stat: path=/usr/lib/jvm/zulu8
-    register: zulu8_installed
-    tags: build_tools
-  - name: Install latest zulu-8 release if not already installed
-    unarchive:
-      src: https://cdn.azul.com/zulu/bin/zulu8.58.0.13-ca-jdk8.0.312-linux_musl_x64.tar.gz
-      dest: /usr/lib/jvm/
-      remote_src: yes
-    when:
-      - not zulu8_installed.stat.exists
-    tags: build_tools
+    - name: Check if zulu-8 is already installed in the target location
+      stat: path=/usr/lib/jvm/zulu8
+      register: zulu8_installed
+      tags: build_tools
+    - name: Install latest zulu-8 release if not already installed
+      unarchive:
+        src: https://cdn.azul.com/zulu/bin/zulu8.58.0.13-ca-jdk8.0.312-linux_musl_x64.tar.gz
+        dest: /usr/lib/jvm/
+        remote_src: yes
+      when:
+        - not zulu8_installed.stat.exists
+      tags: build_tools
 
-  - name: Create symlink to point at zulu-8
-    file:
-      src: /usr/lib/jvm/zulu8.58.0.13-ca-jdk8.0.312-linux_musl_x64
-      dest: /usr/lib/jvm/zulu8
-      state: link
-    when:
-      - not zulu8_installed.stat.exists
-    tags: build_tools
+    - name: Create symlink to point at zulu-8
+      file:
+        src: /usr/lib/jvm/zulu8.58.0.13-ca-jdk8.0.312-linux_musl_x64
+        dest: /usr/lib/jvm/zulu8
+        state: link
+      when:
+        - not zulu8_installed.stat.exists
+      tags: build_tools
 
-  - name: Check if zulu-11 is already installed in the target location
-    stat: path=/usr/lib/jvm/zulu11
-    register: zulu11_installed
-    tags: build_tools
+    - name: Check if zulu-11 is already installed in the target location
+      stat: path=/usr/lib/jvm/zulu11
+      register: zulu11_installed
+      tags: build_tools
 
-  - name: Install latest zulu-11 release if not already installed
-    unarchive:
-      src: https://cdn.azul.com/zulu/bin/zulu11.54.25-ca-jdk11.0.14.1-linux_musl_x64.tar.gz
-      dest: /usr/lib/jvm/
-      remote_src: yes
-    when:
-      - not zulu11_installed.stat.exists
-    tags: build_tools
+    - name: Install latest zulu-11 release if not already installed
+      unarchive:
+        src: https://cdn.azul.com/zulu/bin/zulu11.54.25-ca-jdk11.0.14.1-linux_musl_x64.tar.gz
+        dest: /usr/lib/jvm/
+        remote_src: yes
+      when:
+        - not zulu11_installed.stat.exists
+      tags: build_tools
 
-  - name: Create symlink to point at zulu-11
-    file:
-      src: /usr/lib/jvm/zulu11.54.25-ca-jdk11.0.14.1-linux_musl_x64
-      dest: /usr/lib/jvm/zulu11
-      state: link
-    when:
-      - not zulu11_installed.stat.exists
-    tags: build_tools
+    - name: Create symlink to point at zulu-11
+      file:
+        src: /usr/lib/jvm/zulu11.54.25-ca-jdk11.0.14.1-linux_musl_x64
+        dest: /usr/lib/jvm/zulu11
+        state: link
+      when:
+        - not zulu11_installed.stat.exists
+      tags: build_tools
 
-  - name: Check if zulu-14 is already installed in the target location
-    stat: path=/usr/lib/jvm/zulu14
-    register: zulu14_installed
-    tags: build_tools
+    - name: Check if zulu-14 is already installed in the target location
+      stat: path=/usr/lib/jvm/zulu14
+      register: zulu14_installed
+      tags: build_tools
 
-  - name: Install latest zulu-14 release if not already installed
-    unarchive:
-      src: https://cdn.azul.com/zulu/bin/zulu14.29.23-ca-jdk14.0.2-linux_musl_x64.tar.gz
-      dest: /usr/lib/jvm/
-      remote_src: yes
-    when:
-      - not zulu14_installed.stat.exists
-    tags: build_tools
+    - name: Install latest zulu-14 release if not already installed
+      unarchive:
+        src: https://cdn.azul.com/zulu/bin/zulu14.29.23-ca-jdk14.0.2-linux_musl_x64.tar.gz
+        dest: /usr/lib/jvm/
+        remote_src: yes
+      when:
+        - not zulu14_installed.stat.exists
+      tags: build_tools
 
-  - name: Create symlink to point at zulu-14
-    file:
-      src: /usr/lib/jvm/zulu14.29.23-ca-jdk14.0.2-linux_musl_x64
-      dest: /usr/lib/jvm/zulu14
-      state: link
-    when:
-      - not zulu14_installed.stat.exists
-    tags: build_tools
+    - name: Create symlink to point at zulu-14
+      file:
+        src: /usr/lib/jvm/zulu14.29.23-ca-jdk14.0.2-linux_musl_x64
+        dest: /usr/lib/jvm/zulu14
+        state: link
+      when:
+        - not zulu14_installed.stat.exists
+      tags: build_tools
 
-  - name: Check if zulu-15 is already installed in the target location
-    stat: path=/usr/lib/jvm/zulu15
-    register: zulu15_installed
-    tags: build_tools
+    - name: Check if zulu-15 is already installed in the target location
+      stat: path=/usr/lib/jvm/zulu15
+      register: zulu15_installed
+      tags: build_tools
 
-  - name: Install latest zulu-15 release if not already installed
-    unarchive:
-      src: https://cdn.azul.com/zulu/bin/zulu15.38.17-ca-jdk15.0.6-linux_musl_x64.tar.gz
-      dest: /usr/lib/jvm/
-      remote_src: yes
-    when:
-      - not zulu15_installed.stat.exists
-    tags: build_tools
+    - name: Install latest zulu-15 release if not already installed
+      unarchive:
+        src: https://cdn.azul.com/zulu/bin/zulu15.38.17-ca-jdk15.0.6-linux_musl_x64.tar.gz
+        dest: /usr/lib/jvm/
+        remote_src: yes
+      when:
+        - not zulu15_installed.stat.exists
+      tags: build_tools
 
-  - name: Create symlink to point at zulu-15
-    file:
-      src: /usr/lib/jvm/zulu15.38.17-ca-jdk15.0.6-linux_musl_x64
-      dest: /usr/lib/jvm/zulu15
-      state: link
-    when:
-      - not zulu15_installed.stat.exists
-    tags: build_tools
+    - name: Create symlink to point at zulu-15
+      file:
+        src: /usr/lib/jvm/zulu15.38.17-ca-jdk15.0.6-linux_musl_x64
+        dest: /usr/lib/jvm/zulu15
+        state: link
+      when:
+        - not zulu15_installed.stat.exists
+      tags: build_tools
 
 - name: Install JDK for aarch64
   when: ansible_architecture == "aarch64"
   block:
-  - name: Check if zulu-16 is already installed in the target location
-    stat: path=/usr/lib/jvm/zulu16
-    register: zulu16_installed
-    tags: build_tools
+    - name: Check if zulu-16 is already installed in the target location
+      stat: path=/usr/lib/jvm/zulu16
+      register: zulu16_installed
+      tags: build_tools
 
-  - name: Install latest zulu-16 release if not already installed
-    unarchive:
-      src: https://cdn.azul.com/zulu/bin/zulu16.32.15-ca-jdk16.0.2-linux_musl_aarch64.tar.gz
-      dest: /usr/lib/jvm/
-      remote_src: yes
-    when:
-      - not zulu16_installed.stat.exists
-    tags: build_tools
+    - name: Install latest zulu-16 release if not already installed
+      unarchive:
+        src: https://cdn.azul.com/zulu/bin/zulu16.32.15-ca-jdk16.0.2-linux_musl_aarch64.tar.gz
+        dest: /usr/lib/jvm/
+        remote_src: yes
+      when:
+        - not zulu16_installed.stat.exists
+      tags: build_tools
 
-  - name: Create symlink to point at zulu-16
-    file:
-      src: /usr/lib/jvm/zulu16.32.15-ca-jdk16.0.2-linux_musl_aarch64
-      dest: /usr/lib/jvm/zulu16
-      state: link
-    when:
-      - not zulu16_installed.stat.exists
-    tags: build_tools
+    - name: Create symlink to point at zulu-16
+      file:
+        src: /usr/lib/jvm/zulu16.32.15-ca-jdk16.0.2-linux_musl_aarch64
+        dest: /usr/lib/jvm/zulu16
+        state: link
+      when:
+        - not zulu16_installed.stat.exists
+      tags: build_tools
 
-  - name: Check if zulu-17 is already installed in the target location
-    stat: path=/usr/lib/jvm/zulu17
-    register: zulu17_installed
-    tags: build_tools
+    - name: Check if zulu-17 is already installed in the target location
+      stat: path=/usr/lib/jvm/zulu17
+      register: zulu17_installed
+      tags: build_tools
 
-  - name: Install latest zulu-17 release if not already installed
-    unarchive:
-      src: https://cdn.azul.com/zulu/bin/zulu17.32.13-ca-jdk17.0.2-linux_musl_aarch64.tar.gz
-      dest: /usr/lib/jvm/
-      remote_src: yes
-    when:
-      - not zulu17_installed.stat.exists
-    tags: build_tools
+    - name: Install latest zulu-17 release if not already installed
+      unarchive:
+        src: https://cdn.azul.com/zulu/bin/zulu17.32.13-ca-jdk17.0.2-linux_musl_aarch64.tar.gz
+        dest: /usr/lib/jvm/
+        remote_src: yes
+      when:
+        - not zulu17_installed.stat.exists
+      tags: build_tools
 
-  - name: Create symlink to point at zulu-17
-    file:
-      src: /usr/lib/jvm/zulu17.32.13-ca-jdk17.0.2-linux_musl_aarch64
-      dest: /usr/lib/jvm/zulu17
-      state: link
-    when:
-      - not zulu17_installed.stat.exists
-    tags: build_tools
-  
-  - name: Check if zulu-18 is already installed in the target location
-    stat: path=/usr/lib/jvm/zulu18
-    register: zulu18_installed
-    tags: build_tools
+    - name: Create symlink to point at zulu-17
+      file:
+        src: /usr/lib/jvm/zulu17.32.13-ca-jdk17.0.2-linux_musl_aarch64
+        dest: /usr/lib/jvm/zulu17
+        state: link
+      when:
+        - not zulu17_installed.stat.exists
+      tags: build_tools
 
-  - name: Install latest zulu-18 release if not already installed
-    unarchive:
-      src: https://cdn.azul.com/zulu/bin/zulu18.28.13-ca-jdk18.0.0-linux_musl_aarch64.tar.gz
-      dest: /usr/lib/jvm/
-      remote_src: yes
-    when:
-      - not zulu18_installed.stat.exists
-    tags: build_tools
+    - name: Check if zulu-18 is already installed in the target location
+      stat: path=/usr/lib/jvm/zulu18
+      register: zulu18_installed
+      tags: build_tools
 
-  - name: Create symlink to point at zulu-18
-    file:
-      src: /usr/lib/jvm/zulu18.28.13-ca-jdk18.0.0-linux_musl_aarch64
-      dest: /usr/lib/jvm/zulu18
-      state: link
-    when:
-      - not zulu18_installed.stat.exists
-    tags: build_tools
+    - name: Install latest zulu-18 release if not already installed
+      unarchive:
+        src: https://cdn.azul.com/zulu/bin/zulu18.28.13-ca-jdk18.0.0-linux_musl_aarch64.tar.gz
+        dest: /usr/lib/jvm/
+        remote_src: yes
+      when:
+        - not zulu18_installed.stat.exists
+      tags: build_tools
+
+    - name: Create symlink to point at zulu-18
+      file:
+        src: /usr/lib/jvm/zulu18.28.13-ca-jdk18.0.0-linux_musl_aarch64
+        dest: /usr/lib/jvm/zulu18
+        state: link
+      when:
+        - not zulu18_installed.stat.exists
+      tags: build_tools

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Alpine.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Alpine.yml
@@ -24,7 +24,7 @@
     - not usr_lib_jvm_exists.stat.exists
   tags: build_tools
 
-- name: Install JDK for aarch64
+- name: Install JDK for x64
   when: ansible_architecture == "x86_64"
   block:
     - name: Check if zulu-7 is already installed in the target location

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Alpine.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Alpine.yml
@@ -24,14 +24,36 @@
     - not usr_lib_jvm_exists.stat.exists
   tags: build_tools
 
+- name: Check if zulu-7 is already installed in the target location
+  stat: path=/usr/lib/jvm/zulu7
+  register: zulu7_installed
+  tags: build_tools
+
+- name: Install latest zulu-7 release if not already installed
+  unarchive:
+    src: https://cdn.azul.com/zulu/bin/zulu7.52.0.11-ca-jdk7.0.332-linux_x64.tar.gz
+    dest: /usr/lib/jvm/
+    remote_src: yes
+  when:
+    - not zulu7_installed.stat.exists
+  tags: build_tools
+
+- name: Create symlink to point at zulu-7
+  file:
+    src: /usr/lib/jvm/zulu7.52.0.11-ca-jdk7.0.332-linux_x64
+    dest: /usr/lib/jvm/zulu7
+    state: link
+  when:
+    - not zulu7_installed.stat.exists
+  tags: build_tools
+
 - name: Check if zulu-8 is already installed in the target location
   stat: path=/usr/lib/jvm/zulu8
   register: zulu8_installed
   tags: build_tools
-
 - name: Install latest zulu-8 release if not already installed
   unarchive:
-    src: https://cdn.azul.com/zulu/bin/zulu8.48.0.53-ca-jdk8.0.265-linux_musl_x64.tar.gz
+    src: https://cdn.azul.com/zulu/bin/zulu8.58.0.13-ca-jdk8.0.312-linux_musl_x64.tar.gz
     dest: /usr/lib/jvm/
     remote_src: yes
   when:
@@ -40,7 +62,7 @@
 
 - name: Create symlink to point at zulu-8
   file:
-    src: /usr/lib/jvm/zulu8.48.0.53-ca-jdk8.0.265-linux_musl_x64
+    src: /usr/lib/jvm/zulu8.58.0.13-ca-jdk8.0.312-linux_musl_x64
     dest: /usr/lib/jvm/zulu8
     state: link
   when:
@@ -54,7 +76,7 @@
 
 - name: Install latest zulu-11 release if not already installed
   unarchive:
-    src: https://cdn.azul.com/zulu/bin/zulu11.50.19-ca-jdk11.0.12-linux_musl_x64.tar.gz
+    src: https://cdn.azul.com/zulu/bin/zulu11.54.25-ca-jdk11.0.14.1-linux_musl_x64.tar.gz
     dest: /usr/lib/jvm/
     remote_src: yes
   when:
@@ -63,7 +85,7 @@
 
 - name: Create symlink to point at zulu-11
   file:
-    src: /usr/lib/jvm/zulu11.50.19-ca-jdk11.0.12-linux_musl_x64
+    src: /usr/lib/jvm/zulu11.54.25-ca-jdk11.0.14-linux_musl_x64
     dest: /usr/lib/jvm/zulu11
     state: link
   when:
@@ -100,7 +122,7 @@
 
 - name: Install latest zulu-15 release if not already installed
   unarchive:
-    src: https://cdn.azul.com/zulu/bin/zulu15.0.73-ea-jdk15.0.0-ea.34-linux_musl_x64.tar.gz
+    src: https://cdn.azul.com/zulu/bin/zulu15.38.17-ca-jdk15.0.6-linux_musl_x64.tar.gz
     dest: /usr/lib/jvm/
     remote_src: yes
   when:
@@ -109,7 +131,7 @@
 
 - name: Create symlink to point at zulu-15
   file:
-    src: /usr/lib/jvm/zulu15.0.73-ea-jdk15.0.0-ea.34-linux_musl_x64
+    src: /usr/lib/jvm/zulu15.38.17-ca-jdk15.0.6-linux_musl_x64
     dest: /usr/lib/jvm/zulu15
     state: link
   when:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Alpine.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Alpine.yml
@@ -85,7 +85,7 @@
 
 - name: Create symlink to point at zulu-11
   file:
-    src: /usr/lib/jvm/zulu11.54.25-ca-jdk11.0.14-linux_musl_x64
+    src: /usr/lib/jvm/zulu11.54.25-ca-jdk11.0.14.1-linux_musl_x64
     dest: /usr/lib/jvm/zulu11
     state: link
   when:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Alpine.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Alpine.yml
@@ -24,186 +24,191 @@
     - not usr_lib_jvm_exists.stat.exists
   tags: build_tools
 
-- name: Check if zulu-7 is already installed in the target location
-  stat: path=/usr/lib/jvm/zulu7
-  register: zulu7_installed
-  tags: build_tools
+- name: Install JDK for aarch64
+  when: ansible_architecture == "x86_64"
+  block:
+  - name: Check if zulu-7 is already installed in the target location
+    stat: path=/usr/lib/jvm/zulu7
+    register: zulu7_installed
+    tags: build_tools
 
-- name: Install latest zulu-7 release if not already installed
-  unarchive:
-    src: https://cdn.azul.com/zulu/bin/zulu7.52.0.11-ca-jdk7.0.332-linux_x64.tar.gz
-    dest: /usr/lib/jvm/
-    remote_src: yes
-  when:
-    - not zulu7_installed.stat.exists
-  tags: build_tools
+  - name: Install latest zulu-7 release if not already installed
+    unarchive:
+      src: https://cdn.azul.com/zulu/bin/zulu7.52.0.11-ca-jdk7.0.332-linux_x64.tar.gz
+      dest: /usr/lib/jvm/
+      remote_src: yes
+    when:
+      - not zulu7_installed.stat.exists
+    tags: build_tools
 
-- name: Create symlink to point at zulu-7
-  file:
-    src: /usr/lib/jvm/zulu7.52.0.11-ca-jdk7.0.332-linux_x64
-    dest: /usr/lib/jvm/zulu7
-    state: link
-  when:
-    - not zulu7_installed.stat.exists
-  tags: build_tools
+  - name: Create symlink to point at zulu-7
+    file:
+      src: /usr/lib/jvm/zulu7.52.0.11-ca-jdk7.0.332-linux_x64
+      dest: /usr/lib/jvm/zulu7
+      state: link
+    when:
+      - not zulu7_installed.stat.exists
+    tags: build_tools
 
-- name: Check if zulu-8 is already installed in the target location
-  stat: path=/usr/lib/jvm/zulu8
-  register: zulu8_installed
-  tags: build_tools
-- name: Install latest zulu-8 release if not already installed
-  unarchive:
-    src: https://cdn.azul.com/zulu/bin/zulu8.58.0.13-ca-jdk8.0.312-linux_musl_x64.tar.gz
-    dest: /usr/lib/jvm/
-    remote_src: yes
-  when:
-    - not zulu8_installed.stat.exists
-  tags: build_tools
+  - name: Check if zulu-8 is already installed in the target location
+    stat: path=/usr/lib/jvm/zulu8
+    register: zulu8_installed
+    tags: build_tools
+  - name: Install latest zulu-8 release if not already installed
+    unarchive:
+      src: https://cdn.azul.com/zulu/bin/zulu8.58.0.13-ca-jdk8.0.312-linux_musl_x64.tar.gz
+      dest: /usr/lib/jvm/
+      remote_src: yes
+    when:
+      - not zulu8_installed.stat.exists
+    tags: build_tools
 
-- name: Create symlink to point at zulu-8
-  file:
-    src: /usr/lib/jvm/zulu8.58.0.13-ca-jdk8.0.312-linux_musl_x64
-    dest: /usr/lib/jvm/zulu8
-    state: link
-  when:
-    - not zulu8_installed.stat.exists
-  tags: build_tools
+  - name: Create symlink to point at zulu-8
+    file:
+      src: /usr/lib/jvm/zulu8.58.0.13-ca-jdk8.0.312-linux_musl_x64
+      dest: /usr/lib/jvm/zulu8
+      state: link
+    when:
+      - not zulu8_installed.stat.exists
+    tags: build_tools
 
-- name: Check if zulu-11 is already installed in the target location
-  stat: path=/usr/lib/jvm/zulu11
-  register: zulu11_installed
-  tags: build_tools
+  - name: Check if zulu-11 is already installed in the target location
+    stat: path=/usr/lib/jvm/zulu11
+    register: zulu11_installed
+    tags: build_tools
 
-- name: Install latest zulu-11 release if not already installed
-  unarchive:
-    src: https://cdn.azul.com/zulu/bin/zulu11.54.25-ca-jdk11.0.14.1-linux_musl_x64.tar.gz
-    dest: /usr/lib/jvm/
-    remote_src: yes
-  when:
-    - not zulu11_installed.stat.exists
-  tags: build_tools
+  - name: Install latest zulu-11 release if not already installed
+    unarchive:
+      src: https://cdn.azul.com/zulu/bin/zulu11.54.25-ca-jdk11.0.14.1-linux_musl_x64.tar.gz
+      dest: /usr/lib/jvm/
+      remote_src: yes
+    when:
+      - not zulu11_installed.stat.exists
+    tags: build_tools
 
-- name: Create symlink to point at zulu-11
-  file:
-    src: /usr/lib/jvm/zulu11.54.25-ca-jdk11.0.14.1-linux_musl_x64
-    dest: /usr/lib/jvm/zulu11
-    state: link
-  when:
-    - not zulu11_installed.stat.exists
-  tags: build_tools
+  - name: Create symlink to point at zulu-11
+    file:
+      src: /usr/lib/jvm/zulu11.54.25-ca-jdk11.0.14.1-linux_musl_x64
+      dest: /usr/lib/jvm/zulu11
+      state: link
+    when:
+      - not zulu11_installed.stat.exists
+    tags: build_tools
 
-- name: Check if zulu-14 is already installed in the target location
-  stat: path=/usr/lib/jvm/zulu14
-  register: zulu14_installed
-  tags: build_tools
+  - name: Check if zulu-14 is already installed in the target location
+    stat: path=/usr/lib/jvm/zulu14
+    register: zulu14_installed
+    tags: build_tools
 
-- name: Install latest zulu-14 release if not already installed
-  unarchive:
-    src: https://cdn.azul.com/zulu/bin/zulu14.29.23-ca-jdk14.0.2-linux_musl_x64.tar.gz
-    dest: /usr/lib/jvm/
-    remote_src: yes
-  when:
-    - not zulu14_installed.stat.exists
-  tags: build_tools
+  - name: Install latest zulu-14 release if not already installed
+    unarchive:
+      src: https://cdn.azul.com/zulu/bin/zulu14.29.23-ca-jdk14.0.2-linux_musl_x64.tar.gz
+      dest: /usr/lib/jvm/
+      remote_src: yes
+    when:
+      - not zulu14_installed.stat.exists
+    tags: build_tools
 
-- name: Create symlink to point at zulu-14
-  file:
-    src: /usr/lib/jvm/zulu14.29.23-ca-jdk14.0.2-linux_musl_x64
-    dest: /usr/lib/jvm/zulu14
-    state: link
-  when:
-    - not zulu14_installed.stat.exists
-  tags: build_tools
+  - name: Create symlink to point at zulu-14
+    file:
+      src: /usr/lib/jvm/zulu14.29.23-ca-jdk14.0.2-linux_musl_x64
+      dest: /usr/lib/jvm/zulu14
+      state: link
+    when:
+      - not zulu14_installed.stat.exists
+    tags: build_tools
 
-- name: Check if zulu-15 is already installed in the target location
-  stat: path=/usr/lib/jvm/zulu15
-  register: zulu15_installed
-  tags: build_tools
+  - name: Check if zulu-15 is already installed in the target location
+    stat: path=/usr/lib/jvm/zulu15
+    register: zulu15_installed
+    tags: build_tools
 
-- name: Install latest zulu-15 release if not already installed
-  unarchive:
-    src: https://cdn.azul.com/zulu/bin/zulu15.38.17-ca-jdk15.0.6-linux_musl_x64.tar.gz
-    dest: /usr/lib/jvm/
-    remote_src: yes
-  when:
-    - not zulu15_installed.stat.exists
-  tags: build_tools
+  - name: Install latest zulu-15 release if not already installed
+    unarchive:
+      src: https://cdn.azul.com/zulu/bin/zulu15.38.17-ca-jdk15.0.6-linux_musl_x64.tar.gz
+      dest: /usr/lib/jvm/
+      remote_src: yes
+    when:
+      - not zulu15_installed.stat.exists
+    tags: build_tools
 
-- name: Create symlink to point at zulu-15
-  file:
-    src: /usr/lib/jvm/zulu15.38.17-ca-jdk15.0.6-linux_musl_x64
-    dest: /usr/lib/jvm/zulu15
-    state: link
-  when:
-    - not zulu15_installed.stat.exists
-  tags: build_tools
+  - name: Create symlink to point at zulu-15
+    file:
+      src: /usr/lib/jvm/zulu15.38.17-ca-jdk15.0.6-linux_musl_x64
+      dest: /usr/lib/jvm/zulu15
+      state: link
+    when:
+      - not zulu15_installed.stat.exists
+    tags: build_tools
 
+- name: Install JDK for aarch64
+  when: ansible_architecture == "aarch64"
+  block:
+  - name: Check if zulu-16 is already installed in the target location
+    stat: path=/usr/lib/jvm/zulu16
+    register: zulu16_installed
+    tags: build_tools
 
-- name: Check if zulu-16 is already installed in the target location
-  stat: path=/usr/lib/jvm/zulu16
-  register: zulu16_installed
-  tags: build_tools
+  - name: Install latest zulu-16 release if not already installed
+    unarchive:
+      src: https://cdn.azul.com/zulu/bin/zulu16.32.15-ca-jdk16.0.2-linux_musl_aarch64.tar.gz
+      dest: /usr/lib/jvm/
+      remote_src: yes
+    when:
+      - not zulu16_installed.stat.exists
+    tags: build_tools
 
-- name: Install latest zulu-16 release if not already installed
-  unarchive:
-    src: https://cdn.azul.com/zulu/bin/zulu16.32.15-ca-jdk16.0.2-linux_musl_aarch64.tar.gz
-    dest: /usr/lib/jvm/
-    remote_src: yes
-  when:
-    - not zulu16_installed.stat.exists
-  tags: build_tools
+  - name: Create symlink to point at zulu-16
+    file:
+      src: /usr/lib/jvm/zulu16.32.15-ca-jdk16.0.2-linux_musl_aarch64
+      dest: /usr/lib/jvm/zulu16
+      state: link
+    when:
+      - not zulu16_installed.stat.exists
+    tags: build_tools
 
-- name: Create symlink to point at zulu-16
-  file:
-    src: /usr/lib/jvm/zulu16.32.15-ca-jdk16.0.2-linux_musl_aarch64
-    dest: /usr/lib/jvm/zulu16
-    state: link
-  when:
-    - not zulu16_installed.stat.exists
-  tags: build_tools
+  - name: Check if zulu-17 is already installed in the target location
+    stat: path=/usr/lib/jvm/zulu17
+    register: zulu17_installed
+    tags: build_tools
 
-- name: Check if zulu-17 is already installed in the target location
-  stat: path=/usr/lib/jvm/zulu17
-  register: zulu17_installed
-  tags: build_tools
+  - name: Install latest zulu-17 release if not already installed
+    unarchive:
+      src: https://cdn.azul.com/zulu/bin/zulu17.32.13-ca-jdk17.0.2-linux_musl_aarch64.tar.gz
+      dest: /usr/lib/jvm/
+      remote_src: yes
+    when:
+      - not zulu17_installed.stat.exists
+    tags: build_tools
 
-- name: Install latest zulu-17 release if not already installed
-  unarchive:
-    src: https://cdn.azul.com/zulu/bin/zulu17.32.13-ca-jdk17.0.2-linux_musl_aarch64.tar.gz
-    dest: /usr/lib/jvm/
-    remote_src: yes
-  when:
-    - not zulu17_installed.stat.exists
-  tags: build_tools
+  - name: Create symlink to point at zulu-17
+    file:
+      src: /usr/lib/jvm/zulu17.32.13-ca-jdk17.0.2-linux_musl_aarch64
+      dest: /usr/lib/jvm/zulu17
+      state: link
+    when:
+      - not zulu17_installed.stat.exists
+    tags: build_tools
+  
+  - name: Check if zulu-18 is already installed in the target location
+    stat: path=/usr/lib/jvm/zulu18
+    register: zulu18_installed
+    tags: build_tools
 
-- name: Create symlink to point at zulu-17
-  file:
-    src: /usr/lib/jvm/zulu17.32.13-ca-jdk17.0.2-linux_musl_aarch64
-    dest: /usr/lib/jvm/zulu17
-    state: link
-  when:
-    - not zulu17_installed.stat.exists
-  tags: build_tools
+  - name: Install latest zulu-18 release if not already installed
+    unarchive:
+      src: https://cdn.azul.com/zulu/bin/zulu18.28.13-ca-jdk18.0.0-linux_musl_aarch64.tar.gz
+      dest: /usr/lib/jvm/
+      remote_src: yes
+    when:
+      - not zulu18_installed.stat.exists
+    tags: build_tools
 
-- name: Check if zulu-18 is already installed in the target location
-  stat: path=/usr/lib/jvm/zulu18
-  register: zulu18_installed
-  tags: build_tools
-
-- name: Install latest zulu-18 release if not already installed
-  unarchive:
-    src: https://cdn.azul.com/zulu/bin/zulu18.28.13-ca-jdk18.0.0-linux_musl_aarch64.tar.gz
-    dest: /usr/lib/jvm/
-    remote_src: yes
-  when:
-    - not zulu18_installed.stat.exists
-  tags: build_tools
-
-- name: Create symlink to point at zulu-18
-  file:
-    src: /usr/lib/jvm/zulu18.28.13-ca-jdk18.0.0-linux_musl_aarch64
-    dest: /usr/lib/jvm/zulu18
-    state: link
-  when:
-    - not zulu18_installed.stat.exists
-  tags: build_tools
+  - name: Create symlink to point at zulu-18
+    file:
+      src: /usr/lib/jvm/zulu18.28.13-ca-jdk18.0.0-linux_musl_aarch64
+      dest: /usr/lib/jvm/zulu18
+      state: link
+    when:
+      - not zulu18_installed.stat.exists
+    tags: build_tools


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->
- update Alpine play to install jdk16/17/18 from zulu which has support for aarch64
- add jenkins stage to build alpine image
- skip install test_tools packages


##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Ref: https://github.com/adoptium/infrastructure/issues/2497