### PR TITLE
github: updates workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,20 +17,20 @@ on:
     - master
 
 jobs:
-  build-and-push-centos6:
-    name: Centos6
+  build-and-push-centos7:
+    name: Centos7
     runs-on: ubuntu-latest
     steps:
 
     - uses: actions/checkout@v2
 
-    - name: Docker Build & Push Centos6 Image to Docker Hub
+    - name: Docker Build & Push Centos7 Image to Docker Hub
       uses: docker/build-push-action@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         dockerfile: ./ansible/docker/Dockerfile.CentOS7
-        repository: adoptopenjdk/centos6_build_image
+        repository: adoptopenjdk/centos7_build_image
         tags: latest
         push: ${{ github.ref == 'refs/heads/master' }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        dockerfile: ./ansible/docker/Dockerfile.CentOS6
+        dockerfile: ./ansible/docker/Dockerfile.CentOS7
         repository: adoptopenjdk/centos6_build_image
         tags: latest
         push: ${{ github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
	- use CentOS7 than CentOS6 for check: ansible 2.6.20 is not
match for newer modules, better use 2.9.X of ansible


##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [ x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ x] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
