### PR TITLE
github: fix failing vagrant CI job

### DIFF
--- a/.github/workflows/build_vagrant.yml
+++ b/.github/workflows/build_vagrant.yml
@@ -27,10 +27,10 @@ jobs:
         brew install --cask virtualbox
 
     - name: Setup Vagrant VM
+      working-directory: ansible
       run: |
-        cd ansible
         # Temporary fix as the Adopt vagrant vm image is not available on the GitHub Actions executors
-        sed -i e "s/solaris10/tnarik\/solaris10-minimal/g" ansible/vagrant/Vagrantfile.Solaris10
+        sed -i e "s/solaris10/tnarik\/solaris10-minimal/g" vagrant/Vagrantfile.Solaris10
         ln -sf vagrant/Vagrantfile.Solaris10 Vagrantfile
         rm -f id_rsa.pub id_rsa
         # Copy the machine's ssh key for the VMs to use, after removing prior files

--- a/.github/workflows/build_vagrant.yml
+++ b/.github/workflows/build_vagrant.yml
@@ -8,6 +8,11 @@ on:
     branches:         
     - master
 
+# Cancel existing runs if user makes another push.
+concurrency:
+  group: "${{ github.ref }}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-solaris:
     name: Solaris
@@ -24,6 +29,8 @@ jobs:
     - name: Setup Vagrant VM
       run: |
         cd ansible
+        # Temporary fix as the Adopt vagrant vm image is not available on the GitHub Actions executors
+        sed -i e "s/solaris10/tnarik\/solaris10-minimal/g" ansible/vagrant/Vagrantfile.Solaris10
         ln -sf vagrant/Vagrantfile.Solaris10 Vagrantfile
         rm -f id_rsa.pub id_rsa
         # Copy the machine's ssh key for the VMs to use, after removing prior files
@@ -33,8 +40,6 @@ jobs:
         rm -f playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx
         echo "[127.0.0.1]:${vagrantPORT}" >> playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx
         sed -i -e "s/.*hosts:.*/- hosts: all/g" playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
-        # Temporary fix as the Adopt vagrant vm image is not available on the GitHub Actions executors
-        sed -i e "s/solaris10/tnarik\/solaris10-minimal/g" ansible/vagrant/Vagrantfile.Solaris10
         awk '{print}/^\[defaults\]$/{print "private_key_file = id_rsa"; print "timeout = 30"; print "remote_tmp = $HOME/.ansible/tmp"}' < ansible.cfg > ansible.cfg.tmp && mv ansible.cfg.tmp ansible.cfg
 
     - name: Run Ansible Playbook

--- a/.github/workflows/build_vagrant.yml
+++ b/.github/workflows/build_vagrant.yml
@@ -33,6 +33,8 @@ jobs:
         rm -f playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx
         echo "[127.0.0.1]:${vagrantPORT}" >> playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx
         sed -i -e "s/.*hosts:.*/- hosts: all/g" playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+        # Temporary fix as the Adopt vagrant vm image is not available on the GitHub Actions executors
+        sed -i e "s/solaris10/tnarik\/solaris10-minimal/g" ansible/vagrant/Vagrantfile.Solaris10
         awk '{print}/^\[defaults\]$/{print "private_key_file = id_rsa"; print "timeout = 30"; print "remote_tmp = $HOME/.ansible/tmp"}' < ansible.cfg > ansible.cfg.tmp && mv ansible.cfg.tmp ansible.cfg
 
     - name: Run Ansible Playbook


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

fixes: https://github.com/adoptium/infrastructure/issues/2425

This PR fixes the long-term failing Solaris Vagrant GH actions job. This was broken when we decided to switch to a custom vagrant image that was not available in the environment of the action. This PR switches that logic back to the public image for GH actions CI runs