### PR TITLE
ansible: Remove jinja name template errors

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -16,6 +16,7 @@ skip_list:
   - 'var-naming'     # var-naming File defines variable that violates variable naming standards
   - 'fqcn-builtins'  # Disable error introduced in ansible-lint 6.X (https://github.com/ansible/ansible-lint/pull/1908)
   - 'name[template]' # Jinja templates should only be at the end of ‘name’.
+  - 'template-instead-of-copy' # Replaced upstream in https://github.com/ansible/ansible-lint/pull/2512
 
 exclude_paths:
   - ./ansible/playbooks/adoptopenjdk_variables.yml # See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1926

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -13,8 +13,9 @@ skip_list:
   - '501'  # Become_user requires become to work as expected
   - '601'  # Don't compare to literal True/False
   - '602'  # Don't compare to empty string
-  - 'var-naming' # var-naming File defines variable that violates variable naming standards
-  - 'fqcn-builtins' # Disable error introduced in ansible-lint 6.X (https://github.com/ansible/ansible-lint/pull/1908)
+  - 'var-naming'     # var-naming File defines variable that violates variable naming standards
+  - 'fqcn-builtins'  # Disable error introduced in ansible-lint 6.X (https://github.com/ansible/ansible-lint/pull/1908)
+  - 'name[template]' # Jinja templates should only be at the end of ‘name’.
 
 exclude_paths:
   - ./ansible/playbooks/adoptopenjdk_variables.yml # See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1926


### PR DESCRIPTION
We have a number of instances where this policy of requiring jinja templates in `name:` clauses does not make sense e.g. when a path name is used (e.g. `/home/{{ Jenkins_User }}/somedir`) and I have not seen a compelling reason for this to be enforced, therefore I propose disabling it.

Ref: https://ansible-lint.readthedocs.io/rules/name/

Similarly when running the checks on this PR it was noticed that there is another error showing up in some of the rules. The second commit in skips that one too (I tried moving to warn_list: as per the snippet below but that didn't seem to work and it still showed as an error). Removal of this as an error is consistent with the comments made upstream in https://github.com/ansible/ansible-lint/pull/2512

```
warn_list:
  - 'template-instead-of-copy' # Replaced upstream in https://github.com/ansible/ansible-lint/pull/2512
```
Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] VPC/QPC not applicable for this PR
