### PR TITLE
unixPB: Remove gcc-7 package install as we use our self-built one

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
@@ -134,13 +134,6 @@
 ##########################
 # Additional build tools #
 ##########################
-- name: Call gcc-7 for all but arm32
-  package: "name={{ item }} state=latest"
-  with_items: "{{ gcc_7 }}"
-  when:
-    - ansible_architecture != "armv7l"
-    - ansible_architecture != "riscv64"
-  tags: build_tools
 
 - name: Call Build Packages and Tools Task for OpenJFX
   package: "name={{ item }} state=latest"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
@@ -144,9 +144,8 @@
   package: "name={{ item }} state=latest"
   with_items: "{{ gcc_compiler }}"
   when:
-    - (ansible_distribution_major_version != "9" and ansible_architecture != "armv7l")
     - ansible_architecture != "riscv64"
-    - ansible_distribution_major_version != "10"
+    - ansible_distribution_major_version == "10"
   tags: build_tools
 
 - name: Install GCC G++ on Raspian Buster

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Debian.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Debian.yml
@@ -61,8 +61,8 @@ OpenJFX_Build_Tool_Packages:
   - ruby
 
 gcc_compiler:
-  - g++-4.8
-  - gcc-4.8
+  - g++-7
+  - gcc-7
 
 Additional_Packages_Debian8:
   - libgstreamer0.10-dev                # OpenJFX prereq

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Debian.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Debian.yml
@@ -60,10 +60,6 @@ OpenJFX_Build_Tool_Packages:
   - libxxf86vm-dev
   - ruby
 
-gcc_7:                            # On all architectures but arm32 and riscv64
-  - g++-7                         # OpenJ9
-  - gcc-7                         # OpenJ9
-
 gcc_compiler:
   - g++-4.8
   - gcc-4.8

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
@@ -65,6 +65,8 @@ OpenJFX_Build_Tool_Packages:
 gcc_compiler:
   - g++-4.8
   - gcc-4.8
+  - gcc-7
+  - g++-7
 
 Additional_Packages_Ubuntu16:
   - xserver-xorg-legacy                 # Not actually sure if this is still needed
@@ -72,6 +74,8 @@ Additional_Packages_Ubuntu16:
   - libgstreamer-plugins-base0.10-dev   # OpenJFX prereq
   - libmpfr4
   - libmpfr4-dbg
+  - gcc-7                               # Our own one doesn't seem to work on Ubuntu16
+  - g++-7                               # Our own one doesn't seem to work on Ubuntu16
 
 Additional_Packages_Ubuntu18:
   - libgstreamer1.0-dev                 # OpenJFX prereq

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
@@ -80,19 +80,13 @@ Additional_Packages_Ubuntu18:
 Additional_Build_Tools_x86:
   - libnuma-dev
   - numactl
-  - gcc-7
-  - g++-7
   - gcc-multilib                        # a dependency required for executing a 32-bit C binary
 
 Additional_Build_Tools_ppc64le:
   - libnuma-dev
   - numactl
-  - gcc-7                         # OpenJ9
-  - g++-7                         # OpenJ9
 
 Additional_Build_Tools_s390x:
-  - gcc-7                         # OpenJ9
-  - g++-7                         # OpenJ9
   - numactl
   - libfreetype6-dev              # Needed by test state=installed
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_7/tasks/main.yml
@@ -7,7 +7,7 @@
   shell: /usr/local/gcc/bin/gcc-7.5 --version 2>&1 > /dev/null
   failed_when: false
   register: gcc7_installed
-  when: ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or (ansible_distribution == "Debian" and ansible_distribution_major_version == "10")
+  when: ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian")) or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= 22)
   changed_when: false
   tags: gcc_7
 
@@ -29,7 +29,7 @@
     mode: 0644
     checksum: "sha256:{{ lookup('vars', 'csum_' + ansible_architecture + '_' + gccsuffix) }}"
   when:
-    - ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or (ansible_distribution == "Debian" and ansible_distribution_major_version == "10")
+    - ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian")) or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= 22)
     - gcc7_installed.rc != 0
   tags: gcc_7
 
@@ -39,7 +39,7 @@
     dest: /usr/local/
     copy: False
   when:
-    - ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or (ansible_distribution == "Debian" and ansible_distribution_major_version == "10")
+    - ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian")) or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= 22)
     - gcc7_installed.rc != 0
   tags: gcc_7
 
@@ -48,7 +48,7 @@
     path: '/tmp/ansible-adoptopenjdk-gcc-7.tar.{{ gccsuffix }}'
     state: absent
   when:
-    - ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or (ansible_distribution == "Debian" and ansible_distribution_major_version == "10")
+    - ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian")) or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= 22)
     - gcc7_installed.rc != 0
   tags: gcc_7
 
@@ -59,7 +59,7 @@
     path: /usr/local/bin/ccache
   register: ccache_symlink
   when:
-    - ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or (ansible_distribution == "Debian" and ansible_distribution_major_version == "10")
+    - ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian")) or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= 22)
   tags: gcc_7
 
 - name: Create symlink for ccache
@@ -68,6 +68,6 @@
     dest: /usr/local/bin/ccache
     state: link
   when:
-    - ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or (ansible_distribution == "Debian" and ansible_distribution_major_version == "10")
+    - ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian")) or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= 22)
     - not ccache_symlink.stat.exists
   tags: gcc_7

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_7/tasks/main.yml
@@ -7,7 +7,7 @@
   shell: /usr/local/gcc/bin/gcc-7.5 --version 2>&1 > /dev/null
   failed_when: false
   register: gcc7_installed
-  when: ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
+  when: ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or (ansible_distribution == "Debian" and ansible_distribution_major_version == "10")
   changed_when: false
   tags: gcc_7
 
@@ -29,7 +29,7 @@
     mode: 0644
     checksum: "sha256:{{ lookup('vars', 'csum_' + ansible_architecture + '_' + gccsuffix) }}"
   when:
-    - ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
+    - ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or (ansible_distribution == "Debian" and ansible_distribution_major_version == "10")
     - gcc7_installed.rc != 0
   tags: gcc_7
 
@@ -39,7 +39,7 @@
     dest: /usr/local/
     copy: False
   when:
-    - ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
+    - ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or (ansible_distribution == "Debian" and ansible_distribution_major_version == "10")
     - gcc7_installed.rc != 0
   tags: gcc_7
 
@@ -48,7 +48,7 @@
     path: '/tmp/ansible-adoptopenjdk-gcc-7.tar.{{ gccsuffix }}'
     state: absent
   when:
-    - ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
+    - ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or (ansible_distribution == "Debian" and ansible_distribution_major_version == "10")
     - gcc7_installed.rc != 0
   tags: gcc_7
 
@@ -59,7 +59,7 @@
     path: /usr/local/bin/ccache
   register: ccache_symlink
   when:
-    - ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
+    - ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or (ansible_distribution == "Debian" and ansible_distribution_major_version == "10")
   tags: gcc_7
 
 - name: Create symlink for ccache
@@ -68,6 +68,6 @@
     dest: /usr/local/bin/ccache
     state: link
   when:
-    - ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_architecture == "armv7l" and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or ansible_distribution == "Debian"))
+    - ansible_distribution == "RedHat" or ansible_distribution == "Fedora" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or (ansible_distribution == "Debian" and ansible_distribution_major_version == "10")
     - not ccache_symlink.stat.exists
   tags: gcc_7


### PR DESCRIPTION
Not only do we use our self-built one, but GCC-7 is not available in the Ubuntu 22.04 repositories, so the playbook fails. We could bypass this on 22.04 and later, but since we do not use it for building it is simpler to remove it. We install the `gcc` package elsewhere so we will always have a system installed compiler even with this change.

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)  ([1492](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/1492/) failed due to https://github.com/adoptium/infrastructure/issues/2692, [1493](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/1493/) is testing with JDK11)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
