### PR TITLE
docker: Add dockerbuild file for Ubuntu 22.04

### DIFF
--- a/ansible/docker/Dockerfile.Ubuntu2204
+++ b/ansible/docker/Dockerfile.Ubuntu2204
@@ -1,0 +1,31 @@
+FROM ubuntu
+
+ARG user=jenkins
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get -y install git curl ansible
+
+COPY . /ansible
+
+RUN echo "localhost ansible_connection=local" > /ansible/hosts
+
+RUN set -eux; \
+ cd /ansible; \
+ ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit,ntp_time"
+
+RUN rm -rf /ansible
+
+RUN groupadd -g 1000 ${user}
+RUN useradd -c "Jenkins user" -d /home/${user} -u 1000 -g 1000 -m ${user}
+RUN mv /bin/uname /bin/uname.real && echo "/bin/uname.real \$@ | sed 's/aarch64/armv7l/g'" > /bin/uname && chmod 755 /bin/uname
+
+ENV \
+    JDK7_BOOT_DIR="/usr/lib/jvm/jdk8" \
+    JDK8_BOOT_DIR="/usr/lib/jvm/jdk8" \
+    JDK10_BOOT_DIR="/usr/lib/jvm/jdk-10" \
+    JDK11_BOOT_DIR="/usr/lib/jvm/jdk-11" \
+    JDK13_BOOT_DIR="/usr/lib/jvm/jdk-13" \
+    JDK14_BOOT_DIR="/usr/lib/jvm/jdk-14" \
+    JDKLATEST_BOOT_DIR="/usr/lib/jvm/jdk-14" \
+    JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"


### PR DESCRIPTION
Adding docker file for Ubuntu 22.04. For anyone that wants to build their own JDK in a dockerfile, using the latest Ubuntu 22.04 is likely the best option for a supported distribution. This is a modified version of the Ubuntu 16.04 with simpler prereqs for Ansible that can be used if desired. Note that Adoptium does not currently use this as a build image for any platforms (Although it's possible we'd use it if we started to build in Docker for RISC-V in the future)

This has been tested on arm32 for the purposes of validating a solution to https://github.com/adoptium/infrastructure/issues/2760#issuecomment-1263801235

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
