### PR TITLE
unixPB: Remove gcc-7 install from Ubuntu 16

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -22,13 +22,6 @@
   when: ansible_architecture == "aarch64"
   tags: patch_update
 
-- name: Add the ubuntu toolchain repository to apt for gcc-7 on Ubuntu 16.04
-  apt_repository: repo='ppa:ubuntu-toolchain-r/test'
-  when:
-    - ansible_architecture != "armv7l"
-    - ansible_distribution_major_version == "16"
-  tags: patch_update
-
 - name: Add Azul Zulu GPG Package Signing Key for x86_64
   apt_key:
     url: http://repos.azulsystems.com/RPM-GPG-KEY-azulsystems

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
@@ -67,8 +67,6 @@ Additional_Packages_Ubuntu16:
   - libgstreamer-plugins-base0.10-dev   # OpenJFX prereq
   - libmpfr4
   - libmpfr4-dbg
-  - gcc-7                               # Our own one doesn't seem to work on Ubuntu16
-  - g++-7                               # Our own one doesn't seem to work on Ubuntu16
 
 Additional_Packages_Ubuntu18:
   - libgstreamer1.0-dev                 # OpenJFX prereq


### PR DESCRIPTION
Follow on to https://github.com/adoptium/infrastructure/pull/2736 which seems to have caused problems with Ubuntu16 on arm32 based on comments in https://github.com/adoptium/infrastructure/issues/2760#issuecomment-1263801235

The error which this should resolve is:
```
failed: [localhost] (item=gcc-7) => {"ansible_loop_var": "item", "changed": false, "item": "gcc-7", "msg": "No package matching 'gcc-7' is available"}
failed: [localhost] (item=g++-7) => {"ansible_loop_var": "item", "changed": false, "item": "g++-7", "msg": "No package matching 'g++-7' is available"}
```

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) - https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/1554/
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
