### PR TITLE
Jenkins: Add centos6 build job to centos7_docker_image_updater jenkins job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,14 @@ pipeline {
     stages {
         stage('Docker Build') {
             parallel { 
+                stage('CentOS6 x64') {
+                    agent {
+                        label "dockerBuild&&linux&&x64"
+                    } 
+                    steps {
+                        dockerBuild('amd64', 'centos6', 'Dockerfile.CentOS6')
+                    }
+                }
                 stage('CentOS7 x64') {
                     agent {
                         label "dockerBuild&&linux&&x64"
@@ -82,6 +90,12 @@ def dockerManifest() {
     docker.withRegistry('https://index.docker.io/v1/', 'dockerhub') {
         git poll: false, url: 'https://github.com/adoptium/infrastructure.git'
         sh '''
+            # Centos6
+            export TARGET="adoptopenjdk/centos6_build_image"
+            AMD64=$TARGET:linux-amd64
+            docker manifest create $TARGET $AMD64
+            docker manifest annotate $TARGET $AMD64 --arch amd64 --os linux
+            docker manifest push $TARGET
             # Centos7
             export TARGET="adoptopenjdk/centos7_build_image"
             AMD64=$TARGET:linux-amd64


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/2753

If we're using this job to push the centos6 image to dockerhub, then am I correct to assume that we then do not have to push the image to dockerhub during the github workflow https://github.com/adoptium/infrastructure/blob/de2d533f614be45ea37d34082efc306f1e2f4e74/.github/workflows/build.yml#L20, and just use the pr workflow as a test?
