### PR TITLE
VPC: Clean up vagrant boxes on exit

### DIFF
--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -396,7 +396,7 @@ destroyVM()
 	fi
 }
 
-trap destroyVM $OS EXIT
+trap destroyVM $vagrantOS EXIT
 
 processArgs $*
 checkVars

--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -396,7 +396,7 @@ destroyVM()
 	fi
 }
 
-trap "destroyVM ${vagrantOS}" EXIT
+trap 'destroyVM $vagrantOS' EXIT
 
 processArgs $*
 checkVars

--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -372,6 +372,7 @@ startVMPlaybookWin()
 destroyVM()
 {
 	if [[ "$retainVM" == false ]]; then
+		echo "Destroying the VM"
 		local OS=$1
 		echo "Destroying the $OS Machine"
 		echo === `date +%T`: showing global status before pruning:

--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -396,7 +396,7 @@ destroyVM()
 	fi
 }
 
-trap destroyVM $vagrantOS EXIT
+trap "destroyVM ${vagrantOS}" EXIT
 
 processArgs $*
 checkVars

--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -372,7 +372,6 @@ startVMPlaybookWin()
 destroyVM()
 {
 	if [[ "$retainVM" == false ]]; then
-		echo "Destroying the VM"
 		local OS=$1
 		echo "Destroying the $OS Machine"
 		echo === `date +%T`: showing global status before pruning:

--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -396,7 +396,7 @@ destroyVM()
 	fi
 }
 
-trap destroyVM EXIT
+trap destroyVM $OS EXIT
 
 processArgs $*
 checkVars

--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -372,30 +372,32 @@ startVMPlaybookWin()
 destroyVM()
 {
 	if [[ "$retainVM" == false ]]; then
-		local OS=$1
-		echo "Destroying the $OS Machine"
-		echo === `date +%T`: showing global status before pruning:
-		vagrant global-status
-		free
-		echo === showing global status while pruning:
-		vagrant global-status --prune
-		echo === Determining VM to destroy:
-		VM_TO_DESTROY=`vagrant global-status --prune | grep $OS | awk "/${gitFork}-${gitBranch}/ { print \\$1 }"`
-		if [ ! -z "$VM_TO_DESTROY" ]; then
-		echo === Destroying VM with id $VM_TO_DESTROY
-		vagrant destroy -f $VM_TO_DESTROY
-		else
-		echo === NOT DESTROYING ANY VM as no suitable ID was found searching for $OS and ${gitFork}-${gitBranch}
-		fi
+		for OS in $vagrantOS
+		do
+			echo "Destroying the $OS Machine"
+			echo === `date +%T`: showing global status before pruning:
+			vagrant global-status
+			free
+			echo === showing global status while pruning:
+			vagrant global-status --prune
+			echo === Determining VM to destroy:
+			VM_TO_DESTROY=`vagrant global-status --prune | grep $OS | awk "/${gitFork}-${gitBranch}/ { print \\$1 }"`
+			if [ ! -z "$VM_TO_DESTROY" ]; then
+				echo === Destroying VM with id $VM_TO_DESTROY
+				vagrant destroy -f $VM_TO_DESTROY
+			else
+				echo === NOT DESTROYING ANY VM as no suitable ID was found searching for $OS and ${gitFork}-${gitBranch}
+			fi
 			echo === Final status:
 			vagrant global-status --prune
 			free
+		done
 	else
 		echo "You have chosen to retain the VM. It will not be destroyed"
 	fi
 }
 
-trap 'destroyVM $vagrantOS' EXIT
+trap 'destroyVM' EXIT
 
 processArgs $*
 checkVars
@@ -413,5 +415,5 @@ do
   	if [[ "$vmHalt" == true ]]; then
                 vagrant halt 
 	fi
-	destroyVM $OS
 done
+destroyVM


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/2581
