### PR TITLE
pbTests: Fix Issue With Windows VPC Not Running Tests

### DIFF
--- a/ansible/pbTestScripts/testJDKWin.sh
+++ b/ansible/pbTestScripts/testJDKWin.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Script to execute System tests on the previously built JDK.
-export HOME=c:/tmp/test
+export HOME=/cygdrive/c/tmp
 
 mv /cygdrive/c/tmp/workspace/build/src/build/*/images/jdk* $HOME
 # Ensures to set it to the JDK, not JRE or different images

--- a/ansible/pbTestScripts/testJDKWin.sh
+++ b/ansible/pbTestScripts/testJDKWin.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
 
 # Relocate Built JDKS
-mv /tmp/workspace/build/src/build/*/images/jdk* c:/tmp
+mv /cygdrive/c/tmp/workspace/build/src/build/*/images/jdk* c:/tmp
 
 # Remove Redundant Images
-rm -rf c:/tmp/*-debug-image
-rm -rf c:/tmp/*-jre
-rm -rf c:/tmp/*-test-image
+rm -rf /cygdrive/c/tmp/*-debug-image
+rm -rf /cygdrive/c/tmp/*-jre
+rm -rf /cygdrive/c/tmp/*-test-image
 
 #Identify The JDK
 
 # Set Test JDK HOME To The Relocated JDK
 # export TEST_JDK_HOME=C:/cygwin64$(find ~ -maxdepth 1 -type d -name "*jdk*"|grep -v ".*jre"| grep -v ".*-image")
-export TEST_JDK_HOME=`ls -d c:/tmp/jdk*|grep -v "static"|grep -v "debug"|grep -v "jre"|grep -v "test-image"`
+export TEST_JDK_HOME=`ls -d /cygdrive/c/tmp/jdk*|grep -v "static"|grep -v "debug"|grep -v "jre"|grep -v "test-image"`
 echo TEST_JDK_HOME=$TEST_JDK_HOME
 
-cd /tmp
+cd /cygdrive/c/tmp
 if [ ! -d "testLocation" ];
 then
 	echo "Creating testLocation directory"

--- a/ansible/pbTestScripts/testJDKWin.sh
+++ b/ansible/pbTestScripts/testJDKWin.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 
 # Relocate Built JDKS
-mv /tmp/workspace/build/src/build/*/images/jdk* /tmp
+mv /tmp/workspace/build/src/build/*/images/jdk* c:/tmp
 
 # Remove Redundant Images
-rm -rf /tmp/*-debug-image
-rm -rf /tmp/*-jre
-rm -rf /tmp/*-test-image
+rm -rf c:/tmp/*-debug-image
+rm -rf c:/tmp/*-jre
+rm -rf c:/tmp/*-test-image
 
 #Identify The JDK
 
 # Set Test JDK HOME To The Relocated JDK
 # export TEST_JDK_HOME=C:/cygwin64$(find ~ -maxdepth 1 -type d -name "*jdk*"|grep -v ".*jre"| grep -v ".*-image")
-export TEST_JDK_HOME=C:/tmp/$(find ~ -maxdepth 1 -type d -name "*jdk*"|grep -v "static")
+export TEST_JDK_HOME=`ls -d c:/tmp/jdk*|grep -v "static"|grep -v "debug"|grep -v "jre"|grep -v "test-image"`
 echo TEST_JDK_HOME=$TEST_JDK_HOME
 
 cd /tmp

--- a/ansible/pbTestScripts/testJDKWin.sh
+++ b/ansible/pbTestScripts/testJDKWin.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
-mv /cygdrive/c/tmp/workspace/build/src/build/*/images/jdk* $HOME
+mv /tmp/workspace/build/src/build/*/images/jdk* /tmp/jdk
 # Ensures to set it to the JDK, not JRE or different images
-export TEST_JDK_HOME=C:/cygwin64$(find ~ -maxdepth 1 -type d -name "*jdk*"|grep -v ".*jre"| grep -v ".*-image")
+# export TEST_JDK_HOME=C:/cygwin64$(find ~ -maxdepth 1 -type d -name "*jdk*"|grep -v ".*jre"| grep -v ".*-image")
+export TEST_JDK_HOME=C:/tmp/$(find ~ -maxdepth 1 -type d -name "*jdk*"|grep -v ".*jre"| grep -v ".*-image")
 
-cd $HOME
+cd /tmp
 if [ ! -d "testLocation" ];
 then
 	echo "Creating testLocation directory"

--- a/ansible/pbTestScripts/testJDKWin.sh
+++ b/ansible/pbTestScripts/testJDKWin.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# Script to execute System tests on the previously built JDK.
-export HOME=/cygdrive/c/tmp
-
 mv /cygdrive/c/tmp/workspace/build/src/build/*/images/jdk* $HOME
 # Ensures to set it to the JDK, not JRE or different images
 export TEST_JDK_HOME=C:/cygwin64$(find ~ -maxdepth 1 -type d -name "*jdk*"|grep -v ".*jre"| grep -v ".*-image")

--- a/ansible/pbTestScripts/testJDKWin.sh
+++ b/ansible/pbTestScripts/testJDKWin.sh
@@ -20,7 +20,7 @@ then
 fi
 cd openjdk-tests
 
-./get.sh -t $HOME/testLocation/openjdk-tests -p x64_windows
+./get.sh -T $HOME/testLocation/openjdk-tests -p x64_windows
 cd TKG
 export BUILD_LIST=system
 make compile

--- a/ansible/pbTestScripts/testJDKWin.sh
+++ b/ansible/pbTestScripts/testJDKWin.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
 
-mv /tmp/workspace/build/src/build/*/images/jdk* /tmp/jdk
-# Ensures to set it to the JDK, not JRE or different images
+# Relocate Built JDKS
+mv /tmp/workspace/build/src/build/*/images/jdk* /tmp
+
+# Remove Redundant Images
+rm -rf /tmp/*-debug-image
+rm -rf /tmp/*-jre
+rm -rf /tmp/*-test-image
+
+#Identify The JDK
+
+# Set Test JDK HOME To The Relocated JDK
 # export TEST_JDK_HOME=C:/cygwin64$(find ~ -maxdepth 1 -type d -name "*jdk*"|grep -v ".*jre"| grep -v ".*-image")
-export TEST_JDK_HOME=C:/tmp/$(find ~ -maxdepth 1 -type d -name "*jdk*"|grep -v ".*jre"| grep -v ".*-image")
+export TEST_JDK_HOME=C:/tmp/$(find ~ -maxdepth 1 -type d -name "*jdk*"|grep -v "static")
+echo TEST_JDK_HOME=$TEST_JDK_HOME
 
 cd /tmp
 if [ ! -d "testLocation" ];

--- a/ansible/pbTestScripts/testJDKWin.sh
+++ b/ansible/pbTestScripts/testJDKWin.sh
@@ -12,7 +12,7 @@ rm -rf /cygdrive/c/tmp/*-test-image
 
 # Set Test JDK HOME To The Relocated JDK
 # export TEST_JDK_HOME=C:/cygwin64$(find ~ -maxdepth 1 -type d -name "*jdk*"|grep -v ".*jre"| grep -v ".*-image")
-export TEST_JDK_HOME=`ls -d /cygdrive/c/tmp/jdk*|grep -v "static"|grep -v "debug"|grep -v "jre"|grep -v "test-image"`
+export TEST_JDK_HOME=`ls -d c:/tmp/jdk*|grep -v "static"|grep -v "debug"|grep -v "jre"|grep -v "test-image"`
 echo TEST_JDK_HOME=$TEST_JDK_HOME
 
 cd /cygdrive/c/tmp

--- a/ansible/pbTestScripts/testJDKWin.sh
+++ b/ansible/pbTestScripts/testJDKWin.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Script to execute System tests on the previously built JDK.
+export HOME=c:/tmp/test
 
 mv /cygdrive/c/tmp/workspace/build/src/build/*/images/jdk* $HOME
 # Ensures to set it to the JDK, not JRE or different images


### PR DESCRIPTION
Amend testJDKWin.sh for correct paths to build JDKs, and path definition issues.

Fixes #2772 

##### Checklist

- [X] commit message has one of the [standard prefixes]
- [X] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)

Successful VPC Run Here : 
https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/1570/