### PR TITLE
ansible: skip restart docker service if not tag "docker" on playbook

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
@@ -72,7 +72,7 @@
 - name: Enable and Start Docker Service for Ubuntu, Debian, SLES12, CentOS7  and RHEL7
   service:
     name: docker
-    state: restarted
+    state: started
     enabled: yes
   when:
     - (ansible_distribution == "Ubuntu" or ansible_distribution == "Debian") or (ansible_distribution == "SLES" and ansible_distribution_major_version == "12") or ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS" ) and ansible_distribution_major_version == "7")


### PR DESCRIPTION
- we should not try to restart docker service (e.g in job https://ci.adoptopenjdk.net/blue/organizations/jenkins/centos7_docker_image_updater/ which does not first install docker packages, the cmd we use is `ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags=debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit)`
Fixes: https://github.com/adoptium/infrastructure/issues/2599
- error in GH action check on macos: Error: Calling Cask::DSL::Version#before_colon is disabled! Use Cask::DSL::Version#csv instead. see log: https://github.com/adoptium/infrastructure/runs/6876366759?check_suite_focus=true
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->


##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
