### PR TITLE
github: Adjust templates to stop misinterpretation of checkboxes

### DIFF
--- a/.github/ISSUE_TEMPLATE/ansible.md
+++ b/.github/ISSUE_TEMPLATE/ansible.md
@@ -8,8 +8,10 @@ assignees: ''
 ---
 Please put the name of the software product (and affected platforms if relevant) in the title of this issue
 
-- [ ] Missing install
-- [ ] Bug in ansible playbook
-- [ ] Request for new playbook addition
+Delete as appropriate from this list:
+
+- Missing install
+- Bug in ansible playbook
+- Request for new playbook addition
 
 Details:

--- a/.github/ISSUE_TEMPLATE/machineaccess.md
+++ b/.github/ISSUE_TEMPLATE/machineaccess.md
@@ -6,7 +6,8 @@ labels: 'Temp Infra Access'
 assignees: 'sxa'
 
 ---
-Access level:
+Required access level (Delete as appropriate). Note that you should only
+request the minimum level that is required to solve your problem
 
 - [ ] Non-privileged
 - [ ] jenkins user

--- a/.github/ISSUE_TEMPLATE/teamaccess.md
+++ b/.github/ISSUE_TEMPLATE/teamaccess.md
@@ -6,11 +6,11 @@ labels: ''
 assignees: 'sxa'
 
 ---
-Team requested:
+Team requested - delete those which are not appicable :
 
-- [ ] infrastructure-triage
-- [ ] infrastructure
-- [ ] infrastructure-core
-- [ ] infrastructure-secret
+- infrastructure-triage
+- infrastructure
+- infrastructure-core
+- infrastructure-secret
 
 Please explain why you need this access:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,10 +4,11 @@ the requirements below.
 -->
 
 ##### Checklist
-<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->
+<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->
 
 - [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
 - [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
 - [ ] other documentation is changed or added (if applicable)
 - [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
+- [ ] VPC/QPC not applicable for this PR
 - [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly


### PR DESCRIPTION
This will avoid github misinterpreting our checkboxes, since by
default github shows how many of these are complete, which is
confusing, so we ask PR submitters to remove lines that are invalid

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)

