### PR TITLE
unixPB: Do not install 31-bit support files on RHEL/s390x

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -95,11 +95,12 @@
     - ansible_architecture == "ppc64"
   tags: build_tools
 
-- name: Install additional build tools for RHEL on s390x
+- name: Install additional build tools for RHEL7 on s390x (31-bit support)
   package: "name={{ item }} state=latest"
-  with_items: "{{ Additional_Build_Tools_RHEL_s390x }}"
+  with_items: "{{ Additional_Build_Tools_RHEL7_s390x }}"
   when:
     - ansible_architecture == "s390x"
+    - (ansible_distribution_major_version == "7")
   tags: build_tools
 
 - name: Install additional build tools for RHEL 8

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -95,12 +95,12 @@
     - ansible_architecture == "ppc64"
   tags: build_tools
 
-- name: Install additional build tools for RHEL7 on s390x (31-bit support)
+- name: Install additional build tools for RHEL6/7 on s390x (31-bit support)
   package: "name={{ item }} state=latest"
   with_items: "{{ Additional_Build_Tools_RHEL7_s390x }}"
   when:
     - ansible_architecture == "s390x"
-    - (ansible_distribution_major_version == "7")
+    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
   tags: build_tools
 
 - name: Install additional build tools for RHEL 8

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -75,7 +75,7 @@ Additional_Build_Tools_RHEL_ppc64:
   - glibc-devel.ppc               # a dependency required for executing a 32-bit C binary
   - libstdc++.ppc                 # a dependency required for executing a 32-bit C binary
 
-Additional_Build_Tools_RHEL_s390x:
+Additional_Build_Tools_RHEL7_s390x:
   - glibc.s390                    # a dependency required for executing a 32-bit C binary
   - glibc-devel.s390              # a dependency required for executing a 32-bit C binary
   - libstdc++.s390                # a dependency required for executing a 32-bit C binary


### PR DESCRIPTION
Packages do not exist on RHEL8 and later, therefore do not attempt to install them.

Fixes https://github.com/adoptium/infrastructure/issues/2725 https://github.com/adoptium/infrastructure/issues/2702

NOTE TO REVIEWERS: Linter issues unrelated to this PR

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) 
- [x] VPC/QPC not applicable for this PR: n/a as VPC does not have RHEL
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
