### PR TITLE
feat: add gcc 11.2 to adoptopenjdk centos7 image

### DIFF
--- a/ansible/docker/Dockerfile.CentOS7
+++ b/ansible/docker/Dockerfile.CentOS7
@@ -2,8 +2,16 @@ FROM centos:7
 
 ARG user=jenkins
 
-RUN yum -y update; yum -y install epel-release
-RUN yum -y install ansible sudo; yum clean all
+RUN yum -y update && yum -y install \
+	epel-release \
+	centos-release-scl-rh # enable devtoolset repo
+RUN yum -y install \
+	ansible \
+	sudo \
+	devtoolset-11-gcc-c++ && \ # install gcc 11.2
+	yum clean all
+
+
 
 COPY . /ansible
 


### PR DESCRIPTION
Fixes #2538 

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
