### PR TITLE
Docker: Fix docker repo for s390x rhel

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/rhel.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/rhel.yml
@@ -12,7 +12,7 @@
     key: https://download.docker.com/linux/{{ OS }}/gpg
     state: present
 
-- name: Add Docker Repo
+- name: Add Docker Repo x86_64
   yum_repository:
     name: docker
     description: docker repository
@@ -38,7 +38,7 @@
   yum_repository:
     name: docker
     description: docker YUM repo s390x
-    baseurl: https://download.docker.com/linux/rhel/docker-ce.repo
+    baseurl: https://download.docker.com/linux/rhel/7/s390x/stable/
     enabled: true
     gpgcheck: false
   when:


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/2700

The former repo does not allow for docker to be installed onto our s390x rhel7 systems. Changing it to https://download.docker.com/linux/rhel/7/s390x/stable/ seems to work

https://awx2.adoptopenjdk.net/#/jobs/playbook/202?job_search=page_size:20;order_by:-finished;not__launch_type:sync
