### PR TITLE
unixPB: Fix Alpine boot JDKs on x64

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -81,7 +81,7 @@
     - role: adoptopenjdk_install
       jdk_version: 8
       when:
-        - ansible_distribution != "Alpine"
+        - (ansible_distribution != "Alpine" or ansible_architecture != "aarch64")
         - ansible_architecture != "riscv64"
       tags: build_tools
     - role: adoptopenjdk_install  # JDK11 Build Bootstrap
@@ -94,7 +94,7 @@
     - role: adoptopenjdk_install
       jdk_version: 11
       when:
-        - ansible_distribution != "Alpine"
+        - (ansible_distribution != "Alpine" or ansible_architecture != "aarch64")
         - ansible_distribution != "Solaris"
         - ansible_architecture != "riscv64"
       tags: build_tools


### PR DESCRIPTION
Don't skip installing 8 and 11 boot JDKs from the normal adoptopenjdk_install role on Alpine/64
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) N/A as it doesn't test Alpine
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
