### PR TITLE
unixPB: remove unneeded repos from Ubuntu playbooks

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -22,18 +22,6 @@
   when: ansible_architecture == "aarch64"
   tags: patch_update
 
-- name: Add the openjdk repository to apt
-  apt_repository: repo='ppa:openjdk-r/ppa'
-  when:
-    - ansible_architecture != "armv7l"
-  tags: patch_update
-
-- name: Add the ubuntu toolchain repository to apt
-  apt_repository: repo='ppa:ubuntu-toolchain-r/test'
-  when:
-    - ansible_architecture != "armv7l"
-  tags: patch_update
-
 - name: Add Azul Zulu GPG Package Signing Key for x86_64
   apt_key:
     url: http://repos.azulsystems.com/RPM-GPG-KEY-azulsystems

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -22,6 +22,13 @@
   when: ansible_architecture == "aarch64"
   tags: patch_update
 
+- name: Add the ubuntu toolchain repository to apt for gcc-7 on Ubuntu 16.04
+  apt_repository: repo='ppa:ubuntu-toolchain-r/test'
+  when:
+    - ansible_architecture != "armv7l"
+    - ansible_distribution_major_version == "16"
+  tags: patch_update
+
 - name: Add Azul Zulu GPG Package Signing Key for x86_64
   apt_key:
     url: http://repos.azulsystems.com/RPM-GPG-KEY-azulsystems
@@ -34,21 +41,6 @@
   apt_repository: repo='deb http://repos.azulsystems.com/ubuntu stable main'
   when:
     - ansible_architecture == "x86_64"
-  tags: patch_update
-
-- name: Add additional repositories for BeagleBone
-  apt_repository: repo={{ item }}
-  with_items:
-    - deb https://deb.debian.org/debian/ stable main contrib non-free
-    - deb-src https://deb.debian.org/debian/ stable main contrib non-free
-    - deb https://deb.debian.org/debian/ stable-updates main contrib non-free
-    - deb-src https://deb.debian.org/debian/ stable-updates main contrib non-free
-    - deb https://deb.debian.org/debian-security stable/updates main
-    - deb-src https://deb.debian.org/debian-security stable/updates main
-    - deb http://ftp.debian.org/debian stretch-backports main
-    - deb-src http://ftp.debian.org/debian stretch-backports main
-  when:
-    - (ansible_distribution_major_version == "9" and ansible_architecture == "armv7l")
   tags: patch_update
 
 - name: Run apt-get upgrade
@@ -73,7 +65,6 @@
   package: "name={{ item }} state=latest"
   with_items: "{{ gcc_compiler }}"
   when:
-    - (ansible_distribution_major_version != "9" and ansible_architecture != "armv7l")
     - not (ansible_distribution_major_version >= "20")
   tags: build_tools
 


### PR DESCRIPTION
I do not believe these repositories are needed for anything. Will verify through VPC. Slight possibility they're needed on certain architectures, however we do not install openjdk-7-jdk on here (We do on Debian, hence not making the same changes there)

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) [VPC#1502](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/1502/)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
