### PR TITLE
docker: Force JDK19_BOOT_DIR=zulu18 for Alpine

### DIFF
--- a/ansible/docker/Dockerfile.Alpine3
+++ b/ansible/docker/Dockerfile.Alpine3
@@ -23,5 +23,6 @@ ENV \
     JDK16_BOOT_DIR="/usr/lib/jvm/zulu16" \
     JDK17_BOOT_DIR="/usr/lib/jvm/zulu17" \
     JDK18_BOOT_DIR="/usr/lib/jvm/zulu18" \
+    JDK19_BOOT_DIR="/usr/lib/jvm/zulu18" \
     JDKLATEST_BOOT_DIR="/usr/lib/jvm/zulu18" \
     JAVA_HOME="/usr/lib/jvm/zulu8"


### PR DESCRIPTION
Temporary fudge while we don't have an `ea` build for jdk-19 in the temurin API so cannot download it during the build process.
Currently JDK19 is forced to bootstrap with 19 https://github.com/adoptium/temurin-build/blob/8d87dd642382b72337ee48e6b74c98cf1f234c89/build-farm/make-adopt-build-farm.sh#L145
We can remove this once we have ea builds regularly being published (And in fact we can hopefully switch away form zulu generally as per https://github.com/adoptium/infrastructure/issues/2564

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
