### PR TITLE
Docker: Add Ansible support for docker on Rhel8

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
@@ -24,7 +24,7 @@
       include_tasks: rhel.yml
       when:
         - ansible_distribution == "RedHat" or ansible_distribution == "CentOS"
-        - ansible_distribution_major_version == "7" or ansible_distribution_major_version == "8"
+        - ansible_distribution_major_version >= "7"
 
     - name: Prepare for Ubuntu
       include_tasks: ubuntu.yml
@@ -45,7 +45,7 @@
           - docker-ce
         state: latest   # TODO: Package installs should not use latest
         use: auto       # automatic select package manager to use yum, apt and so on
-      when: ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version == "7" or ansible_distribution_major_version == "8")) or (ansible_distribution == "Ubuntu" or ansible_distribution == "Debian")
+      when: ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version >= "7")) or (ansible_distribution == "Ubuntu" or ansible_distribution == "Debian")
 
     - name: Install for SLES12 # zypper does not support in package module
       include_tasks: sles.yml

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
@@ -20,11 +20,11 @@
     ################
     # Pre Install  #
     ################
-    - name: Prepare for RHEL7/CentOS7
+    - name: Prepare for RHEL/CentOS 7/8
       include_tasks: rhel.yml
       when:
         - ansible_distribution == "RedHat" or ansible_distribution == "CentOS"
-        - ansible_distribution_major_version == "7"
+        - ansible_distribution_major_version == "7" or ansible_distribution_major_version == "8"
 
     - name: Prepare for Ubuntu
       include_tasks: ubuntu.yml
@@ -39,13 +39,13 @@
     ##################
     # Install Docker #
     ##################
-    - name: Install docker based on OS (Ubuntu, RHEL7, CentOS7, Debian)
+    - name: Install docker based on OS (Ubuntu, RHEL/CentOS 7/8, Debian)
       package:
         name:
           - docker-ce
         state: latest   # TODO: Package installs should not use latest
         use: auto       # automatic select package manager to use yum, apt and so on
-      when: ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version == "7")) or (ansible_distribution == "Ubuntu" or ansible_distribution == "Debian")
+      when: ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version == "7" or ansible_distribution_major_version == "8")) or (ansible_distribution == "Ubuntu" or ansible_distribution == "Debian")
 
     - name: Install for SLES12 # zypper does not support in package module
       include_tasks: sles.yml

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/rhel.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/rhel.yml
@@ -24,7 +24,7 @@
   yum_repository:
     name: docker
     description: docker YUM repo s390x
-    baseurl: https://download.docker.com/linux/{{ OS }}/{{ ansible_distribution_major_version }}/s390x/stable/
+    baseurl: https://download.docker.com/linux/rhel/{{ ansible_distribution_major_version }}/s390x/stable/
     enabled: true
     gpgcheck: false
   when:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/rhel.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/rhel.yml
@@ -10,7 +10,7 @@
     key: https://download.docker.com/linux/rhel/gpg
     state: present
 
-- name: Add Docker Repo x86-64/ppc64le 
+- name: Add Docker Repo x86-64/ppc64le
   yum_repository:
     name: docker
     description: docker repository

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/rhel.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/rhel.yml
@@ -3,51 +3,29 @@
 # Below enable different YUM repo not EPEL
 ##############
 #################CentOS####################################
-- name: Check OS to set variable rhel or centos
-  set_fact:
-    OS: "{{ 'rhel' if (ansible_distribution == 'RedHat') else (ansible_distribution | lower) }}"
 
-- name: Import Docker Repo key
-  rpm_key:
-    key: https://download.docker.com/linux/{{ OS }}/gpg
-    state: present
-
-- name: Add Docker Repo x86_64
+- name: Add Docker Repo x86-64/ppc64le 
   yum_repository:
     name: docker
     description: docker repository
-    baseurl: "https://download.docker.com/linux/{{ OS }}/$releasever/$basearch/stable"
+    baseurl: "https://download.docker.com/linux/centos/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/stable"
     enabled: true
     gpgcheck: false
   when:
-    - ansible_architecture == "x86_64"
+    - ansible_architecture == "x86_64" or ansible_architecture == "ppc64le"
 
-############special handle for architecture###################
-- name: Add Docker repo for ppc64le on RHEL7/Centos7
-  yum_repository:
-    name: docker
-    description: docker YUM repo ppc64le
-    baseurl: https://ftp.unicamp.br/pub/ppc64el/rhel/7/docker-ppc64el/
-    enabled: true
-    gpgcheck: false
-  when:
-    - ansible_architecture == "ppc64le"
-    - ansible_distribution_major_version == "7"
-
-- name: Add Docker repo for s390x on RHEL7
+- name: Add Docker repo for s390x on RHEL
   yum_repository:
     name: docker
     description: docker YUM repo s390x
-    baseurl: https://download.docker.com/linux/rhel/7/s390x/stable/
+    baseurl: https://download.docker.com/linux/{{ OS }}/{{ ansible_distribution_major_version }}/s390x/stable/
     enabled: true
     gpgcheck: false
   when:
     - ansible_architecture == "s390x"
 
-- name: Import Docker repo key for s390x on RHEL7
+# Same key for the Centos Repo
+- name: Import Docker Repo key
   rpm_key:
     key: https://download.docker.com/linux/rhel/gpg
     state: present
-  when:
-    - ansible_architecture == "s390x"
-    - ansible_distribution_major_version == "7"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/rhel.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/rhel.yml
@@ -4,6 +4,12 @@
 ##############
 #################CentOS####################################
 
+# Same key for the Centos Repo
+- name: Import Docker Repo key
+  rpm_key:
+    key: https://download.docker.com/linux/rhel/gpg
+    state: present
+
 - name: Add Docker Repo x86-64/ppc64le 
   yum_repository:
     name: docker
@@ -23,9 +29,3 @@
     gpgcheck: false
   when:
     - ansible_architecture == "s390x"
-
-# Same key for the Centos Repo
-- name: Import Docker Repo key
-  rpm_key:
-    key: https://download.docker.com/linux/rhel/gpg
-    state: present


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/2710

Added support for docker to be installed on rhel8 (ppc64, x64 and s390x)
Old ppc64le and x64 repo url no longer valid. Updated them to use a centos docker repo
The docker repo key is the same for rhel and centos