### PR TITLE
ansible: fix wrong path for nagios NTP check on Centos/RHEL

### DIFF
--- a/ansible/playbooks/Supporting_Scripts/Nagios_Ansible_Config_tool/templates/check_ntp_timesync.cfg
+++ b/ansible/playbooks/Supporting_Scripts/Nagios_Ansible_Config_tool/templates/check_ntp_timesync.cfg
@@ -2,6 +2,6 @@ define service{
         use                             generic-service
         host_name                       ReplaceHostName
         service_description             Check Network Time System
-        check_command                   check_by_ssh!/usr/lib/nagios/plugins/check_ntp_timesync
+        check_command                   check_by_ssh!/usr/local/nagios/libexec/check_ntp_timesync
         check_interval                  15
 }

--- a/ansible/playbooks/Supporting_Scripts/Nagios_Ansible_Config_tool/templates/check_timesync.cfg
+++ b/ansible/playbooks/Supporting_Scripts/Nagios_Ansible_Config_tool/templates/check_timesync.cfg
@@ -2,6 +2,6 @@ define service{
         use                             generic-service
         host_name                       ReplaceHostName
         service_description             Check Network Time System
-        check_command                   check_by_ssh!/usr/lib/nagios/plugins/check_timesync
+        check_command                   check_by_ssh!/usr/local/nagios/libexec/check_timesync
         check_interval                  15
 }

--- a/ansible/playbooks/Supporting_Scripts/Nagios_Ansible_Config_tool/templates/zypper.cfg
+++ b/ansible/playbooks/Supporting_Scripts/Nagios_Ansible_Config_tool/templates/zypper.cfg
@@ -2,9 +2,9 @@
 define service{
         use                             generic-service
         host_name                       ReplaceHostName
-	check_period			once-a-day-at-8
+		check_period					once-a-day-at-8
         service_description             Updates Required - Zypper
-	check_command                   check_by_ssh!/usr/local/nagios/libexec/check_zypper
-	notifications_enabled   0        
+		check_command                   check_by_ssh!/usr/local/nagios/libexec/check_zypper
+		notifications_enabled   		0        
 	}
 

--- a/ansible/playbooks/Supporting_Scripts/Nagios_Ansible_Config_tool/templates/zypper.cfg
+++ b/ansible/playbooks/Supporting_Scripts/Nagios_Ansible_Config_tool/templates/zypper.cfg
@@ -2,9 +2,9 @@
 define service{
         use                             generic-service
         host_name                       ReplaceHostName
-		check_period					once-a-day-at-8
+	check_period			once-a-day-at-8
         service_description             Updates Required - Zypper
-		check_command                   check_by_ssh!/usr/local/nagios/libexec/check_zypper
-		notifications_enabled   		0        
+	check_command                   check_by_ssh!/usr/local/nagios/libexec/check_zypper
+	notifications_enabled   	0        
 	}
 


### PR DESCRIPTION
	- on centos/rhel default location is /usr/lib64/nagios/plugins , there is no /usr/lib/nagios/plugins/ unless we create symlink
	- on unbuntu/debian, default is /usr/lib/nagios/plugins/
	- we should use /usr/local/nagios (symlink) to access for different distro since the symlink has been created there for different ones.
this PR should not change anything for nagios on ubuntu/debian but fix centos/rhel
Related to https://github.com/adoptium/infrastructure/issues/2199

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
