### PR TITLE
unixPB: verify sha256sum of gmake 4.1 source

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gmake/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gmake/tasks/main.yml
@@ -14,6 +14,10 @@
   set_fact: makeVersion=4.1
   tags: goodmake_source
 
+# This SHA was determined by SHA after verifying the public key pulled from ubuntu's keyserver
+- name: Set make sha256sum
+  set_fact: makeVersionSHA=9fc7a9783d3d2ea002aa1348f851875a2636116c433677453cc1d1acc3fc4d55
+
 - name: Test if self-built make {{ makeVersion }} is available
   shell: /usr/local/bin/make --version >/dev/null
   failed_when: false
@@ -31,6 +35,8 @@
     url: https://ftp.gnu.org/gnu/make/make-{{ makeVersion }}.tar.gz
     dest: /tmp/make-{{ makeVersion }}.tar.gz
     mode: 0440
+    checksum: sha256:{{ makeVersionSHA }}
+
   when:
     - ((((ansible_distribution == "SLES" or ansible_distribution == "openSUSE") and ansible_distribution_major_version == "12") or
       (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "14")) and


### PR DESCRIPTION
We have not been verifying this source download. This fixes that omission.
The download has been verified with GPG using the key from the Ubuntu keyserver prior to generating the SHA checksum for inclusion into this file.

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/1505/
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
