### PR TITLE
winPB: Fix broken Visual Studio 2013 role to use local installation media

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -331,8 +331,9 @@ Several files will also need to be edited for Windows:
 To run the playbook against the VM, from the `openjdk-infrastructure/ansible` directory:
 
 ```bash
-ansible-playbook -i playbooks/AdoptOpenJDK_Windows_playbook/hosts.tmp -u vagrant --skip-tags jenkins,adoptopenjdk playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+ansible-playbook -i playbooks/AdoptOpenJDK_Windows_playbook/hosts.tmp -u vagrant --skip-tags jenkins,adoptopenjdk,MSVS_2013 playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
 ```
+Note: it is recommended to skip the MSVS_2013 CE installation role (MSVS_2013) as it is no longer globally available, and is expected to be removed at some point, and replaced with a later version of MSVS.
 
 Alternatively, [pbTestScripts/vagrantPlaybookCheck.sh](pbTestScripts/vagrantPlaybookCheck.sh) will do this for you when executing `./vagrantPlaybookCheck.sh -v Win2012 -u https://github.com/adoptopenjdk/openjdk-infrastructure --retainVM`
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/7-Zip/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/7-Zip/tasks/main.yml
@@ -6,10 +6,10 @@
 
 - name: Download 7-Zip (required to unpack MinGW-W64)
   win_get_url:
-    url: https://www.7-zip.org/a/7z1805-x64.exe
+    url: https://www.7-zip.org/a/7z2201-x64.exe
     dest: 'C:\temp\7z.exe'
     force: no
-    checksum: c1e42d8b76a86ea1890ad080e69a04c75a5f2c0484bdcd838dc8fa908dd4a84c
+    checksum: b055fee85472921575071464a97a79540e489c1c3a14b9bdfbdbab60e17f36e4
     checksum_algorithm: sha256
   tags: 7zip
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java_install/tasks/main.yml
@@ -2,7 +2,7 @@
 ################
 # Java_install #
 ################
-- name: Test if Java is already installed version: {{ jdk_version }}
+- name: Test if Java is already installed version {{ jdk_version }}
   win_stat:
     path: 'C:\openjdk\jdk-{{ jdk_version }}\bin'
   register: java_installed

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java_install/tasks/main.yml
@@ -2,7 +2,7 @@
 ################
 # Java_install #
 ################
-- name: Test if Java{{ jdk_version }} is already installed
+- name: Test if Java is already installed version: {{ jdk_version }}
   win_stat:
     path: 'C:\openjdk\jdk-{{ jdk_version }}\bin'
   register: java_installed

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2013/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2013/tasks/main.yml
@@ -17,7 +17,7 @@
   when: (not vs2013_installed.stat.exists)
   tags: MSVS_2013
 
-- name: unzip VS2013_COMMUNITY_LOCAL_MEDIA
+- name: Unzip VS2013_COMMUNITY_LOCAL_MEDIA
   win_unzip:
     src: C:\TEMP\VS2013_CE_MEDIA.zip
     dest: C:\TEMP\VS2013_CE_MEDIA

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2013/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2013/tasks/main.yml
@@ -9,18 +9,33 @@
   register: vs2013_installed
   tags: MSVS_2013
 
-- name: Download Visual Studio Community 2013
-  win_get_url:
-    url: 'https://go.microsoft.com/fwlink/?LinkId=532495'
-    dest: 'C:\TEMP\vs2013_community.exe'
-    force: no
+- name: Transfer VS2013_COMMUNITY_LOCAL_MEDIA
+  win_copy:
+    src: /Vendor_Files/windows/VS2013_CE_MEDIA.zip
+    dest: C:\TEMP\VS2013_CE_MEDIA.zip
+    remote_src: no
   when: (not vs2013_installed.stat.exists)
   tags: MSVS_2013
 
-- name: Install Visual Studio Community 2013
-  raw: 'C:\TEMP\vs2013_community.exe /Silent /NoRestart
-        /Log C:\TEMP\vs2013_install_log.txt'
+- name: unzip VS2013_COMMUNITY_LOCAL_MEDIA
+  win_unzip:
+    src: C:\TEMP\VS2013_CE_MEDIA.zip
+    dest: C:\TEMP\VS2013_CE_MEDIA
   when: (not vs2013_installed.stat.exists)
+  tags: MSVS_2013
+
+- name: Remove Zip File
+  win_file:
+    path: C:\TEMP\VS2013_CE_MEDIA.zip
+    state: absent
+
+- name: Install Visual Studio Community 2013
+  win_shell: 'C:\TEMP\VS2013_CE_MEDIA\vs_community.exe /Silent /NoRestart /Log C:\TEMP\vs2013_install_log.txt'
+  args:
+    executable: cmd
+  when: (not vs2013_installed.stat.exists)
+  register: vs2013_error
+  failed_when: vs2013_error.rc != 1 and vs2013_error.rc != 0
   tags: MSVS_2013
 
 - name: Register Visual Studio Community 2013 DIA SDK shared libraries
@@ -29,6 +44,11 @@
     - C:\Program Files (x86)\Microsoft Visual Studio 12.0\DIA SDK\bin\msdia120.dll
     - C:\Program Files (x86)\Microsoft Visual Studio 12.0\DIA SDK\bin\amd64\msdia120.dll
   tags: MSVS_2013
+
+- name: Remove Extracted VS2013 Installation Files
+  win_file:
+    path: C:\TEMP\VS2013_CE_MEDIA
+    state: absent
 
 - name: Reboot machine after Visual Studio installation
   win_reboot:


### PR DESCRIPTION
Update the VS2013 role to work from  local installation media.
This is only required until VS2013 is no longer used.
Fixes #2178

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
