### PR TITLE
UnixPb: Add a check for the ansible version when running the MacOS playbook

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
@@ -4,6 +4,12 @@
 # Updates all packages for macos-based distributions
 #
 
+# Issue https://github.com/adoptium/infrastructure/issues/1902
+- name: Ensure ansible version is greater than 2.11
+  fail:
+    msg: "The version of Ansible you are using needs to be greater than 2.11"
+  when: ansible_version.full is version('2.11', '<=')
+
 - name: Get macOS version
   shell: sw_vers -productVersion
   register: macos_version


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/1902
