### PR TITLE
GH: upgrade runner from macos-10.15 to macos-11

### DIFF
--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-10.15]
+        os: [macos-11]
     steps:
 
     - uses: actions/checkout@v2

--- a/FAQ.md
+++ b/FAQ.md
@@ -26,7 +26,7 @@ Most Ansible changes are tested automatically with a series of CI jobs:
 |---|---|---|
 | Centos 6 | [build.yml](./.github/workflows/build.yml) | |
 | Alpine 3 | [build.yml](./.github/workflows/build.yml) | |
-| macOS 10.15 | [build_mac.yml](./.github/workflows/build_mac.yml) | |
+| macOS 11 | [build_mac.yml](./.github/workflows/build_mac.yml) | |
 | Windows (2019 and 2022) | [build_wsl.yml](./.github/workflows/build_wsl.yml) | Uses Windows Subsystem for Linux to run ansible |
 | Solaris 10 | [build_vagrant.yml](./.github/workflows/build_vagrant.yml) | Uses Vagrant to run a Solaris image inside a macOS host |
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Fix: https://github.com/adoptium/infrastructure/issues/2715