### PR TITLE
github: upgrade build-push-action to v2 to fix "linter" warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,15 +24,23 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - name: Docker Build & Push Centos6 Image to Docker Hub
-      uses: docker/build-push-action@v1
+    - name: Set up Docker Buildx to use cache feature
+      uses: docker/setup-buildx-action@v2
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        dockerfile: ./ansible/docker/Dockerfile.CentOS6
-        repository: adoptopenjdk/centos6_build_image
-        tags: latest
-        push: ${{ github.ref == 'refs/heads/master' }}
+
+    - name: Docker Build & Push Centos6 Image to Docker Hub
+      uses: docker/build-push-action@v2
+      with:
+        file: ./ansible/docker/Dockerfile.CentOS6
+        tags: adoptopenjdk/centos6_build_image:latest
+        cache-from: type=registry,ref=adoptopenjdk/centos6_build_image:latest
+        cache-to: type=inline
+        push: true
 
   build-and-push-alpine3:
     name: Alpine3
@@ -41,12 +49,20 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - name: Docker Build & Push Alpine3 Image to Docker Hub
-      uses: docker/build-push-action@v1
+    - name: Set up Docker Buildx to use cache feature
+      uses: docker/setup-buildx-action@v2
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        dockerfile: ./ansible/docker/Dockerfile.Alpine3
-        repository: adoptopenjdk/alpine3_build_image
-        tags: latest
-        push: ${{ github.ref == 'refs/heads/master' }}
+
+    - name: Docker Build & Push Alpine3 Image to Docker Hub
+      uses: docker/build-push-action@v2
+      with:
+        file: ./ansible/docker/Dockerfile.Alpine3
+        tags: adoptopenjdk/alpine3_build_image:latest
+        cache-from: type=registry,ref=adoptopenjdk/alpine3_build_image:latest
+        cache-to: type=inline
+        push: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
+      if: github.ref == 'refs/heads/master'
 
     - name: Docker Build & Push Centos6 Image to Docker Hub
       uses: docker/build-push-action@v2
@@ -40,7 +41,7 @@ jobs:
         tags: adoptopenjdk/centos6_build_image:latest
         cache-from: type=registry,ref=adoptopenjdk/centos6_build_image:latest
         cache-to: type=inline
-        push: true
+        push: ${{ github.ref == 'refs/heads/master' }}
 
   build-and-push-alpine3:
     name: Alpine3
@@ -57,6 +58,7 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
+      if: github.ref == 'refs/heads/master'
 
     - name: Docker Build & Push Alpine3 Image to Docker Hub
       uses: docker/build-push-action@v2
@@ -65,4 +67,4 @@ jobs:
         tags: adoptopenjdk/alpine3_build_image:latest
         cache-from: type=registry,ref=adoptopenjdk/alpine3_build_image:latest
         cache-to: type=inline
-        push: true
+        push: ${{ github.ref == 'refs/heads/master' }}

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -17,9 +17,9 @@ on:
     - master
 
 jobs:
-  build-and-push-windows2016:
-    name: Windows 2016
-    runs-on: windows-2016
+  build-and-push-windows2019:
+    name: Windows 2019
+    runs-on: windows-2019
     steps:
 
     - uses: actions/checkout@v2

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -13,7 +13,7 @@ on:
     - .github/workflows/build_windows.yml
     - ansible/docker/DockerFile.Windows2016_Base
     - ansible/docker/Dockerfile.Windows2016_VS2017
-    branches:         
+    branches:
     - master
 
 jobs:
@@ -24,11 +24,8 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - name: Docker Build Windows 2016 Base Image to Docker Hub
-      run: docker build -t adoptopenjdk/windows2016_build_image:base -f ansible/docker/Dockerfile.windows2016_Base .
-
-    - name: Docker Build Windows 2016 VS2017 Image to Docker Hub
-      run: docker build -t adoptopenjdk/windows2016_build_image:vs2017 -f ansible/docker/Dockerfile.windows2016_VS2017 .
+    - name: Set up Docker Buildx to use cache feature
+      uses: docker/setup-buildx-action@v2
 
     - name: Docker login
       uses: azure/docker-login@v1
@@ -37,8 +34,20 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
       if: github.ref == 'refs/heads/master'
 
-    - name: Push Windows images to Docker Hub
-      run: |
-        docker push adoptopenjdk/windows2016_build_image:base
-        docker push adoptopenjdk/windows2016_build_image:vs2017
-      if: github.ref == 'refs/heads/master'
+    - name: Docker Build & Push Windows 2016 Base Image to Docker Hub
+      uses: docker/build-push-action@v2
+      with:
+        file: ./ansible/docker/Dockerfile.windows2016_Base
+        tags: adoptopenjdk/windows2016_build_image:base:latest
+        cache-from: type=registry,ref=adoptopenjdk/windows2016_build_image:base:latest
+        cache-to: type=inline
+        push: true
+
+    - name: Docker Build & Push Windows 2016 VS2017 Image to Docker Hub
+      uses: docker/build-push-action@v2
+      with:
+        file: ./ansible/docker/Dockerfile.windows2016_VS2017
+        tags: adoptopenjdk/windows2016_build_image:vs2017
+        cache-from: type=registry,ref=adoptopenjdk/windows2016_build_image:vs2017
+        cache-to: type=inline
+        push: true

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -13,19 +13,22 @@ on:
     - .github/workflows/build_windows.yml
     - ansible/docker/DockerFile.Windows2016_Base
     - ansible/docker/Dockerfile.Windows2016_VS2017
-    branches:
+    branches:         
     - master
 
 jobs:
-  build-and-push-windows2019:
-    name: Windows 2019
-    runs-on: windows-2019
+  build-and-push-windows2016:
+    name: Windows 2016
+    runs-on: windows-2016
     steps:
 
     - uses: actions/checkout@v2
 
-    - name: Set up Docker Buildx to use cache feature
-      uses: docker/setup-buildx-action@v2
+    - name: Docker Build Windows 2016 Base Image to Docker Hub
+      run: docker build -t adoptopenjdk/windows2016_build_image:base -f ansible/docker/Dockerfile.windows2016_Base .
+
+    - name: Docker Build Windows 2016 VS2017 Image to Docker Hub
+      run: docker build -t adoptopenjdk/windows2016_build_image:vs2017 -f ansible/docker/Dockerfile.windows2016_VS2017 .
 
     - name: Docker login
       uses: azure/docker-login@v1
@@ -34,20 +37,8 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
       if: github.ref == 'refs/heads/master'
 
-    - name: Docker Build & Push Windows 2016 Base Image to Docker Hub
-      uses: docker/build-push-action@v2
-      with:
-        file: ./ansible/docker/Dockerfile.windows2016_Base
-        tags: adoptopenjdk/windows2016_build_image:base:latest
-        cache-from: type=registry,ref=adoptopenjdk/windows2016_build_image:base:latest
-        cache-to: type=inline
-        push: ${{ github.ref == 'refs/heads/master' }}
-
-    - name: Docker Build & Push Windows 2016 VS2017 Image to Docker Hub
-      uses: docker/build-push-action@v2
-      with:
-        file: ./ansible/docker/Dockerfile.windows2016_VS2017
-        tags: adoptopenjdk/windows2016_build_image:vs2017
-        cache-from: type=registry,ref=adoptopenjdk/windows2016_build_image:vs2017
-        cache-to: type=inline
-        push: ${{ github.ref == 'refs/heads/master' }}
+    - name: Push Windows images to Docker Hub
+      run: |
+        docker push adoptopenjdk/windows2016_build_image:base
+        docker push adoptopenjdk/windows2016_build_image:vs2017
+      if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -41,7 +41,7 @@ jobs:
         tags: adoptopenjdk/windows2016_build_image:base:latest
         cache-from: type=registry,ref=adoptopenjdk/windows2016_build_image:base:latest
         cache-to: type=inline
-        push: true
+        push: ${{ github.ref == 'refs/heads/master' }}
 
     - name: Docker Build & Push Windows 2016 VS2017 Image to Docker Hub
       uses: docker/build-push-action@v2
@@ -50,4 +50,4 @@ jobs:
         tags: adoptopenjdk/windows2016_build_image:vs2017
         cache-from: type=registry,ref=adoptopenjdk/windows2016_build_image:vs2017
         cache-to: type=inline
-        push: true
+        push: ${{ github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
	- remove branch check per action since it is done in "on"
	- add buildx to enable[ cache feature](https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#inline-cache)
	- move auth to login-action

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ x] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
