### PR TITLE
UnixPb: Install Cronie and Bzip2 for SLES

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/SLES.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/SLES.yml
@@ -7,6 +7,7 @@
 Build_Tool_Packages:
   - bind-utils
   - bison                         # OpenJ9
+  - bzip2
   - cpio
   - curl
   - flex

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/SLES.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/SLES.yml
@@ -9,6 +9,7 @@ Build_Tool_Packages:
   - bison                         # OpenJ9
   - bzip2
   - cpio
+  - cronie
   - curl
   - flex
   - gcc


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Cronie is needed for crontab tasks. 
Without bzip2, the [expat](https://github.com/adoptium/infrastructure/blob/7c29bb812d58c4df12cfa2dad1779f9f2c724fe8/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/SLES.yml#L240) tarball will not extract