### PR TITLE
github: macos-12 for solaris

### DIFF
--- a/.github/workflows/build_vagrant.yml
+++ b/.github/workflows/build_vagrant.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-solaris:
     name: Solaris
-    runs-on: macos-10.15
+    runs-on: macos-12
     steps:
 
     - uses: actions/checkout@v2
@@ -19,7 +19,6 @@ jobs:
     - name: Install dependencies
       run: |
         brew install ansible
-        brew install --cask virtualbox
 
     - name: Setup Vagrant VM
       run: |
@@ -32,8 +31,10 @@ jobs:
         vagrantPORT=$(vagrant port | grep host | awk '{ print $4 }')
         rm -f playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx
         echo "[127.0.0.1]:${vagrantPORT}" >> playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx
+        [ ! -r $HOME/.ssh/known_hosts ] && touch $HOME/.ssh/known_hosts && chmod 644 $HOME/.ssh/known_hosts
+        ssh-keygen -R $(cat playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx)
         sed -i -e "s/.*hosts:.*/- hosts: all/g" playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
-        awk '{print}/^\[defaults\]$/{print "private_key_file = id_rsa"; print "timeout = 30"; print "remote_tmp = $HOME/.ansible/tmp"}' < ansible.cfg > ansible.cfg.tmp && mv ansible.cfg.tmp ansible.cfg
+        awk '{print}/^\[defaults\]$/{print "private_key_file = id_rsa"; print "timeout = 60"; print "remote_tmp = $HOME/.ansible/tmp"}' < ansible.cfg > ansible.cfg.tmp && mv ansible.cfg.tmp ansible.cfg
 
     - name: Run Ansible Playbook
       run: |


### PR DESCRIPTION
- according to https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
macos-12 has vagrant and virtualbox pre-installed, so no need brew install virtualbox again
- macos-11 does not and  add "brew install --cask vagrant" still problem to run it
- set the same config e.g ssh, time out etc in the action to match whats set in the vagrantPlaybookCheck.sh (as in VPC jobs)
-  this PR wont make GH action vagrant check on Solaris green, due to https://github.com/adoptium/infrastructure/issues/2694 need to be fixed as well. but using test with an existing [tnarik/solaris10-minimal](https://vagrantcloud.com/tnarik/solaris10-minimal) https://github.com/adoptium/infrastructure/runs/8232496747?check_suite_focus=true it is able to do "vagrant up" 

Fix: https://github.com/adoptium/infrastructure/issues/2717


##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
