### PR TITLE
winPB: Install NSClient++ On Windows Hosts For Nagios Monitoring

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/group_vars/all/adoptopenjdk_variables.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/group_vars/all/adoptopenjdk_variables.yml
@@ -13,5 +13,4 @@ bootjdk: hotspot
 heapsize: normal
 
 ## Nagios Server Details
-Nagios_Monitoring: Enabled
 Nagios_Master_IP: 78.47.239.96

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/group_vars/all/adoptopenjdk_variables.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/group_vars/all/adoptopenjdk_variables.yml
@@ -11,3 +11,7 @@ Nagios_Plugins: Disabled
 ### Default JDK ###
 bootjdk: hotspot
 heapsize: normal
+
+## Nagios Server Details
+Nagios_Monitoring: Enabled
+Nagios_Master_IP: 78.47.239.96

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -48,19 +48,19 @@
     - Strawberry_Perl             # Testing
 #    - Freemarker                  # OpenJ9"
     - GIT
-    - Java7                       # JDK8 build bootstrap
-    - Java8                       # JDK9 build bootstrap/ For Gradle
-    - role: Java_install          # JDK11 build bootstrap
-      jdk_version: 10
-    - role: Java_install          # For Gradle
-      jdk_version: 11
-    - role: Java_install          # JDK16 build bootstrap
-      jdk_version: 15
-    - role: Java_install          # JDK17 build bootstrap
-      jdk_version: 16
-    - role: Java_install
-      jdk_version: 17
-    - ANT                         # Testing
+#    - Java7                       # JDK8 build bootstrap
+#    - Java8                       # JDK9 build bootstrap/ For Gradle
+#    - role: Java_install          # JDK11 build bootstrap
+#      jdk_version: 10
+#    - role: Java_install          # For Gradle
+#      jdk_version: 11
+#    - role: Java_install          # JDK16 build bootstrap
+#      jdk_version: 15
+#    - role: Java_install          # JDK17 build bootstrap
+#      jdk_version: 16
+#    - role: Java_install
+#      jdk_version: 17
+#    - ANT                         # Testing
 #    - MSVS_2013
 #    - MSVS_2017                   # OpenJ9
 #    - MSVS_2019                   # OpenJ9
@@ -71,7 +71,7 @@
 #    - nasm                        # OpenJ9
 #    - Rust                        # IcedTea-Web
 #    - IcedTea-Web                 # For Jenkins webstart
-    - WiX                         # For creating installers
+#    - WiX                         # For creating installers
     - NSClient                    # Required For Nagios Monitoring
     - shortNames
     - Dragonwell                  # Dragonwell bootstrap image

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -72,7 +72,7 @@
     - Rust                        # IcedTea-Web
     - IcedTea-Web                 # For Jenkins webstart
     - WiX                         # For creating installers
-    - NSCLient                    # Required For Nagios Monitoring
+    - NSClient                    # Required For Nagios Monitoring
     - shortNames
     - Dragonwell                  # Dragonwell bootstrap image
     - role: Thunderbird

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -38,9 +38,9 @@
       tags: [vendor_files, adoptopenjdk, jenkins]
     - Version
     - Common
-#    - Windows_Updates
-#    - WMF_5.1
-#    - Jenkins                     # AdoptOpenJDK infrastructure
+    - Windows_Updates
+    - WMF_5.1
+    - Jenkins                     # AdoptOpenJDK infrastructure
     - CodesignCert
     - 7-Zip                       # Mostly extracting other prereqs :-)
     - cygwin
@@ -48,30 +48,30 @@
     - Strawberry_Perl             # Testing
 #    - Freemarker                  # OpenJ9"
     - GIT
-#    - Java7                       # JDK8 build bootstrap
-#    - Java8                       # JDK9 build bootstrap/ For Gradle
-#    - role: Java_install          # JDK11 build bootstrap
-#      jdk_version: 10
-#    - role: Java_install          # For Gradle
-#      jdk_version: 11
-#    - role: Java_install          # JDK16 build bootstrap
-#      jdk_version: 15
-#    - role: Java_install          # JDK17 build bootstrap
-#      jdk_version: 16
-#    - role: Java_install
-#      jdk_version: 17
-#    - ANT                         # Testing
-#    - MSVS_2013
-#    - MSVS_2017                   # OpenJ9
-#    - MSVS_2019                   # OpenJ9
+    - Java7                       # JDK8 build bootstrap
+    - Java8                       # JDK9 build bootstrap/ For Gradle
+    - role: Java_install          # JDK11 build bootstrap
+      jdk_version: 10
+    - role: Java_install          # For Gradle
+      jdk_version: 11
+    - role: Java_install          # JDK16 build bootstrap
+      jdk_version: 15
+    - role: Java_install          # JDK17 build bootstrap
+      jdk_version: 16
+    - role: Java_install
+      jdk_version: 17
+    - ANT                         # Testing
+    - MSVS_2013
+    - MSVS_2017                   # OpenJ9
+    - MSVS_2019                   # OpenJ9
 #    - NVidia_Cuda_Toolkit         # OpenJ9
-#    - NTP_TIME
-#    - Clang_64bit                 # OpenJ9
-#    - Clang_32bit                 # OpenJ9
-#    - nasm                        # OpenJ9
-#    - Rust                        # IcedTea-Web
-#    - IcedTea-Web                 # For Jenkins webstart
-#    - WiX                         # For creating installers
+    - NTP_TIME
+    - Clang_64bit                 # OpenJ9
+    - Clang_32bit                 # OpenJ9
+    - nasm                        # OpenJ9
+    - Rust                        # IcedTea-Web
+    - IcedTea-Web                 # For Jenkins webstart
+    - WiX                         # For creating installers
     - NSClient                    # Required For Nagios Monitoring
     - shortNames
     - Dragonwell                  # Dragonwell bootstrap image

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -64,7 +64,7 @@
     - MSVS_2013
     - MSVS_2017                   # OpenJ9
     - MSVS_2019                   # OpenJ9
-    - NVidia_Cuda_Toolkit         # OpenJ9
+#    - NVidia_Cuda_Toolkit         # OpenJ9
     - NTP_TIME
     - Clang_64bit                 # OpenJ9
     - Clang_32bit                 # OpenJ9

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -38,9 +38,9 @@
       tags: [vendor_files, adoptopenjdk, jenkins]
     - Version
     - Common
-    - Windows_Updates
-    - WMF_5.1
-    - Jenkins                     # AdoptOpenJDK infrastructure
+#    - Windows_Updates
+#    - WMF_5.1
+#    - Jenkins                     # AdoptOpenJDK infrastructure
     - CodesignCert
     - 7-Zip                       # Mostly extracting other prereqs :-)
     - cygwin
@@ -61,16 +61,16 @@
     - role: Java_install
       jdk_version: 17
     - ANT                         # Testing
-    - MSVS_2013
-    - MSVS_2017                   # OpenJ9
-    - MSVS_2019                   # OpenJ9
+#    - MSVS_2013
+#    - MSVS_2017                   # OpenJ9
+#    - MSVS_2019                   # OpenJ9
 #    - NVidia_Cuda_Toolkit         # OpenJ9
-    - NTP_TIME
-    - Clang_64bit                 # OpenJ9
-    - Clang_32bit                 # OpenJ9
-    - nasm                        # OpenJ9
-    - Rust                        # IcedTea-Web
-    - IcedTea-Web                 # For Jenkins webstart
+#    - NTP_TIME
+#    - Clang_64bit                 # OpenJ9
+#    - Clang_32bit                 # OpenJ9
+#    - nasm                        # OpenJ9
+#    - Rust                        # IcedTea-Web
+#    - IcedTea-Web                 # For Jenkins webstart
     - WiX                         # For creating installers
     - NSClient                    # Required For Nagios Monitoring
     - shortNames

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -72,6 +72,7 @@
     - Rust                        # IcedTea-Web
     - IcedTea-Web                 # For Jenkins webstart
     - WiX                         # For creating installers
+    - NSCLient                    # Required For Nagios Monitoring
     - shortNames
     - Dragonwell                  # Dragonwell bootstrap image
     - role: Thunderbird

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -64,7 +64,7 @@
     - MSVS_2013
     - MSVS_2017                   # OpenJ9
     - MSVS_2019                   # OpenJ9
-#    - NVidia_Cuda_Toolkit         # OpenJ9
+    - NVidia_Cuda_Toolkit         # OpenJ9
     - NTP_TIME
     - Clang_64bit                 # OpenJ9
     - Clang_32bit                 # OpenJ9

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NSClient/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NSClient/tasks/main.yml
@@ -30,8 +30,11 @@
   tags: NSClient
 
 - name: Install NSClient
-  raw: msiexec /i /qn C:\temp\nscp.msi INSTALLLOCATION=c:\nsclient CONF_CAN_CHANGE=1 MONITORING_TOOL=none ALLOWED_HOSTS=127.0.0.1,{{ Nagios_Master_IP }} ADD_DEFAULTS=1 CONF_CHECKS=1 CONF_NSCLIENT=1
-  failed_when: false
+  win_package:
+    path: 'C:\temp\nscp.msi'
+    creates_path: 'c:\nsclient\nscp.exe'
+    state: present
+    arguments: /l* C:\temp\nscp.log /quiet INSTALLLOCATION=c:\nsclient CONF_CAN_CHANGE=1 MONITORING_TOOL=none ALLOWED_HOSTS=127.0.0.1,{{ Nagios_Master_IP }} ADD_DEFAULTS=1 CONF_CHECKS=1 CONF_NSCLIENT=1 /quiet
   when: (not nsclient_installed.stat.exists)
   tags: NSClient
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NSClient/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NSClient/tasks/main.yml
@@ -16,7 +16,7 @@
     force: no
     checksum: dfe93c293f30586b02510d8b7884e4e177b93a5fead8b5dc6de8103532e6e159
     checksum_algorithm: sha256
-  when: (not nsclient_installed.stat.exists) and (ansible_architecture == "64 -bit")
+  when: (not nsclient_installed.stat.exists) and (ansible_architecture == "64-bit")
   tags: NSClient
 
 - name: Download NSClient installer (32-Bit)

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NSClient/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NSClient/tasks/main.yml
@@ -16,7 +16,7 @@
     force: no
     checksum: dfe93c293f30586b02510d8b7884e4e177b93a5fead8b5dc6de8103532e6e159
     checksum_algorithm: sha256
-  when: (not nsclient_installed.stat.exists) and (ansible_architecture == "x86_64")
+  when: (not nsclient_installed.stat.exists) and (ansible_architecture == "64 -bit")
   tags: NSClient
 
 - name: Download NSClient installer (32-Bit)
@@ -26,7 +26,7 @@
     force: no
     checksum: ca6a67fb01c1468f2b510fd2f9eb0750887db3fb49a0302732c1421c85c6627c
     checksum_algorithm: sha256
-  when: (not nsclient_installed.stat.exists) and (ansible_architecture == "x86_32")
+  when: (not nsclient_installed.stat.exists) and (ansible_architecture == "32-bit")
   tags: NSClient
 
 - name: Install NSClient
@@ -60,4 +60,9 @@
     path: C:\temp\nscp.msi
     state: absent
   failed_when: false
+  tags: NSClient
+
+- name: Print all available facts
+  ansible.builtin.debug:
+    var: ansible_facts
   tags: NSClient

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NSClient/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NSClient/tasks/main.yml
@@ -64,8 +64,3 @@
     state: absent
   failed_when: false
   tags: NSClient
-
-- name: Print all available facts
-  ansible.builtin.debug:
-    var: ansible_facts
-  tags: NSClient

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NSClient/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NSClient/tasks/main.yml
@@ -1,0 +1,63 @@
+---
+####################################
+# NSCLient++ - Used For Nagios     #
+####################################
+
+- name: Test if NSClient++ is already installed
+  win_stat:
+    path: 'c:\nsclient\nscp.exe'
+  register: nsclient_installed
+  tags: NSClient
+
+- name: Download NSClient installer (64-Bit)
+  win_get_url:
+    url: https://github.com/mickem/nscp/releases/download/0.5.2.39/NSCP-0.5.2.39-x64.msi
+    dest: 'C:\temp\nscp.msi'
+    force: no
+    checksum: dfe93c293f30586b02510d8b7884e4e177b93a5fead8b5dc6de8103532e6e159
+    checksum_algorithm: sha256
+  when: (not nsclient_installed.stat.exists) and (ansible_architecture2 == "x86_64")
+  tags: NSClient
+
+- name: Download NSClient installer (32-Bit)
+  win_get_url:
+    url: https://github.com/mickem/nscp/releases/download/0.5.2.39/NSCP-0.5.2.39-Win32.msi
+    dest: 'C:\temp\nscp.msi'
+    force: no
+    checksum: ca6a67fb01c1468f2b510fd2f9eb0750887db3fb49a0302732c1421c85c6627c
+    checksum_algorithm: sha256
+  when: (not nsclient_installed.stat.exists) and (ansible_architecture2 == "x86_32")
+  tags: NSClient
+
+- name: Install NSClient
+  raw: msiexec /i C:\temp\nscp.msi INSTALLLOCATION=c:\nsclient CONF_CAN_CHANGE=1 MONITORING_TOOL=none ALLOWED_HOSTS=127.0.0.1,{{ Nagios_Master_IP }} ADD_DEFAULTS=1 CONF_CHECKS=1 CONF_NSCLIENT=1 /quiet
+  failed_when: false
+  when: (not nsclient_installed.stat.exists)
+  tags: NSClient
+
+- name: Enable External Script Options For NSClient
+  raw: c:\nsclient\nscp settings --activate-module {{ item }}
+  with_items:
+    - CheckExternalScripts
+    - CheckHelpers
+    - CheckEventLog
+    - CheckNSCP
+    - CheckDisk
+    - CheckSystem
+  when: (not nsclient_installed.stat.exists)
+  register: result
+  failed_when: (result.rc == 0) or (result.rc == -1)
+  tags: NSClient
+
+- name: NSClient - Restart Service
+  win_service:
+    name: nscp
+    state: restarted
+  tags: NSClient
+
+- name: Cleanup NSClient
+  win_file:
+    path: C:\temp\nscp.msi
+    state: absent
+  failed_when: false
+  tags: NSClient

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NSClient/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NSClient/tasks/main.yml
@@ -16,7 +16,7 @@
     force: no
     checksum: dfe93c293f30586b02510d8b7884e4e177b93a5fead8b5dc6de8103532e6e159
     checksum_algorithm: sha256
-  when: (not nsclient_installed.stat.exists) and (ansible_architecture2 == "x86_64")
+  when: (not nsclient_installed.stat.exists) and (ansible_architecture == "x86_64")
   tags: NSClient
 
 - name: Download NSClient installer (32-Bit)
@@ -26,7 +26,7 @@
     force: no
     checksum: ca6a67fb01c1468f2b510fd2f9eb0750887db3fb49a0302732c1421c85c6627c
     checksum_algorithm: sha256
-  when: (not nsclient_installed.stat.exists) and (ansible_architecture2 == "x86_32")
+  when: (not nsclient_installed.stat.exists) and (ansible_architecture == "x86_32")
   tags: NSClient
 
 - name: Install NSClient

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NSClient/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NSClient/tasks/main.yml
@@ -30,7 +30,7 @@
   tags: NSClient
 
 - name: Install NSClient
-  raw: msiexec /i C:\temp\nscp.msi INSTALLLOCATION=c:\nsclient CONF_CAN_CHANGE=1 MONITORING_TOOL=none ALLOWED_HOSTS=127.0.0.1,{{ Nagios_Master_IP }} ADD_DEFAULTS=1 CONF_CHECKS=1 CONF_NSCLIENT=1 /quiet
+  raw: msiexec /i /qn C:\temp\nscp.msi INSTALLLOCATION=c:\nsclient CONF_CAN_CHANGE=1 MONITORING_TOOL=none ALLOWED_HOSTS=127.0.0.1,{{ Nagios_Master_IP }} ADD_DEFAULTS=1 CONF_CHECKS=1 CONF_NSCLIENT=1
   failed_when: false
   when: (not nsclient_installed.stat.exists)
   tags: NSClient


### PR DESCRIPTION
Fixes #2825 

Installs NSClient software for windows as part of the nagios monitoring improvements.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
