### PR TITLE
unixPB: Adjust boot JDKs to current required ones. Remove JDK11

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -94,17 +94,10 @@
         - ansible_distribution != "Solaris"
         - ansible_architecture != "riscv64"
       tags: build_tools
-    - role: adoptopenjdk_install
+    - role: adoptopenjdk_install  # JDK11 is LTS and likely still relied on by some agents
       jdk_version: 11
       when:
         - (ansible_distribution != "Alpine" or ansible_architecture != "aarch64")
-        - ansible_distribution != "Solaris"
-        - ansible_architecture != "riscv64"
-      tags: build_tools
-    - role: adoptopenjdk_install  # JDK16 Build Bootstrap
-      jdk_version: 15
-      when:
-        - ansible_distribution != "Alpine"
         - ansible_distribution != "Solaris"
         - ansible_architecture != "riscv64"
       tags: build_tools
@@ -115,9 +108,23 @@
         - ansible_distribution != "Solaris"
         - ansible_architecture != "riscv64"
       tags: build_tools
-    - role: adoptopenjdk_install  # JDK18 Build Bootstrap
+    - role: adoptopenjdk_install  # Current LTS
       jdk_version: 17
       when:
+        - ansible_distribution != "Solaris"
+        - ansible_architecture != "riscv64"
+      tags: build_tools
+    - role: adoptopenjdk_install  # JDK19 Build Bootstrap
+      jdk_version: 18
+      when:
+        - ansible_distribution != "Alpine"
+        - ansible_distribution != "Solaris"
+        - ansible_architecture != "riscv64"
+      tags: build_tools
+    - role: adoptopenjdk_install  # JDK20 Build Bootstrap
+      jdk_version: 19
+      when:
+        - ansible_distribution != "Alpine"
         - ansible_distribution != "Solaris"
         - ansible_architecture != "riscv64"
       tags: build_tools


### PR DESCRIPTION
Based on the current set of supported java versions, this ensures that a suitable GA boot JDK is available on each system (18 and 19) so it doesn't have to be downloaded at build time.

Part of me also wants to remove JDK 8 and 11 as well but I'm not feeling that brave ... yet. Will be dependent on  https://github.com/adoptium/infrastructure/issues/2763 being complete and moving all systems to JDK17.

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/1565/ (Run without the change is at 1564 for comparison)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
