### PR TITLE
UnixPb: Add (basic) logs role

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -5,7 +5,7 @@
 # Groups can be passed in as a command-line variable in Ansible playbook.
 # It can be defined as 'all' or a specific group which the host belongs to.
 # For example, it can be 'all' or 'x86' for when a host is in the group 'x86'.
-- hosts: "{{ Groups | default('localhost:build:test:perf:jck:!*zos*:!*win*:!*aix*') }}"
+- hosts: all
   gather_facts: yes
   tasks:
     - block:
@@ -14,14 +14,6 @@
           include_vars: group_vars/all/adoptopenjdk_variables.yml
   environment:
     PATH: "/opt/csw/bin/:/usr/local/bin:/opt/homebrew/bin:{{ ansible_env.PATH }}"
-
-  pre_tasks:
-    - name: Logs
-      lineinfile:
-        create: yes
-        path: /home/jenkins/ansible.log
-        insertafter: EOF
-        line: "{{ ansible_date_time.date }} -- {{ ansible_date_time.time }}"
 
   #########
   # Roles #
@@ -139,3 +131,5 @@
     - IPv6
     - role: disable_gui
       tags: adoptopenjdk
+    - role: logs
+      tags: always

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -5,7 +5,7 @@
 # Groups can be passed in as a command-line variable in Ansible playbook.
 # It can be defined as 'all' or a specific group which the host belongs to.
 # For example, it can be 'all' or 'x86' for when a host is in the group 'x86'.
-- hosts: all
+- hosts: "{{ Groups | default('localhost:build:test:perf:jck:!*zos*:!*win*:!*aix*') }}"
   gather_facts: yes
   tasks:
     - block:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -15,6 +15,14 @@
   environment:
     PATH: "/opt/csw/bin/:/usr/local/bin:/opt/homebrew/bin:{{ ansible_env.PATH }}"
 
+  pre_tasks:
+    - name: Logs
+      lineinfile:
+        create: yes
+        path: /home/jenkins/ansible.log
+        insertafter: EOF
+        line: "{{ ansible_date_time.date }} -- {{ ansible_date_time.time }}"
+
   #########
   # Roles #
   #########

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
@@ -1,0 +1,40 @@
+# Updates $HOME/ansible.log with the date and time of latest ansible playbook run
+
+- name: Set variables (Linux)
+  set_fact:
+    home_path: /home/{{ Jenkins_Username }}
+    user_group: "{{ Jenkins_Username }}"
+  when:
+    - ansible_distribution != "MacOSX"
+    - ansible_distribution != "Solaris"
+
+- name: Set variables (MacOS)
+  set_fact:
+    home_path: /Users/{{ Jenkins_Username }}
+    user_group: "staff"
+  when:
+    - ansible_distribution == "MacOSX"
+
+- name: Set variables (Solaris)
+  set_fact:
+    home_path: /export/home/{{ Jenkins_Username }}
+    user_group: "{{ Jenkins_Username }}"
+  when:
+    - ansible_distribution == "Solaris"
+
+- name: Check if Jenkins user exists
+  stat:
+    path: "{{ home_path }}"
+  register: home_exists
+
+- name: Update Log File
+  lineinfile:
+    owner: "{{ Jenkins_Username }}"
+    group: "{{ user_group }}"
+    create: yes
+    path: "{{ home_path }}/ansible.log"
+    insertafter: EOF
+    line: "{{ ansible_date_time.date }} -- {{ ansible_date_time.time }}"
+  become: yes
+  become_user: root
+  when: home_exists.stat.isdir

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
@@ -38,4 +38,4 @@
     line: "{{ ansible_date_time.date }} -- {{ ansible_date_time.time }}"
   become: yes
   become_user: root
-  when: home_exists.stat.isdir
+  when: home_exists.stat.exists

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 # Updates $HOME/ansible.log with the date and time of latest ansible playbook run
 
 - name: Set variables (Linux)


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/2745

This is currently very rudimentary. All it does it update a file on the remote host whenever the playbook is run to indicate the date and time of the run.

Limitations (to hopefully be resolved once pr is ready for review):

~Only runs when playbook is run as a whole. Not run if tags are specified~
~Only indicates date and time, specific tags/roles and a 'git hash' of the playbook should be included~

Feel free to provide feedback 

