### PR TITLE
Adding a check for the machines with the build, windows & x64 labels 

### DIFF
--- a/ansible/playbooks/nagios/README.md
+++ b/ansible/playbooks/nagios/README.md
@@ -93,7 +93,7 @@ define command{
 
 ```bash
 	define service{
-		use                             local-service
+        use                             local-service
         host_name                       Nagios_Server
         check_period                    once-a-day-at-8
         service_description             Check Label- build/windows/x64

--- a/ansible/playbooks/nagios/README.md
+++ b/ansible/playbooks/nagios/README.md
@@ -63,7 +63,7 @@ Based off the [installation guide](https://support.nagios.com/kb/article/nagios-
 And Off This [GitRepo](https://github.com/Willsparker/AnsibleBoilerPlates/tree/main/Nagios) :
 For some useful tips for working with vault files see [here](https://docs.ansible.com/ansible/latest/user_guide/vault.html)
 
-## How to Add Additional Jenkins Check Label Job To Nagios Server Group For windows ##
+## How to add additional Jenkins Check Label Job To Nagios server group For Windows ##
 
 * The commands configuration file `commands.cfg` can be located at 
 ```bash

--- a/ansible/playbooks/nagios/README.md
+++ b/ansible/playbooks/nagios/README.md
@@ -99,6 +99,5 @@ define command{
         service_description             Check Label- build/windows/x64
         check_command                   check_label!build&&windows&&x64!75!30
         notifications_enabled           0
-
 	}
 ``

--- a/ansible/playbooks/nagios/README.md
+++ b/ansible/playbooks/nagios/README.md
@@ -1,20 +1,4 @@
-**IMPORTANT!**
 
-Currently the Nagios server (4.4.7) installation playbook has only been developed and tested on Ubuntu 22.04. Changes will be required if you wish to install a Nagios Server on a different host OS
-
-Ensure to update the ansible.cfg and nagios_inventory.yml files before running this playbook.
-
-**Repository Contents:**
-
-README.MD (This File)
-
-1) ./VagrantFiles/
-
-  This directory contains a vagrantfile that can be used to create a test server for running the Nagios_Server playbook on.
-
-  **NB: For the Ubuntu 2204 Vagrantfile, its recommended to use a minimum Vagrant version of 2.2.19-1**
-
-2) ./roles/*
 
 This directory houses the ansible roles used in the creation of the nagios server.
 
@@ -65,31 +49,7 @@ For some useful tips for working with vault files see [here](https://docs.ansibl
 
 ## How to add additional Jenkins Check Label Job To Nagios server group For Windows ##
 
-* The commands configuration file `commands.cfg` can be located at 
-```bash
-/usr/local/nagios/etc/objects/commands.cfg
-```
-
-* Navigate to
-
-```bash
-cd /usr/local/nagios/etc/objects
-```
-
-* Open commands.cfg in a text editor
-
-```bash
-nano commands.cfg
-```
-* add `check_build_windows_x64` command definition
-
-```bash
-define command{
-	    command_name	check_label_build_windows_x64
-	    command_line  $USER1$/check_build_windows_x64 "$ARG1$" $ARG2$ $ARG3$
-	}
-```
-*  Amend the machine specific config file, e.g ( /usr/local/nagios/etc/objects/localhost.cfg ) to include the entry for the new label check.
+*  Amend the Nagios server config file, e.g ( /usr/local/nagios/etc/objects/localhost.cfg ) to include the entry for the new label check.
 
 ```bash
 	define service{

--- a/ansible/playbooks/nagios/README.md
+++ b/ansible/playbooks/nagios/README.md
@@ -62,3 +62,44 @@ The Encrypted File Can Have Its Password Changed With The Following command
 Based off the [installation guide](https://support.nagios.com/kb/article/nagios-core-installing-nagios-core-from-source-96.html):
 And Off This [GitRepo](https://github.com/Willsparker/AnsibleBoilerPlates/tree/main/Nagios) :
 For some useful tips for working with vault files see [here](https://docs.ansible.com/ansible/latest/user_guide/vault.html)
+
+## How to Add Additional Jenkins Check Label Job To Nagios Server Group For windows ##
+
+* The commands configuration file `commands.cfg` can be located at 
+```bash
+/usr/local/nagios/etc/objects/commands.cfg
+```
+
+* Navigate to
+
+```bash
+cd /usr/local/nagios/etc/objects
+```
+
+* Open commands.cfg in a text editor
+
+```bash
+nano commands.cfg
+```
+* add `check_build_windows_x64` command definition
+
+```bash
+define command{
+	    command_name	check_label_build_windows_x64
+	    command_line  $USER1$/check_build_windows_x64 "$ARG1$" $ARG2$ $ARG3$
+
+	}
+```
+*  Amend the machine specific config file, e.g ( /usr/local/nagios/etc/objects/localhost.cfg ) to include the entry for the new label check.
+
+```bash
+	define service{
+		 use                             local-service
+        host_name                       Nagios_Server
+        check_period                    once-a-day-at-8
+        service_description             Check Label- build/windows/x64
+        check_command                   check_label!build&&windows&&x64!75!30
+        notifications_enabled           0
+
+	}
+``

--- a/ansible/playbooks/nagios/README.md
+++ b/ansible/playbooks/nagios/README.md
@@ -87,14 +87,13 @@ nano commands.cfg
 define command{
 	    command_name	check_label_build_windows_x64
 	    command_line  $USER1$/check_build_windows_x64 "$ARG1$" $ARG2$ $ARG3$
-
 	}
 ```
 *  Amend the machine specific config file, e.g ( /usr/local/nagios/etc/objects/localhost.cfg ) to include the entry for the new label check.
 
 ```bash
 	define service{
-		 use                             local-service
+		use                             local-service
         host_name                       Nagios_Server
         check_period                    once-a-day-at-8
         service_description             Check Label- build/windows/x64

--- a/ansible/playbooks/nagios/README.md
+++ b/ansible/playbooks/nagios/README.md
@@ -1,4 +1,20 @@
+**IMPORTANT!**
 
+Currently the Nagios server (4.4.7) installation playbook has only been developed and tested on Ubuntu 22.04. Changes will be required if you wish to install a Nagios Server on a different host OS
+
+Ensure to update the ansible.cfg and nagios_inventory.yml files before running this playbook.
+
+**Repository Contents:**
+
+README.MD (This File)
+
+1) ./VagrantFiles/
+
+  This directory contains a vagrantfile that can be used to create a test server for running the Nagios_Server playbook on.
+
+  **NB: For the Ubuntu 2204 Vagrantfile, its recommended to use a minimum Vagrant version of 2.2.19-1**
+
+2) ./roles/*
 
 This directory houses the ansible roles used in the creation of the nagios server.
 

--- a/ansible/playbooks/nagios/README.md
+++ b/ansible/playbooks/nagios/README.md
@@ -76,4 +76,4 @@ For some useful tips for working with vault files see [here](https://docs.ansibl
         check_command                   check_label!build&&windows&&x64!75!30
         notifications_enabled           0
 	}
-``
+```


### PR DESCRIPTION
Added a check for the machines with the build, windows & x64 labels  
 updated the readme.md file in the ansible/playbooks/nagios/README.md with a new section detailing how to add an additional version of these checks.
fixes #2765 

cc @steelhead31 @smlambert @sxa 


