### PR TITLE
UnixPb: Add arm64 binaries on MacOS instead of x64 when available

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
@@ -64,7 +64,7 @@
     - ansible_os_family == "Darwin"
     - ansible_architecture == "arm64"
     - jdk_version < 17
-    - jdk_version !=11
+    - jdk_version != 11
   tags: adoptopenjdk_install
 
 - name: Set aarch64 api_architecture variable for macOS Arm64

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
@@ -63,7 +63,8 @@
   when:
     - ansible_os_family == "Darwin"
     - ansible_architecture == "arm64"
-    - jdk_version != 11 or jdk_version != 17 or jdk_version != 18
+    - jdk_version < 17
+    - jdk_version !=11
   tags: adoptopenjdk_install
 
 - name: Set aarch64 api_architecture variable for macOS Arm64
@@ -72,7 +73,7 @@
   when:
     - ansible_os_family == "Darwin"
     - ansible_architecture == "arm64"
-    - jdk_version == 11 or jdk_version == 17 or jdk_version == 18
+    - jdk_version >= 17 or jdk_version == 11
   tags: adoptopenjdk_install
 
 - name: Set api_architecture variable for armv7l

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
@@ -57,12 +57,22 @@
   tags: adoptopenjdk_install
 
 # Download x64 binaries until we have arm64 binaries available
-- name: Set api_architecture variable for macOS Arm64
+- name: Set x64 api_architecture variable for macOS Arm64
   set_fact:
     api_architecture: x64
   when:
     - ansible_os_family == "Darwin"
     - ansible_architecture == "arm64"
+    - jdk_version != 11 or jdk_version != 17 or jdk_version != 18
+  tags: adoptopenjdk_install
+
+- name: Set aarch64 api_architecture variable for macOS Arm64
+  set_fact:
+    api_architecture: aarch64
+  when:
+    - ansible_os_family == "Darwin"
+    - ansible_architecture == "arm64"
+    - jdk_version == 11 or jdk_version == 17 or jdk_version == 18
   tags: adoptopenjdk_install
 
 - name: Set api_architecture variable for armv7l


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly


For jdk 11, 17 and 18, since arm64 binaries are available, it would be best to use those instead of x64 ones