### PR TITLE
unixPB: Avoid attempting to install ccache on RHEL7

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -58,11 +58,9 @@ Additional_Build_Tools_RHEL8:
   - glibc-langpack-zh             # required for creating Chinese locales
   - git
   - cmake
-  - ccache
 
 Additional_Build_Tools_RHEL7:
   - libstdc++-static
-  - ccache
 
 Additional_Build_Tools_RHEL7_PPC64LE:
   - libstdc++


### PR DESCRIPTION
Fixes https://github.com/adoptium/infrastructure/issues/2611
ccache will be installed from source later on in the playbook execution in the ccache role on those OSs
Partial revert of https://github.com/adoptium/infrastructure/pull/2241

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
VPC Not applicable as it does not operate on RHEL