### PR TITLE
UnixPb: Don't install 31bit libraries on rhel 8 or higher

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -95,11 +95,12 @@
     - ansible_architecture == "ppc64"
   tags: build_tools
 
-- name: Install additional build tools for RHEL on s390x
+- name: Install additional build tools for RHEL (<= 7) on s390x
   package: "name={{ item }} state=latest"
   with_items: "{{ Additional_Build_Tools_RHEL_s390x }}"
   when:
     - ansible_architecture == "s390x"
+    - ansible_distribution_major_version <= "7"
   tags: build_tools
 
 - name: Install additional build tools for RHEL 8


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Ref https://github.com/adoptium/infrastructure/issues/2725

The packages in https://github.com/adoptium/infrastructure/blob/236e3bac330514c36956d3af0a9488f29de4fe6d/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml#L78 are not available on Rhel8