### PR TITLE
docker: fix alpine manifest build for amd64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,13 +53,6 @@ jobs:
     - name: Set up Docker Buildx to use cache feature
       uses: docker/setup-buildx-action@v2
 
-    - name: Login to Docker Hub
-      uses: docker/login-action@v2
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-      if: github.ref == 'refs/heads/master'
-
     - name: Docker Build & Push Alpine3 Image to Docker Hub
       uses: docker/build-push-action@v2
       with:
@@ -67,4 +60,4 @@ jobs:
         tags: adoptopenjdk/alpine3_build_image:latest
         cache-from: type=registry,ref=adoptopenjdk/alpine3_build_image:latest
         cache-to: type=inline
-        push: ${{ github.ref == 'refs/heads/master' }}
+        push: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Set up Docker Buildx to use cache feature
       uses: docker/setup-buildx-action@v2
 
-    - name: Docker Build & Push Alpine3 Image to Docker Hub
+    - name: Docker Build Alpine3 Image
       uses: docker/build-push-action@v2
       with:
         file: ./ansible/docker/Dockerfile.Alpine3

--- a/FAQ.md
+++ b/FAQ.md
@@ -72,8 +72,7 @@ have at the moment:
 |---|---|---|---|---|
 | [Centos7](./ansible/docker/Dockerfile.CentOS7) | [`adoptopenjdk/centos7_build_image`](https://hub.docker.com/r/adoptopenjdk/centos7_build_image) | linux on amd64, arm64, ppc64le | [Jenkins](https://ci.adoptopenjdk.net/job/centos7_docker_image_updater/) | Yes
 | [Centos6](./ansible/docker/Dockerfile.CentOS6) | [`adoptopenjdk/centos6_build_image`](https://hub.docker.com/r/adoptopenjdk/centos6_build_image)| linux/amd64 | [GH Actions](.github/workflows/build.yml) | Yes
-| [Alpine3](./ansible/docker/Dockerfile.Alpine3) | [`adoptopenjdk/alpine3_build_image`](https://hub.docker.com/r/adoptopenjdk/alpine3_build_image) | linux/x64 | [GH Actions](.github/workflows/build.yml) | Yes
-| [Alpine3](./ansible/docker/Dockerfile.Alpine3) | [`adoptopenjdk/alpine3_build_image`](https://hub.docker.com/r/adoptopenjdk/alpine3_build_image) | linux/arm64 | [Jenkins](https://ci.adoptopenjdk.net/job/centos7_docker_image_updater/) | Yes
+| [Alpine3](./ansible/docker/Dockerfile.Alpine3) | [`adoptopenjdk/alpine3_build_image`](https://hub.docker.com/r/adoptopenjdk/alpine3_build_image) | linux/x64 & linux/arm64 | [Jenkins](https://ci.adoptopenjdk.net/job/centos7_docker_image_updater/) | Yes
 
 When a change lands into master, the relevant dockerfiles are built using
 the appropriate CI system listed in the table above by configuring them with

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,6 +100,8 @@ def dockerManifest() {
             docker manifest push $TARGET
             # Alpine3
             export TARGET="adoptopenjdk/alpine3_build_image"
+            AMD64=$TARGET:linux-amd64
+            ARM64=$TARGET:linux-arm64
             docker manifest create $TARGET $AMD64 $ARM64
             docker manifest annotate $TARGET $AMD64 --arch amd64 --os linux
             docker manifest annotate $TARGET $ARM64 --arch arm64 --os linux

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,12 +35,20 @@ pipeline {
                         dockerBuild('armv7l', 'ubuntu1604', 'Dockerfile.Ubuntu1604')
                     }
                 }
+                stage('Alpine3 x64') {
+                    agent {
+                        label "dockerBuild&&linux&&x64"
+                    }
+                    steps {
+                        dockerBuild('amd64', 'alpine3', 'Dockerfile.Alpine3')
+                    }
+                }
                 stage('Alpine3 aarch64') {
                     agent {
                         label "dockerBuild&&linux&&aarch64"
                     }
                     steps {
-                        dockerBuild('aarch64', 'alpine3', 'Dockerfile.Alpine3')
+                        dockerBuild('arm64', 'alpine3', 'Dockerfile.Alpine3')
                     }
                 }
             }
@@ -92,8 +100,8 @@ def dockerManifest() {
             docker manifest push $TARGET
             # Alpine3
             export TARGET="adoptopenjdk/alpine3_build_image"
-            ARM64=$TARGET:linux-arm64
-            docker manifest create $TARGET $ARM64
+            docker manifest create $TARGET $AMD64 $ARM64
+            docker manifest annotate $TARGET $AMD64 --arch amd64 --os linux
             docker manifest annotate $TARGET $ARM64 --arch arm64 --os linux
             docker manifest push $TARGET
         '''


### PR DESCRIPTION
Now that we've added support for Alpine aarch64 docker images, it makes sense to move the x64 build to also be on Jenkins as it makes the manifest command much simpler to run.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
