### PR TITLE
docker: Copy from the correct directory in Centos6 and Alpine dockerfiles

### DIFF
--- a/ansible/docker/Dockerfile.Alpine3
+++ b/ansible/docker/Dockerfile.Alpine3
@@ -6,14 +6,14 @@ RUN apk update \
     && apk upgrade \
     && apk add ansible
 
-COPY ../. /infrastructure
+COPY . /ansible
 
-RUN echo "localhost ansible_connection=local" > /infrastructure/ansible/hosts
+RUN echo "localhost ansible_connection=local" > /ansible/hosts
 
 RUN set -eux; \
- cd /infrastructure; \
- ansible-playbook -i ansible/hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml -e "git_sha=$git_sha" --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit"; \
- rm -rf /infrastructure; apk del ansible
+ cd /ansible; \
+ ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml -e "git_sha=$git_sha" --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit"; \
+ rm -rf /ansible; apk del ansible
 
 ENV \
     JDK7_BOOT_DIR="/usr/lib/jvm/jdk8" \ 

--- a/ansible/docker/Dockerfile.CentOS6
+++ b/ansible/docker/Dockerfile.CentOS6
@@ -10,16 +10,16 @@ RUN sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-Base.repo; \
     yum -y install gcc openssl-devel bzip2-devel sqlite-devel sudo wget python3 epel-release; \
     yum -y install ansible
 
-COPY ../. /infrastructure
+COPY . /ansible
 
-RUN echo "localhost ansible_connection=local" > /infrastructure/ansible/hosts
+RUN echo "localhost ansible_connection=local" > /ansible/hosts
 
 RUN set -eux; \
- cd /infrastructure; \
- ansible-playbook -i ansible/hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml -e "git_sha=$git_sha" --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit"; \
- ansible-playbook -i ansible/hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml -e "git_sha=$git_sha" --tags="riscv"
+ cd /ansible; \
+ ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml -e "git_sha=$git_sha" --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit"; \
+ ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml -e "git_sha=$git_sha" --tags="riscv"
 
-RUN rm -rf /infrastructure; yum remove -y ansible; yum clean all
+RUN rm -rf /ansible; yum remove -y ansible; yum clean all
 
 RUN groupadd -g 1000 ${user}
 RUN useradd -c "Jenkins user" -d /home/${user} -u 1000 -g 1000 -m ${user}


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/2760

Revert `copy directory` changes that I made in https://github.com/adoptium/infrastructure/pull/2751/files#diff-cdadf2592f693c4816b592c519b913084ed2de4a238be6dbf42f75464798334bL7

The changes to which level of the infra repo gets copied are obsolete in that pr since I was able to get the SHA to be passed in as a parameter. More so, these changes are causing a build failure on our alpine images in the centos7_docker_image_updater job

https://ci.adoptopenjdk.net/job/centos7_docker_image_updater/268/execution/node/63/log/
https://ci.adoptopenjdk.net/job/centos7_docker_image_updater/268/execution/node/77/log/

```
Step 4/7 : COPY ../. /infrastructure
COPY failed: forbidden path outside the build context: ../. ()
```