### PR TITLE
ansible: fix typo on ansible module

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/debian.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/debian.yml
@@ -41,7 +41,7 @@
 
 - name: Install Docker prerequisites for Debian ( < 10 )
   apt:
-    pkg=: "{ item }}"
+    pkg: "{ item }}"
     state: latest
   with_items:
     - apt-transport-https


### PR DESCRIPTION
To fix a typo, error https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/OS=Debian8,label=vagrant/1428/console
`17:30:28 failed: [127.0.0.1] (item=apt-transport-https) => {"ansible_loop_var": "item", "changed": false, "item": "apt-transport-https", "msg": "Unsupported parameters for (apt) module: pkg= Supported parameters include: allow_unauthenticated, autoclean, autoremove, cache_valid_time, deb, default_release, dpkg_options, force, force_apt_get, install_recommends, only_upgrade, package, policy_rc_d, purge, state, update_cache, upgrade"}
17:30:30 failed: [127.0.0.1] (item=ca-certificates) => {"ansible_loop_var": "item", "changed": false, "item": "ca-certificates", "msg": "Unsupported parameters for (apt) module: pkg= Supported parameters include: allow_unauthenticated, autoclean, autoremove, cache_valid_time, deb, default_release, dpkg_options, force, force_apt_get, install_recommends, only_upgrade, package, policy_rc_d, purge, state, update_cache, upgrade"}
17:30:32 failed: [127.0.0.1] (item=curl) => {"ansible_loop_var": "item", "changed": false, "item": "curl", "msg": "Unsupported parameters for (apt) module: pkg= Supported parameters include: allow_unauthenticated, autoclean, autoremove, cache_valid_time, deb, default_release, dpkg_options, force, force_apt_get, install_recommends, only_upgrade, package, policy_rc_d, purge, state, update_cache, upgrade"}
17:30:34 failed: [127.0.0.1] (item=software-properties-common) => {"ansible_loop_var": "item", "changed": false, "item": "software-properties-common", "msg": "Unsupported parameters for (apt) module: pkg= Supported parameters include: allow_unauthenticated, autoclean, autoremove, cache_valid_time, deb, default_release, dpkg_options, force, force_apt_get, install_recommends, only_upgrade, package, policy_rc_d, purge, state, update_cache, upgrade"}`

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
