### PR TITLE
unixPB: remove two package for docker installaion

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
@@ -43,8 +43,6 @@
       package:
         name:
           - docker-ce
-          - containerd.io
-          - docker-ce-cli
         state: latest   # TODO: Package installs should not use latest
         use: auto       # automatic select package manager to use yum, apt and so on
       when: ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version == "7")) or (ansible_distribution == "Ubuntu" or ansible_distribution == "Debian")


### PR DESCRIPTION
	- as dependencies they will be installed by "package"

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Fixes: https://github.com/adoptium/infrastructure/issues/2610
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
