### PR TITLE
Dockerstatic: Add sles12 and sles15 dockerfiles

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.f35
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.f35
@@ -23,7 +23,7 @@ RUN echo "Jenkins_User_SSHKey" > /home/jenkins/.ssh/authorized_keys
 RUN chown -R jenkins /home/jenkins/.ssh
 RUN chmod -R og-rwx /home/jenkins/.ssh
 # RUN service ssh start
-CMD ["/bin/bash"]
+CMD ["/usr/sbin/sshd","-D"]
 RUN yum install -y git curl make gcc xorg-x11-server-Xvfb libXrender libXi libXtst procps glibc-langpack-en fontconfig which hostname fakeroot
 # ENTRYPOINT /usr/lib/jvm/jdk8/bin/java
 EXPOSE 22

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.f35
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.f35
@@ -23,7 +23,7 @@ RUN echo "Jenkins_User_SSHKey" > /home/jenkins/.ssh/authorized_keys
 RUN chown -R jenkins /home/jenkins/.ssh
 RUN chmod -R og-rwx /home/jenkins/.ssh
 # RUN service ssh start
-CMD ["/usr/sbin/sshd","-D"]
+CMD ["/bin/bash"]
 RUN yum install -y git curl make gcc xorg-x11-server-Xvfb libXrender libXi libXtst procps glibc-langpack-en fontconfig which hostname fakeroot
 # ENTRYPOINT /usr/lib/jvm/jdk8/bin/java
 EXPOSE 22

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.sles12
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.sles12
@@ -1,6 +1,38 @@
 FROM registry.suse.com/suse/sles12sp5:latest
 
-RUN zypper ar https://download.opensuse.org/repositories/YaST:/SLE-12:/SP5/SLE_12_SP4/ sles12sp5
-RUN zypper ar http://download.opensuse.org/distribution/12.3/repo/oss/ sles12oss
-RUN zypper refresh
-RUN zypper update && zypper -y install wget perl openssh-server unzip zip
+RUN zypper ar https://download.opensuse.org/distribution/leap/15.4/repo/oss/ sles15oss
+RUN zypper --gpg-auto-import-keys refresh
+RUN zypper update -y && zypper install -y wget perl openssh-server unzip zip tar gzip
+
+RUN wget 'https://api.adoptium.net/v3/binary/latest/11/ga/linux/s390x/jdk/hotspot/normal/eclipse?project=jdk' -O /tmp/jdk11.tar.gz
+RUN mkdir -p /usr/lib/jvm/jdk11 && tar -xpzf /tmp/jdk11.tar.gz -C /usr/lib/jvm/jdk11 --strip-components=1
+RUN ln -s /usr/lib/jvm/jdk11/bin/java /usr/bin/java
+
+# Install ant
+RUN wget -q -O /tmp/ant.zip 'https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.zip'
+RUN wget -q -O /tmp/ant-contrib.tar.gz  https://sourceforge.net/projects/ant-contrib/files/ant-contrib/ant-contrib-1.0b2/ant-contrib-1.0b2-bin.tar.gz
+RUN echo "2e48f9e429d67708f5690bc307232f08440d01ebe414059292b6543971da9c7cd259c21533b9163b4dd753321c17bd917adf8407d03245a0945fc30a4e633163  /tmp/ant.zip" > /tmp/ant.sha512
+RUN echo "0fd2771dca2b8b014a4cb3246715b32e20ad5d26754186d82eee781507a183d5e63064890b95eb27c091c93c1209528a0b18a6d7e6901899319492a7610e74ad  /tmp/ant-contrib.tar.gz" >> /tmp/ant.sha512
+RUN sha512sum --check --strict /tmp/ant.sha512
+RUN ln -s /usr/local/apache-ant-1.10.5/bin/ant /usr/bin/ant
+RUN unzip -q -d /usr/local /tmp/ant.zip
+RUN tar xpfz /tmp/ant-contrib.tar.gz -C /usr/local/apache-ant-1.10.5/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
+
+# Clear up space
+RUN rm /tmp/jdk11.tar.gz /tmp/ant.zip /tmp/ant-contrib.tar.gz
+
+# Set up jenkins user
+RUN useradd -m -d /home/jenkins jenkins
+RUN mkdir /home/jenkins/.ssh
+RUN echo "Jenkins_User_SSHKey" > /home/jenkins/.ssh/authorized_keys
+RUN chown -R jenkins /home/jenkins/.ssh
+RUN chmod -R og-rwx /home/jenkins/.ssh
+
+RUN ssh-keygen -A
+
+CMD ["/usr/sbin/sshd", "-D"]
+
+RUN zypper update -y && zypper install -y git curl make gcc libXrender1 libXi6 libXtst6 fontconfig fakeroot xorg-x11-server awk
+
+EXPOSE 22
+# Start with docker run -p 22XX:22 UUID

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.sles12
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.sles12
@@ -1,0 +1,6 @@
+FROM registry.suse.com/suse/sles12sp5:latest
+
+RUN zypper ar https://download.opensuse.org/repositories/YaST:/SLE-12:/SP5/SLE_12_SP4/ sles12sp5
+RUN zyper ar http://download.opensuse.org/distribution/12.3/repo/oss/ sles12oss
+RUN zypper refresh
+RUN zypper update && zypper -y install wget perl openssh-server unzip zip

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.sles12
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.sles12
@@ -1,6 +1,6 @@
 FROM registry.suse.com/suse/sles12sp5:latest
 
 RUN zypper ar https://download.opensuse.org/repositories/YaST:/SLE-12:/SP5/SLE_12_SP4/ sles12sp5
-RUN zyper ar http://download.opensuse.org/distribution/12.3/repo/oss/ sles12oss
+RUN zypper ar http://download.opensuse.org/distribution/12.3/repo/oss/ sles12oss
 RUN zypper refresh
 RUN zypper update && zypper -y install wget perl openssh-server unzip zip

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.sles15
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.sles15
@@ -1,5 +1,6 @@
-FROM opensuse/leap
+FROM registry.suse.com/suse/sle15
 
+RUN zypper addrepo https://download.opensuse.org/distribution/leap/15.4/repo/oss/ "Main Repository" && zypper --gpg-auto-import-keys refresh
 RUN zypper update -y && zypper install -y perl openssh-server unzip zip wget tar gzip
 
 RUN wget 'https://api.adoptium.net/v3/binary/latest/11/ga/linux/s390x/jdk/hotspot/normal/eclipse?project=jdk' -O /tmp/jdk11.tar.gz
@@ -26,11 +27,11 @@ RUN echo "Jenkins_User_SSHKey" > /home/jenkins/.ssh/authorized_keys
 RUN chown -R jenkins /home/jenkins/.ssh
 RUN chmod -R og-rwx /home/jenkins/.ssh
 
-#No such service: ssh
-# RUN service ssh start 
-CMD ["/bin/bash"]
+RUN ssh-keygen -A
+
+CMD ["/usr/sbin/sshd", "-D"]
 
 RUN zypper update -y && zypper install -y git curl make gcc libXrender1 libXi6 libXtst6 fontconfig fakeroot xorg-x11-server
-# RUN locale-gen en_US.utf8
 
-#Need to install locales and xvfb. Locales may already be installed. Using xorg-x11-server for xvfb
+EXPOSE 22
+# Start with docker run -p 22XX:22 UUID

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.sles15
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.sles15
@@ -1,0 +1,36 @@
+FROM opensuse/leap
+
+RUN zypper update -y && zypper install -y perl openssh-server unzip zip wget tar gzip
+
+RUN wget 'https://api.adoptium.net/v3/binary/latest/11/ga/linux/s390x/jdk/hotspot/normal/eclipse?project=jdk' -O /tmp/jdk11.tar.gz
+RUN mkdir -p /usr/lib/jvm/jdk11 && tar -xpzf /tmp/jdk11.tar.gz -C /usr/lib/jvm/jdk11 --strip-components=1
+RUN ln -s /usr/lib/jvm/jdk11/bin/java /usr/bin/java
+
+# Install ant
+RUN wget -q -O /tmp/ant.zip 'https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.zip'
+RUN wget -q -O /tmp/ant-contrib.tar.gz  https://sourceforge.net/projects/ant-contrib/files/ant-contrib/ant-contrib-1.0b2/ant-contrib-1.0b2-bin.tar.gz
+RUN echo "2e48f9e429d67708f5690bc307232f08440d01ebe414059292b6543971da9c7cd259c21533b9163b4dd753321c17bd917adf8407d03245a0945fc30a4e633163  /tmp/ant.zip" > /tmp/ant.sha512
+RUN echo "0fd2771dca2b8b014a4cb3246715b32e20ad5d26754186d82eee781507a183d5e63064890b95eb27c091c93c1209528a0b18a6d7e6901899319492a7610e74ad  /tmp/ant-contrib.tar.gz" >> /tmp/ant.sha512
+RUN sha512sum --check --strict /tmp/ant.sha512
+RUN ln -s /usr/local/apache-ant-1.10.5/bin/ant /usr/bin/ant
+RUN unzip -q -d /usr/local /tmp/ant.zip
+RUN tar xpfz /tmp/ant-contrib.tar.gz -C /usr/local/apache-ant-1.10.5/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
+
+# Clear up space
+RUN rm /tmp/jdk11.tar.gz /tmp/ant.zip /tmp/ant-contrib.tar.gz
+
+# Set up jenkins user
+RUN useradd -m -d /home/jenkins jenkins
+RUN mkdir /home/jenkins/.ssh
+RUN echo "Jenkins_User_SSHKey" > /home/jenkins/.ssh/authorized_keys
+RUN chown -R jenkins /home/jenkins/.ssh
+RUN chmod -R og-rwx /home/jenkins/.ssh
+
+#No such service: ssh
+# RUN service ssh start 
+CMD ["/usr/sbin/sshd","-D"]
+
+RUN zypper update -y && zypper install -y git curl make gcc libXrender1 libXi6 libXtst6 fontconfig fakeroot xorg-x11-server
+# RUN locale-gen en_US.utf8
+
+#Need to install locales and xvfb. Locales may already be installed. Using xorg-x11-server for xvfb

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.sles15
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.sles15
@@ -28,7 +28,7 @@ RUN chmod -R og-rwx /home/jenkins/.ssh
 
 #No such service: ssh
 # RUN service ssh start 
-CMD ["/usr/sbin/sshd","-D"]
+CMD ["/bin/bash"]
 
 RUN zypper update -y && zypper install -y git curl make gcc libXrender1 libXi6 libXtst6 fontconfig fakeroot xorg-x11-server
 # RUN locale-gen en_US.utf8


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

~Draft~ pr for sles12 and sles15 dockerfiles to be hosted on dockerhost-marist-ubuntu2204-s390x-1

ref https://github.com/adoptium/infrastructure/issues/2689