### PR TITLE
unixPB: Add Alpine/arm boot JDKs from alpine repos (TEMPORARY)

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Alpine.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Alpine.yml
@@ -144,6 +144,46 @@
 - name: Install JDK for aarch64
   when: ansible_architecture == "aarch64"
   block:
+    - name: Install java 8 from Alpine repositories
+      package: "name=openjdk8 state=installed"
+      tags: build_tools
+
+    # Using zulu8 path name for compatibility with the build dockerfile
+    # ENV statements until we replace this with a Temurin 8
+    - name: Check if zulu 8 symlink is in place (TEMPORARY)
+      stat: path=/usr/lib/jvm/zulu8
+      register: zulu8_installed
+      tags: build_tools
+
+    - name: Create symlink to point at openjdk8
+      file:
+        src: /usr/lib/jvm/java-8-openjdk
+        dest: /usr/lib/jvm/zulu8
+        state: link
+      when:
+        - not zulu8_installed.stat.exists
+      tags: build_tools
+
+    - name: Install java 11 from Alpine repositories
+      package: "name=openjdk11 state=installed"
+      tags: build_tools
+
+    # Using zulu11 path name for compatibility with the build dockerfile
+    # ENV statements until we replace this with a Temurin 8
+    - name: Check if zulu 11 symlink is in place (TEMPORARY)
+      stat: path=/usr/lib/jvm/zulu11
+      register: zulu11_installed
+      tags: build_tools
+
+    - name: Create symlink to point at openjdk11
+      file:
+        src: /usr/lib/jvm/java-11-openjdk
+        dest: /usr/lib/jvm/zulu11
+        state: link
+      when:
+        - not zulu8_installed.stat.exists
+      tags: build_tools
+
     - name: Check if zulu-16 is already installed in the target location
       stat: path=/usr/lib/jvm/zulu16
       register: zulu16_installed


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

This is needed to get a boot JDK in place for Alpine/aarch64.
Note that while the JDK11 provided by the Alpine repositories works for building, the JDK8 does not.
This symlinks `/usr/lib/jvm/zulu{8,11}` to the non-zulu versions provided in the Alpine repositories in order to avoid us having to adjust https://github.com/adoptium/infrastructure/blob/master/ansible/docker/Dockerfile.Alpine3 for now. Once this is merged I will create a separate issue to switch over to using the Adoptium JDKs now that we have them (Subject to being able to create a temurin JDK8)