### PR TITLE
ansible: disable installing freemarker on unix, win and mac

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
@@ -132,53 +132,53 @@
     ##############
     # freemarker #
     ##############
-    - name: Add freemarker to jenkins
-      block:
-        - name: Check for freemarker.jar existence
-          stat:
-            path: /home/{{ Jenkins_Username }}/freemarker.jar
-          register: freemarker
-          tags:
-            - freemarker
+    # - name: Add freemarker to jenkins
+    #   block:
+    #     - name: Check for freemarker.jar existence
+    #       stat:
+    #         path: /home/{{ Jenkins_Username }}/freemarker.jar
+    #       register: freemarker
+    #       tags:
+    #         - freemarker
 
-        - name: "freemarker.jar found, skipping download"
-          debug:
-            msg: "freemarker.jar found, skipping download"
-          when: not freemarker.stat.exists
-          tags:
-            - freemarker
+    #     - name: "freemarker.jar found, skipping download"
+    #       debug:
+    #         msg: "freemarker.jar found, skipping download"
+    #       when: not freemarker.stat.exists
+    #       tags:
+    #         - freemarker
 
-        - name: Download and extract freemarker.jar
-          unarchive:
-            src: "https://sourceforge.net/{{ urldir }}/{{ urlfile }}"
-            dest: /tmp/
-            remote_src: true
-            owner: "{{ Jenkins_Username }}"
-            group: staff
-            mode: 0755
-          when: not freemarker.stat.exists
-          tags:
-            - freemarker
-          vars:
-            urldir: projects/freemarker/files/freemarker/2.3.8
-            urlfile: freemarker-2.3.8.tar.gz
+    #     - name: Download and extract freemarker.jar
+    #       unarchive:
+    #         src: "https://sourceforge.net/{{ urldir }}/{{ urlfile }}"
+    #         dest: /tmp/
+    #         remote_src: true
+    #         owner: "{{ Jenkins_Username }}"
+    #         group: staff
+    #         mode: 0755
+    #       when: not freemarker.stat.exists
+    #       tags:
+    #         - freemarker
+    #       vars:
+    #         urldir: projects/freemarker/files/freemarker/2.3.8
+    #         urlfile: freemarker-2.3.8.tar.gz
 
-        - name: Move freemarker.jar to /home/{{ Jenkins_Username }} folder
-          command:
-            cmd: mv /tmp/freemarker-2.3.8/lib/freemarker.jar
-              /home/{{ Jenkins_Username }}
-          when: not freemarker.stat.exists
-          tags:
-            - freemarker
+    #     - name: Move freemarker.jar to /home/{{ Jenkins_Username }} folder
+    #       command:
+    #         cmd: mv /tmp/freemarker-2.3.8/lib/freemarker.jar
+    #           /home/{{ Jenkins_Username }}
+    #       when: not freemarker.stat.exists
+    #       tags:
+    #         - freemarker
 
-        - name: Clean freemarker tmp files
-          file:
-            path: "{{ item }}"
-            state: absent
-          with_items:
-            - /tmp/freemarker-2.3.8
-            - /tmp/freemarker-2.3.8.tar.gz
-      tags: freemarker
+    #     - name: Clean freemarker tmp files
+    #       file:
+    #         path: "{{ item }}"
+    #         state: absent
+    #       with_items:
+    #         - /tmp/freemarker-2.3.8
+    #         - /tmp/freemarker-2.3.8.tar.gz
+    #   tags: freemarker
 
     ###################
     # NTP Time Server #

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -32,7 +32,7 @@
     - autoconf
     - curl
     - Jenkins_User                # AdoptOpenJDK Infrastructure
-    - role: freemarker            # OpenJ9
+#  - role: freemarker            # OpenJ9
       tags: [build_tools, build_tools_openj9]
     - role: macos_codesign
       tags: [adoptopenjdk, codesign]

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -33,7 +33,7 @@
     - curl
     - Jenkins_User                # AdoptOpenJDK Infrastructure
 #  - role: freemarker            # OpenJ9
-      tags: [build_tools, build_tools_openj9]
+#      tags: [build_tools, build_tools_openj9]
     - role: macos_codesign
       tags: [adoptopenjdk, codesign]
       when: ansible_distribution == "MacOSX"

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -46,7 +46,7 @@
     - cygwin
     - Firefox
     - Strawberry_Perl             # Testing
-    - Freemarker                  # OpenJ9
+#    - Freemarker                  # OpenJ9"
     - GIT
     - Java7                       # JDK8 build bootstrap
     - Java8                       # JDK9 build bootstrap/ For Gradle


### PR DESCRIPTION
	- it should only be used for openj9
Fixes: https://github.com/adoptium/infrastructure/issues/1898

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
