### PR TITLE
ansible: Keep Alpine building with 3.15 until OpenJDK supports

### DIFF
--- a/ansible/docker/Dockerfile.Alpine3
+++ b/ansible/docker/Dockerfile.Alpine3
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:3.15
 
 RUN apk update \
     && apk upgrade \


### PR DESCRIPTION
Alpine openjdk 8, 17+ currently won't compile with 3.16 and gcc 11.2 until fixed upstream: https://bugs.openjdk.org/browse/JDK-8288849

Signed-off-by: Andrew Leonard <anleonar@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR

