### PR TITLE
Install default gcc and not attempt to do individual versions

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -28,12 +28,6 @@
     - ansible_architecture != "armv7l"
   tags: patch_update
 
-- name: Add the ubuntu toolchain repository to apt
-  apt_repository: repo='ppa:ubuntu-toolchain-r/test'
-  when:
-    - ansible_architecture != "armv7l"
-  tags: patch_update
-
 - name: Add Azul Zulu GPG Package Signing Key for x86_64
   apt_key:
     url: http://repos.azulsystems.com/RPM-GPG-KEY-azulsystems
@@ -81,12 +75,9 @@
   with_items: "{{ OpenJFX_Build_Tool_Packages }}"
   tags: [build_tools, build_tools_jfx]
 
-- name: Install GCC G++ on supported platforms
+- name: Install default GCC/G++ on supported platforms
   package: "name={{ item }} state=latest"
   with_items: "{{ gcc_compiler }}"
-  when:
-    - (ansible_distribution_major_version != "9" and ansible_architecture != "armv7l")
-    - not (ansible_distribution_major_version >= "20")
   tags: build_tools
 
 - name: Install additional build tools for x86

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -75,11 +75,6 @@
   with_items: "{{ OpenJFX_Build_Tool_Packages }}"
   tags: [build_tools, build_tools_jfx]
 
-- name: Install default GCC/G++ on supported platforms
-  package: "name={{ item }} state=latest"
-  with_items: "{{ gcc_compiler }}"
-  tags: build_tools
-
 - name: Install additional build tools for x86
   package: "name={{ item }} state=latest"
   with_items: "{{ Additional_Build_Tools_x86 }}"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
@@ -63,8 +63,8 @@ OpenJFX_Build_Tool_Packages:
   - ruby
 
 gcc_compiler:
-  - g++-4.8
-  - gcc-4.8
+  - g++
+  - gcc
 
 Additional_Packages_Ubuntu16:
   - libgstreamer0.10-dev                # OpenJFX prereq

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
@@ -62,10 +62,6 @@ OpenJFX_Build_Tool_Packages:
   - libxxf86vm-dev
   - ruby
 
-gcc_compiler:
-  - g++
-  - gcc
-
 Additional_Packages_Ubuntu16:
   - libgstreamer0.10-dev                # OpenJFX prereq
   - libgstreamer-plugins-base0.10-dev   # OpenJFX prereq
@@ -79,19 +75,13 @@ Additional_Packages_Ubuntu18:
 Additional_Build_Tools_x86:
   - libnuma-dev
   - numactl
-  - gcc-7
-  - g++-7
   - gcc-multilib                        # a dependency required for executing a 32-bit C binary
 
 Additional_Build_Tools_ppc64le:
   - libnuma-dev
   - numactl
-  - gcc-7                         # OpenJ9
-  - g++-7                         # OpenJ9
 
 Additional_Build_Tools_s390x:
-  - gcc-7                         # OpenJ9
-  - g++-7                         # OpenJ9
   - numactl
   - libfreetype6-dev              # Needed by test state=installed
 


### PR DESCRIPTION
Fixes https://github.com/adoptium/infrastructure/issues/2735
Introduced by https://github.com/adoptium/infrastructure/pull/2691 (arm32 specific)

The Temurin builds use our self-built compilers installed into /usr/local. As a courtesy to people who prefer to use the system installed ones and skip the installation of ours, we make those available too, along with other parts of the toolchains that may be required. This will default those versions to the normal `gcc` and `g++` on those distributions and not lock them to particular versions.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access): https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/1534
