### PR TITLE
UnixPB: Add latest commit SHA to ansible.log file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,5 +63,5 @@ jobs:
         cache-from: type=registry,ref=adoptopenjdk/alpine3_build_image:latest
         cache-to: type=inline
         push: false
-      args:
-        - ${{ github.sha }}
+      env:
+        - git_sha: ${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,8 @@ jobs:
         cache-from: type=registry,ref=adoptopenjdk/centos6_build_image:latest
         cache-to: type=inline
         push: ${{ github.ref == 'refs/heads/master' }}
+      args:
+        - ${{ github.sha }}
 
   build-and-push-alpine3:
     name: Alpine3
@@ -61,3 +63,5 @@ jobs:
         cache-from: type=registry,ref=adoptopenjdk/alpine3_build_image:latest
         cache-to: type=inline
         push: false
+      args:
+        - ${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,8 +42,8 @@ jobs:
         cache-from: type=registry,ref=adoptopenjdk/centos6_build_image:latest
         cache-to: type=inline
         push: ${{ github.ref == 'refs/heads/master' }}
-      args:
-        - ${{ github.sha }}
+      env:
+        - git_sha: ${{ github.sha }}
 
   build-and-push-alpine3:
     name: Alpine3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         cache-to: type=inline
         push: ${{ github.ref == 'refs/heads/master' }}
       env:
-        - git_sha: $GITHUB_SHA
+        git_sha: ${{ github.sha }}
 
   build-and-push-alpine3:
     name: Alpine3
@@ -64,4 +64,4 @@ jobs:
         cache-to: type=inline
         push: false
       env:
-        - git_sha: $GITHUB_SHA
+        git_sha: ${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         cache-to: type=inline
         push: ${{ github.ref == 'refs/heads/master' }}
       env:
-        - git_sha: ${{ github.sha }}
+        - git_sha: github.sha
 
   build-and-push-alpine3:
     name: Alpine3
@@ -64,4 +64,4 @@ jobs:
         cache-to: type=inline
         push: false
       env:
-        - git_sha: ${{ github.sha }}
+        - git_sha: github.sha

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,12 +38,11 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         file: ./ansible/docker/Dockerfile.CentOS6
+        build-args: git_sha=${{ github.sha }}
         tags: adoptopenjdk/centos6_build_image:latest
         cache-from: type=registry,ref=adoptopenjdk/centos6_build_image:latest
         cache-to: type=inline
         push: ${{ github.ref == 'refs/heads/master' }}
-      env:
-        git_sha: ${{ github.sha }}
 
   build-and-push-alpine3:
     name: Alpine3
@@ -59,9 +58,8 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         file: ./ansible/docker/Dockerfile.Alpine3
+        build-args: git_sha=${{ github.sha }}
         tags: adoptopenjdk/alpine3_build_image:latest
         cache-from: type=registry,ref=adoptopenjdk/alpine3_build_image:latest
         cache-to: type=inline
         push: false
-      env:
-        git_sha: ${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         cache-to: type=inline
         push: ${{ github.ref == 'refs/heads/master' }}
       env:
-        - git_sha: github.sha
+        - git_sha: $GITHUB_SHA
 
   build-and-push-alpine3:
     name: Alpine3
@@ -64,4 +64,4 @@ jobs:
         cache-to: type=inline
         push: false
       env:
-        - git_sha: github.sha
+        - git_sha: $GITHUB_SHA

--- a/ansible/docker/Dockerfile.Alpine3
+++ b/ansible/docker/Dockerfile.Alpine3
@@ -1,5 +1,7 @@
 FROM alpine:3.15
 
+ARG git_sha
+
 RUN apk update \
     && apk upgrade \
     && apk add ansible

--- a/ansible/docker/Dockerfile.Alpine3
+++ b/ansible/docker/Dockerfile.Alpine3
@@ -4,14 +4,14 @@ RUN apk update \
     && apk upgrade \
     && apk add ansible
 
-COPY . /ansible
+COPY ../. /infrastructure
 
 RUN echo "localhost ansible_connection=local" > /ansible/hosts
 
 RUN set -eux; \
- cd /ansible; \
+ cd /infrastructure; \
  ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit"; \
- rm -rf /ansible; apk del ansible
+ rm -rf /infrastructure; apk del ansible
 
 ENV \
     JDK7_BOOT_DIR="/usr/lib/jvm/jdk8" \ 

--- a/ansible/docker/Dockerfile.Alpine3
+++ b/ansible/docker/Dockerfile.Alpine3
@@ -10,7 +10,7 @@ RUN echo "localhost ansible_connection=local" > /infrastructure/ansible/hosts
 
 RUN set -eux; \
  cd /infrastructure; \
- ansible-playbook -i ansible/hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit"; \
+ ansible-playbook -i ansible/hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml -e "git_sha=$GITHUB_SHA" --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit"; \
  rm -rf /infrastructure; apk del ansible
 
 ENV \

--- a/ansible/docker/Dockerfile.Alpine3
+++ b/ansible/docker/Dockerfile.Alpine3
@@ -10,7 +10,7 @@ RUN echo "localhost ansible_connection=local" > /infrastructure/ansible/hosts
 
 RUN set -eux; \
  cd /infrastructure; \
- ansible-playbook -i ansible/hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml -e "git_sha=$GITHUB_SHA" --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit"; \
+ ansible-playbook -i ansible/hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml -e "git_sha=$git_sha" --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit"; \
  rm -rf /infrastructure; apk del ansible
 
 ENV \

--- a/ansible/docker/Dockerfile.Alpine3
+++ b/ansible/docker/Dockerfile.Alpine3
@@ -6,11 +6,11 @@ RUN apk update \
 
 COPY ../. /infrastructure
 
-RUN echo "localhost ansible_connection=local" > /ansible/hosts
+RUN echo "localhost ansible_connection=local" > /infrastructure/ansible/hosts
 
 RUN set -eux; \
  cd /infrastructure; \
- ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit"; \
+ ansible-playbook -i ansible/hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit"; \
  rm -rf /infrastructure; apk del ansible
 
 ENV \

--- a/ansible/docker/Dockerfile.CentOS6
+++ b/ansible/docker/Dockerfile.CentOS6
@@ -1,5 +1,6 @@
 FROM centos:6.9
 
+ARG git_sha
 ARG user=jenkins
 
 # Install Python 3

--- a/ansible/docker/Dockerfile.CentOS6
+++ b/ansible/docker/Dockerfile.CentOS6
@@ -15,8 +15,8 @@ RUN echo "localhost ansible_connection=local" > /infrastructure/ansible/hosts
 
 RUN set -eux; \
  cd /infrastructure; \
- ansible-playbook -i ansible/hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml -e "git_sha=$GITHUB_SHA" --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit"; \
- ansible-playbook -i ansible/hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml -e "git_sha=$GITHUB_SHA" --tags="riscv"
+ ansible-playbook -i ansible/hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml -e "git_sha=$git_sha" --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit"; \
+ ansible-playbook -i ansible/hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml -e "git_sha=$git_sha" --tags="riscv"
 
 RUN rm -rf /infrastructure; yum remove -y ansible; yum clean all
 

--- a/ansible/docker/Dockerfile.CentOS6
+++ b/ansible/docker/Dockerfile.CentOS6
@@ -9,16 +9,16 @@ RUN sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-Base.repo; \
     yum -y install gcc openssl-devel bzip2-devel sqlite-devel sudo wget python3 epel-release; \
     yum -y install ansible
 
-COPY . /ansible
+COPY ../. /infrastructure
 
-RUN echo "localhost ansible_connection=local" > /ansible/hosts
+RUN echo "localhost ansible_connection=local" > /infrastructure/ansible/hosts
 
 RUN set -eux; \
- cd /ansible; \
+ cd /infrastructure; \
  ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit"; \
  ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --tags="riscv"
 
-RUN rm -rf /ansible; yum remove -y ansible; yum clean all
+RUN rm -rf /infrastructure; yum remove -y ansible; yum clean all
 
 RUN groupadd -g 1000 ${user}
 RUN useradd -c "Jenkins user" -d /home/${user} -u 1000 -g 1000 -m ${user}

--- a/ansible/docker/Dockerfile.CentOS6
+++ b/ansible/docker/Dockerfile.CentOS6
@@ -15,8 +15,8 @@ RUN echo "localhost ansible_connection=local" > /infrastructure/ansible/hosts
 
 RUN set -eux; \
  cd /infrastructure; \
- ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit"; \
- ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --tags="riscv"
+ ansible-playbook -i ansible/hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit"; \
+ ansible-playbook -i ansible/hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --tags="riscv"
 
 RUN rm -rf /infrastructure; yum remove -y ansible; yum clean all
 

--- a/ansible/docker/Dockerfile.CentOS6
+++ b/ansible/docker/Dockerfile.CentOS6
@@ -15,8 +15,8 @@ RUN echo "localhost ansible_connection=local" > /infrastructure/ansible/hosts
 
 RUN set -eux; \
  cd /infrastructure; \
- ansible-playbook -i ansible/hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit"; \
- ansible-playbook -i ansible/hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --tags="riscv"
+ ansible-playbook -i ansible/hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml -e "git_sha=$GITHUB_SHA" --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit"; \
+ ansible-playbook -i ansible/hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml -e "git_sha=$GITHUB_SHA" --tags="riscv"
 
 RUN rm -rf /infrastructure; yum remove -y ansible; yum clean all
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -5,7 +5,7 @@
 # Groups can be passed in as a command-line variable in Ansible playbook.
 # It can be defined as 'all' or a specific group which the host belongs to.
 # For example, it can be 'all' or 'x86' for when a host is in the group 'x86'.
-- hosts: "{{ Groups | default('localhost:build:test:perf:jck:!*zos*:!*win*:!*aix*') }}"
+- hosts: all
   gather_facts: yes
   tasks:
     - block:
@@ -19,6 +19,9 @@
   # Roles #
   #########
   roles:
+    - role: logs
+      position: "Start"
+      tags: always
     - Debug
     - role: Get_Vendor_Files
       tags: [vendor_files, adoptopenjdk, jenkins_user, nagios_plugins, superuser]
@@ -132,4 +135,5 @@
     - role: disable_gui
       tags: adoptopenjdk
     - role: logs
+      position: "End"
       tags: always

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -5,7 +5,7 @@
 # Groups can be passed in as a command-line variable in Ansible playbook.
 # It can be defined as 'all' or a specific group which the host belongs to.
 # For example, it can be 'all' or 'x86' for when a host is in the group 'x86'.
-- hosts: all
+- hosts: "{{ Groups | default('localhost:build:test:perf:jck:!*zos*:!*win*:!*aix*') }}"
   gather_facts: yes
   tasks:
     - block:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adopt_etc/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adopt_etc/tasks/main.yml
@@ -115,19 +115,3 @@
     state: present
     backup: yes
   tags: hosts_file, adoptopenjdk
-
-# This doesn't work as ansible says it can't write to the directory
-# Leaving this here in case someoen can make it work in the future
-#
-#- name: Record playbook completion with time in /var/log/ansiblerun.log
-#  lineinfile:
-#    state: present
-#    create: yes
-#    path: /var/tmp/ansiblerun.log
-#    mode: 0644
-#    line: "{{ ansible_date_time.iso8601_basic_short }} END"
-#  tags: ansiblerunlog
-
-# Version of the above that works
-- name: Record playbook completion with time in /var/log/ansiblerun.log
-  command: echo $(date +%Y%m%dT%H%M%S) >> /var/log/ansiblerun.log

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
@@ -17,15 +17,6 @@
   when:
     - ansible_distribution != "MacOSX"
 
-- name: Get PWD
-  shell: pwd
-  register: pwd_output
-  delegate_to: localhost
-
-- name: debug
-  debug:
-    msg: "{{ pwd_output }}"
-
 - name: Get Latest git commit SHA
   shell: git rev-parse HEAD
   register: output

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
@@ -30,6 +30,7 @@
   shell: git rev-parse HEAD
   register: output
   delegate_to: localhost
+  ignore_errors: yes
 
 - name: Update Log File
   lineinfile:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
@@ -28,15 +28,6 @@
     path: "{{ home_path }}"
   register: home_exists
 
-- name: pwd
-  shell: pwd
-  register: debugmsg
-  delegate_to: localhost
-
-- name: debug
-  debug:
-    msg: "{{ debugmsg }}"
-
 - name: Get Latest git commit SHA
   shell: git rev-parse HEAD
   register: output

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
@@ -17,39 +17,45 @@
   when:
     - ansible_distribution != "MacOSX"
 
-- name: List directory /infrastructure
-  shell: ls -la /infrastructure
-  register: ls_inf
-  delegate_to: localhost
+# - name: List directory /infrastructure
+#   shell: ls -la /infrastructure
+#   register: ls_inf
+#   delegate_to: localhost
 
-- name: List directory /
-  shell: ls -la /
-  register: ls_root_dir
-  delegate_to: localhost
+# - name: List directory /
+#   shell: ls -la /
+#   register: ls_root_dir
+#   delegate_to: localhost
 
-- name: List directory /infrastructure/ansible
-  shell: ls -la /infrastructure/ansible
-  register: ls_root_dir
-  delegate_to: localhost
+# - name: List directory /infrastructure/ansible
+#   shell: ls -la /infrastructure/ansible
+#   register: ls_root_dir
+#   delegate_to: localhost
 
-- name: List PWD
-  shell: pwd
-  register: pwd_output
-  delegate_to: localhost
+# - name: List PWD
+#   shell: pwd
+#   register: pwd_output
+#   delegate_to: localhost
 
-- name: Debug 
-  debug:
-    msg: "{{ item }}"
-  with_items:
-    - "{{ ls_inf.stdout }}"
-    - "{{ ls_root_dir.stdout }}"
-    - "{{ pwd_output.stdout }}"
+# - name: Debug 
+#   debug:
+#     msg: "{{ item }}"
+#   with_items:
+#     - "{{ ls_inf.stdout }}"
+#     - "{{ ls_root_dir.stdout }}"
+#     - "{{ pwd_output.stdout }}"
 
 - name: Get Latest git commit SHA
   shell: git rev-parse HEAD
   register: git_output
   delegate_to: localhost
   ignore_errors: yes
+  when: git_sha is not defined
+
+- name: Set git_output to git_sha
+  set_fact:
+    git_sha: "{{ git_output.stdout }}"
+  when: git_sha is not defined
 
 - name: Update Log File
   lineinfile:
@@ -58,6 +64,6 @@
     create: yes
     path: "{{ log_path }}/ansible.log"
     insertafter: EOF
-    line: "{{ ansible_date_time.date }} {{ ansible_date_time.time }} {{ git_output.stdout }}"
+    line: "{{ ansible_date_time.date }} {{ ansible_date_time.time }} {{ git_sha }}"
   become: yes
   become_user: root

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
@@ -1,47 +1,34 @@
 ---
 # Updates $HOME/ansible.log with the date and time of latest ansible playbook run
 
-- name: Set variables (Linux)
+- name: Set Log path
   set_fact:
-    home_path: /home/{{ Jenkins_Username }}
-    user_group: "{{ Jenkins_Username }}"
-  when:
-    - ansible_distribution != "MacOSX"
-    - ansible_distribution != "Solaris"
+    log_path: /var/log
 
 - name: Set variables (MacOS)
   set_fact:
-    home_path: /Users/{{ Jenkins_Username }}
     user_group: "staff"
   when:
     - ansible_distribution == "MacOSX"
 
-- name: Set variables (Solaris)
+- name: Set variables (Not MacOS)
   set_fact:
-    home_path: /export/home/{{ Jenkins_Username }}
-    user_group: "{{ Jenkins_Username }}"
+    user_group: "root"
   when:
-    - ansible_distribution == "Solaris"
-
-- name: Check if Jenkins user exists
-  stat:
-    path: "{{ home_path }}"
-  register: home_exists
+    - ansible_distribution != "MacOSX"
 
 - name: Get Latest git commit SHA
   shell: git rev-parse HEAD
   register: output
   delegate_to: localhost
-  when: home_exists.stat.exists
 
 - name: Update Log File
   lineinfile:
-    owner: "{{ Jenkins_Username }}"
+    owner: root
     group: "{{ user_group }}"
     create: yes
-    path: "{{ home_path }}/ansible.log"
+    path: "{{ log_path }}/ansible.log"
     insertafter: EOF
     line: "{{ ansible_date_time.date }} {{ ansible_date_time.time }} {{ output.stdout }}"
   become: yes
   become_user: root
-  when: home_exists.stat.exists

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
@@ -17,6 +17,34 @@
   when:
     - ansible_distribution != "MacOSX"
 
+- name: List directory /infrastructure
+  shell: ls -la /infrastructure
+  register: ls_inf
+  delegate_to: localhost
+
+- name: List directory /
+  shell: ls -la /
+  register: ls_root_dir
+  delegate_to: localhost
+
+- name: List directory /infrastructure/ansible
+  shell: ls -la /infrastructure/ansible
+  register: ls_root_dir
+  delegate_to: localhost
+
+- name: List PWD
+  shell: pwd
+  register: pwd_output
+  delegate_to: localhost
+
+- name: Debug 
+  debug:
+    msg: "{{ item }}"
+  with_items:
+    - "{{ ls_inf.stdout }}"
+    - "{{ ls_root_dir.stdout }}"
+    - "{{ pwd_output.stdout }}"
+
 - name: Get Latest git commit SHA
   shell: git rev-parse HEAD
   register: git_output

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
@@ -17,6 +17,10 @@
   when:
     - ansible_distribution != "MacOSX"
 
+- name: Get Date and Time
+  shell: date +%Y-%m-%d\ %H:%M:%S
+  register: date_output
+
 - name: Get Latest git commit SHA
   shell: git rev-parse HEAD
   register: git_output
@@ -36,6 +40,6 @@
     create: yes
     path: "{{ log_path }}/ansible.log"
     insertafter: EOF
-    line: "{{ ansible_date_time.date }} {{ ansible_date_time.time }} {{ git_sha }}"
+    line: "{{ position }} {{ date_output.stdout }} {{ git_sha }}"
   become: yes
   become_user: root

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
@@ -28,6 +28,21 @@
     path: "{{ home_path }}"
   register: home_exists
 
+- name: pwd
+  shell: pwd
+  register: debugmsg
+  delegate_to: localhost
+
+- name: debug
+  debug:
+    msg: "{{ debugmsg }}"
+
+- name: Get Latest git commit SHA
+  shell: git rev-parse HEAD
+  register: output
+  delegate_to: localhost
+  when: home_exists.stat.exists
+
 - name: Update Log File
   lineinfile:
     owner: "{{ Jenkins_Username }}"
@@ -35,7 +50,7 @@
     create: yes
     path: "{{ home_path }}/ansible.log"
     insertafter: EOF
-    line: "{{ ansible_date_time.date }} -- {{ ansible_date_time.time }}"
+    line: "{{ ansible_date_time.date }} {{ ansible_date_time.time }} {{ output.stdout }}"
   become: yes
   become_user: root
   when: home_exists.stat.exists

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
@@ -17,6 +17,15 @@
   when:
     - ansible_distribution != "MacOSX"
 
+- name: Get PWD
+  shell: pwd
+  register: pwd_output
+  delegate_to: localhost
+
+- name: debug
+  debug:
+    msg: "{{ pwd_output }}"
+
 - name: Get Latest git commit SHA
   shell: git rev-parse HEAD
   register: output

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
@@ -17,34 +17,6 @@
   when:
     - ansible_distribution != "MacOSX"
 
-# - name: List directory /infrastructure
-#   shell: ls -la /infrastructure
-#   register: ls_inf
-#   delegate_to: localhost
-
-# - name: List directory /
-#   shell: ls -la /
-#   register: ls_root_dir
-#   delegate_to: localhost
-
-# - name: List directory /infrastructure/ansible
-#   shell: ls -la /infrastructure/ansible
-#   register: ls_root_dir
-#   delegate_to: localhost
-
-# - name: List PWD
-#   shell: pwd
-#   register: pwd_output
-#   delegate_to: localhost
-
-# - name: Debug 
-#   debug:
-#     msg: "{{ item }}"
-#   with_items:
-#     - "{{ ls_inf.stdout }}"
-#     - "{{ ls_root_dir.stdout }}"
-#     - "{{ pwd_output.stdout }}"
-
 - name: Get Latest git commit SHA
   shell: git rev-parse HEAD
   register: git_output

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
@@ -19,7 +19,7 @@
 
 - name: Get Latest git commit SHA
   shell: git rev-parse HEAD
-  register: output
+  register: git_output
   delegate_to: localhost
   ignore_errors: yes
 
@@ -30,6 +30,6 @@
     create: yes
     path: "{{ log_path }}/ansible.log"
     insertafter: EOF
-    line: "{{ ansible_date_time.date }} {{ ansible_date_time.time }} {{ output.stdout }}"
+    line: "{{ ansible_date_time.date }} {{ ansible_date_time.time }} {{ git_output.stdout }}"
   become: yes
   become_user: root


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/2745

Adds the latest commit SHA to the logs stored on the remote machine in the jenkins directory. Thankfully, the default working directory of ansible seems to be the directory of the playbook, in this case the `main.yml` file. Which means `git rev-parse HEAD` will always be run in the correct directory.

Tested from my workstation and https://awx2.adoptopenjdk.net/#/jobs/playbook/485?job_search=page_size:20;order_by:-finished;not__launch_type:sync (includes debug tasks which I have removed)