### PR TITLE
unixPb: Install shared-mime-info on fedora docker static containers

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.f33
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.f33
@@ -24,7 +24,7 @@ RUN chown -R jenkins /home/jenkins/.ssh
 RUN chmod -R og-rwx /home/jenkins/.ssh
 # RUN service ssh start
 CMD ["/usr/sbin/sshd","-D"]
-RUN yum install -y git curl make gcc xorg-x11-server-Xvfb libXrender libXi libXtst procps glibc-langpack-en fontconfig which hostname fakeroot
+RUN yum install -y git curl make gcc xorg-x11-server-Xvfb libXrender libXi libXtst procps glibc-langpack-en fontconfig which hostname fakeroot shared-mime-info
 # ENTRYPOINT /usr/lib/jvm/jdk8/bin/java
 EXPOSE 22
 # Start with docker run -p 2222:22 UUID

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.f34
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.f34
@@ -24,7 +24,7 @@ RUN chown -R jenkins /home/jenkins/.ssh
 RUN chmod -R og-rwx /home/jenkins/.ssh
 # RUN service ssh start
 CMD ["/usr/sbin/sshd","-D"]
-RUN yum install -y git curl make gcc xorg-x11-server-Xvfb libXrender libXi libXtst procps glibc-langpack-en fontconfig which hostname fakeroot
+RUN yum install -y git curl make gcc xorg-x11-server-Xvfb libXrender libXi libXtst procps glibc-langpack-en fontconfig which hostname fakeroot shared-mime-info
 # ENTRYPOINT /usr/lib/jvm/jdk8/bin/java
 EXPOSE 22
 # Start with docker run -p 2222:22 UUID

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.f35
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.f35
@@ -24,7 +24,7 @@ RUN chown -R jenkins /home/jenkins/.ssh
 RUN chmod -R og-rwx /home/jenkins/.ssh
 # RUN service ssh start
 CMD ["/usr/sbin/sshd","-D"]
-RUN yum install -y git curl make gcc xorg-x11-server-Xvfb libXrender libXi libXtst procps glibc-langpack-en fontconfig which hostname fakeroot
+RUN yum install -y git curl make gcc xorg-x11-server-Xvfb libXrender libXi libXtst procps glibc-langpack-en fontconfig which hostname fakeroot shared-mime-info
 # ENTRYPOINT /usr/lib/jvm/jdk8/bin/java
 EXPOSE 22
 # Start with docker run -p 2222:22 UUID


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/2631#issuecomment-1188992683

The jdk8 test java/nio/file/Files/probeContentType/Basic.java seems to pass on fedora only when this package is installed

Tested on test-docker-fedora36-x64-1

Before install
https://ci.adoptopenjdk.net/view/Test_grinder/job/Grinder/5225/

After install
https://ci.adoptopenjdk.net/view/Test_grinder/job/Grinder/5226/