### PR TITLE
UnixPB: Update CRIU role for Ubuntu

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/criu/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/criu/tasks/main.yml
@@ -6,7 +6,7 @@
 ##############################################################
 
 - name: Set CRIU version on Ubuntu
-  set_fact: criuVersion=3.16.1
+  set_fact: criuVersion=3.17.1
   when:
     - ansible_architecture == "x86_64"
     - ansible_distribution == "Ubuntu"
@@ -185,8 +185,17 @@
     - ansible_distribution_major_version == "7"
   tags: criu
 
+- name: Set other_capabilities variable on Ubuntu
+  set_fact: other_capabilities=cap_checkpoint_restore,
+  when:
+    - not criu_installed.stat.exists
+    - ansible_architecture == "x86_64"
+    - ansible_distribution == "Ubuntu"
+    - ansible_distribution_major_version == "22"
+  tags: criu
+
 - name: Set capablities for CRIU on Ubuntu
-  shell: setcap cap_sys_time,cap_dac_override,cap_chown,cap_setpcap,cap_setgid,cap_audit_control,cap_dac_read_search,cap_net_admin,cap_sys_chroot,cap_sys_ptrace,cap_fowner,cap_kill,cap_fsetid,cap_sys_resource,cap_setuid,cap_sys_admin=eip /usr/local/sbin/criu
+  shell: setcap {{ other_capabilities | default("") | quote }}cap_sys_time,cap_dac_override,cap_chown,cap_setpcap,cap_setgid,cap_audit_control,cap_dac_read_search,cap_net_admin,cap_sys_chroot,cap_sys_ptrace,cap_fowner,cap_kill,cap_fsetid,cap_sys_resource,cap_setuid,cap_sys_admin=eip /usr/local/sbin/criu
   when:
     - not criu_installed.stat.exists
     - ansible_architecture == "x86_64"


### PR DESCRIPTION
Upgrade version from v3.16 to 3.17.
Add cap_checkpoint_restore capabilities on Ubuntu 22.

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
