### PR TITLE
Docker: Pass the git sha to the centos7 and ubuntu 16 dockerfiles

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,9 +69,9 @@ pipeline {
 
 def dockerBuild(architecture, distro, dockerfile) {
     git poll: false, url: 'https://github.com/adoptium/infrastructure.git'
-    echo "${env.GIT_COMMIT}"
+    def git_sha = "${env.GIT_COMMIT.trim()}"
     dockerImage = docker.build("adoptopenjdk/${distro}_build_image:linux-$architecture",
-        "-f ansible/docker/$dockerfile .")
+        "-f ansible/docker/$dockerfile .", "--build-arg git_sha=$git_sha")
     // dockerhub is the ID of the credentials stored in Jenkins 
     // docker.withRegistry('https://index.docker.io/v1/', 'dockerhub') {
     //     dockerImage.push()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
 def dockerBuild(architecture, distro, dockerfile) {
     git poll: false, url: 'https://github.com/adoptium/infrastructure.git'
     dockerImage = docker.build("adoptopenjdk/${distro}_build_image:linux-$architecture",
-        "-f ansible/docker/$dockerfile .", "--build-arg git_sha=${env.GIT_COMMIT}}")
+        "-f ansible/docker/$dockerfile .", "--build-arg git_sha=${env.GIT_COMMIT}")
     // dockerhub is the ID of the credentials stored in Jenkins 
     docker.withRegistry('https://index.docker.io/v1/', 'dockerhub') {
         dockerImage.push()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,8 +69,9 @@ pipeline {
 
 def dockerBuild(architecture, distro, dockerfile) {
     git poll: false, url: 'https://github.com/adoptium/infrastructure.git'
+    echo "${env.GIT_COMMIT}"
     dockerImage = docker.build("adoptopenjdk/${distro}_build_image:linux-$architecture",
-        "-f ansible/docker/$dockerfile .", "--build-arg git_sha=${env.GIT_COMMIT}")
+        "-f ansible/docker/$dockerfile .")
     // dockerhub is the ID of the credentials stored in Jenkins 
     // docker.withRegistry('https://index.docker.io/v1/', 'dockerhub') {
     //     dockerImage.push()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,7 @@ def dockerBuild(architecture, distro, dockerfile) {
     git poll: false, url: 'https://github.com/adoptium/infrastructure.git'
     def git_sha = "${env.GIT_COMMIT.trim()}"
     dockerImage = docker.build("adoptopenjdk/${distro}_build_image:linux-$architecture",
-        "-f ansible/docker/$dockerfile .", "--build-arg git_sha=$git_sha")
+        "--build-arg git_sha=$git_sha -f ansible/docker/$dockerfile .")
     // dockerhub is the ID of the credentials stored in Jenkins 
     // docker.withRegistry('https://index.docker.io/v1/', 'dockerhub') {
     //     dockerImage.push()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,17 +53,17 @@ pipeline {
                 }
             }
         }
-        stage('Docker Manifest') {
-            agent {
-                label "dockerBuild&&linux&&x64"
-            } 
-            environment {
-                DOCKER_CLI_EXPERIMENTAL = "enabled"
-            }
-            steps {
-                dockerManifest()
-            }
-        }
+        // stage('Docker Manifest') {
+        //     agent {
+        //         label "dockerBuild&&linux&&x64"
+        //     } 
+        //     environment {
+        //         DOCKER_CLI_EXPERIMENTAL = "enabled"
+        //     }
+        //     steps {
+        //         dockerManifest()
+        //     }
+        // }
     } 
 } 
 
@@ -72,8 +72,8 @@ def dockerBuild(architecture, distro, dockerfile) {
     dockerImage = docker.build("adoptopenjdk/${distro}_build_image:linux-$architecture",
         "-f ansible/docker/$dockerfile .", "--build-arg git_sha=${env.GIT_COMMIT}")
     // dockerhub is the ID of the credentials stored in Jenkins 
-    docker.withRegistry('https://index.docker.io/v1/', 'dockerhub') {
-        dockerImage.push()
+    // docker.withRegistry('https://index.docker.io/v1/', 'dockerhub') {
+    //     dockerImage.push()
     }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,7 +74,7 @@ def dockerBuild(architecture, distro, dockerfile) {
     // dockerhub is the ID of the credentials stored in Jenkins 
     // docker.withRegistry('https://index.docker.io/v1/', 'dockerhub') {
     //     dockerImage.push()
-    }
+    // }
 }
 
 def dockerManifest() { 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,17 +53,17 @@ pipeline {
                 }
             }
         }
-        // stage('Docker Manifest') {
-        //     agent {
-        //         label "dockerBuild&&linux&&x64"
-        //     } 
-        //     environment {
-        //         DOCKER_CLI_EXPERIMENTAL = "enabled"
-        //     }
-        //     steps {
-        //         dockerManifest()
-        //     }
-        // }
+        stage('Docker Manifest') {
+            agent {
+                label "dockerBuild&&linux&&x64"
+            } 
+            environment {
+                DOCKER_CLI_EXPERIMENTAL = "enabled"
+            }
+            steps {
+                dockerManifest()
+            }
+        }
     } 
 } 
 
@@ -73,9 +73,9 @@ def dockerBuild(architecture, distro, dockerfile) {
     dockerImage = docker.build("adoptopenjdk/${distro}_build_image:linux-$architecture",
         "--build-arg git_sha=$git_sha -f ansible/docker/$dockerfile .")
     // dockerhub is the ID of the credentials stored in Jenkins 
-    // docker.withRegistry('https://index.docker.io/v1/', 'dockerhub') {
-    //     dockerImage.push()
-    // }
+    docker.withRegistry('https://index.docker.io/v1/', 'dockerhub') {
+        dockerImage.push()
+    }
 }
 
 def dockerManifest() { 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
 def dockerBuild(architecture, distro, dockerfile) {
     git poll: false, url: 'https://github.com/adoptium/infrastructure.git'
     dockerImage = docker.build("adoptopenjdk/${distro}_build_image:linux-$architecture",
-        "-f ansible/docker/$dockerfile .")
+        "-f ansible/docker/$dockerfile .", "--build-arg git_sha=${env.GIT_COMMIT}}")
     // dockerhub is the ID of the credentials stored in Jenkins 
     docker.withRegistry('https://index.docker.io/v1/', 'dockerhub') {
         dockerImage.push()

--- a/ansible/docker/Dockerfile.CentOS7
+++ b/ansible/docker/Dockerfile.CentOS7
@@ -1,5 +1,6 @@
 FROM centos:7
 
+ARG git_sha
 ARG user=jenkins
 
 RUN yum -y update; yum -y install epel-release
@@ -11,7 +12,7 @@ RUN echo "localhost ansible_connection=local" > /ansible/hosts
 
 RUN set -eux; \
  cd /ansible; \
- ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit"
+ ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml -e "git_sha=$git_sha" --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit"
 
 RUN rm -rf /ansible; yum remove ansible; yum clean all
 

--- a/ansible/docker/Dockerfile.Ubuntu1604
+++ b/ansible/docker/Dockerfile.Ubuntu1604
@@ -1,5 +1,6 @@
 FROM ubuntu:16.04
 
+ARG git_sha
 ARG user=jenkins
 
 RUN apt-get update
@@ -21,7 +22,7 @@ RUN echo "localhost ansible_connection=local" > /ansible/hosts
 
 RUN set -eux; \
  cd /ansible; \
- ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit,ntp_time"
+ ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml -e "git_sha=$git_sha" --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit,ntp_time"
 
 RUN rm -rf /ansible
 

--- a/ansible/docker/Dockerfile.Ubuntu2204
+++ b/ansible/docker/Dockerfile.Ubuntu2204
@@ -12,7 +12,7 @@ RUN echo "localhost ansible_connection=local" > /ansible/hosts
 
 RUN set -eux; \
  cd /ansible; \
- ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml -e --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit,ntp_time"
+ ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit,ntp_time"
 
 RUN rm -rf /ansible
 

--- a/ansible/docker/Dockerfile.Ubuntu2204
+++ b/ansible/docker/Dockerfile.Ubuntu2204
@@ -1,6 +1,5 @@
 FROM ubuntu
 
-ARG git_sha
 ARG user=jenkins
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -13,7 +12,7 @@ RUN echo "localhost ansible_connection=local" > /ansible/hosts
 
 RUN set -eux; \
  cd /ansible; \
- ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml -e "git_sha=$git_sha" --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit,ntp_time"
+ ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml -e --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit,ntp_time"
 
 RUN rm -rf /ansible
 

--- a/ansible/docker/Dockerfile.Ubuntu2204
+++ b/ansible/docker/Dockerfile.Ubuntu2204
@@ -1,5 +1,6 @@
 FROM ubuntu
 
+ARG git_sha
 ARG user=jenkins
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -12,7 +13,7 @@ RUN echo "localhost ansible_connection=local" > /ansible/hosts
 
 RUN set -eux; \
  cd /ansible; \
- ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit,ntp_time"
+ ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml -e "git_sha=$git_sha" --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit,ntp_time"
 
 RUN rm -rf /ansible
 


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Alpine docker images are failing because they are not being passed the git_sha parameter. 
https://ci.adoptopenjdk.net/job/centos7_docker_image_updater/277/execution/node/58/log/

```
cd /ansible
/bin/sh: git_sha: parameter not set
The command '/bin/sh -c set -eux;  cd /ansible;  ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml -e "git_sha=$git_sha" --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit";  rm -rf /ansible; apk del ansible' returned a non-zero code: 2
```

Also added the git_sha to the centos7 and ubuntu16 dockerfiles

Using https://ci.adoptopenjdk.net/env-vars.html/ as a reference to get the git sha