### PR TITLE
github: Fix actions to specific hashes

### DIFF
--- a/.github/dependabot
+++ b/.github/dependabot
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,26 +16,29 @@ on:
     branches:
     - master
 
+permissions:
+  contents: read
+
 jobs:
   build-and-push-centos6:
     name: Centos6
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
     - name: Set up Docker Buildx to use cache feature
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # v2.2.1
 
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
       if: github.ref == 'refs/heads/master'
 
     - name: Docker Build & Push Centos6 Image to Docker Hub
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0
       with:
         file: ./ansible/docker/Dockerfile.CentOS6
         build-args: git_sha=${{ github.sha }}
@@ -49,13 +52,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
     - name: Set up Docker Buildx to use cache feature
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # v2.2.1
 
     - name: Docker Build Alpine3 Image
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0
       with:
         file: ./ansible/docker/Dockerfile.Alpine3
         build-args: git_sha=${{ github.sha }}

--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -8,6 +8,9 @@ on:
     branches:         
     - master
 
+permissions:
+  contents: read
+
 jobs:
   build-macos:
     name: macOS
@@ -17,7 +20,7 @@ jobs:
         os: [macos-11]
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
     - name: Install dependencies
       run: brew install ansible

--- a/.github/workflows/build_vagrant.yml
+++ b/.github/workflows/build_vagrant.yml
@@ -8,13 +8,16 @@ on:
     branches:         
     - master
 
+permissions:
+  contents: read
+
 jobs:
   build-solaris:
     name: Solaris
     runs-on: macos-12
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/build_wsl.yml
+++ b/.github/workflows/build_wsl.yml
@@ -17,6 +17,9 @@ concurrency:
   group: "${{ github.ref }}"
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   build-wsl:
     strategy:
@@ -38,9 +41,9 @@ jobs:
         .\ConfigureRemotingForAnsible.ps1 -ForceNewSSLCert
         .\ConfigureRemotingForAnsible.ps1 -SkipNetworkProfileCheck
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
-    - uses: Vampire/setup-wsl@v1
+    - uses: Vampire/setup-wsl@230f54c1aaf45965739002df30b3e4de43349a37 # v1.3.4
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/check_dockerstatic.yml
+++ b/.github/workflows/check_dockerstatic.yml
@@ -13,6 +13,9 @@ on:
 env:
   ROOT_PATH: "ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/"
 
+permissions:
+  contents: read
+
 jobs:
   check-alpine:
     name: alpine
@@ -31,7 +34,7 @@ jobs:
          - os: alpine13.4
            dockerfile: "Dockerfile.alp314"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
     - name: Test Dockerfile on ${{ matrix.os }}
       env:
         DOCKERFILE: ${{ matrix.dockerfile }}
@@ -48,7 +51,7 @@ jobs:
          - os: centos8
            dockerfile: "Dockerfile.cent8"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
     - name: Test Dockerfile on ${{ matrix.os }}
       env:
         DOCKERFILE: ${{ matrix.dockerfile }}
@@ -69,7 +72,7 @@ jobs:
          - os: fedora35
            dockerfile: "Dockerfile.f35"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
     - name: Test Dockerfile on ${{ matrix.os }}
       env:
         DOCKERFILE: ${{ matrix.dockerfile }}
@@ -92,7 +95,7 @@ jobs:
          - os: ubuntu21.04
            dockerfile: "Dockerfile.u2104"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
     - name: Test Dockerfile on ${{ matrix.os }}
       env:
         DOCKERFILE: ${{ matrix.dockerfile }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,12 +10,12 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@main
+    - uses: actions/labeler@3e20f3d061896109eedd1ff7e9942a063b936e06 # main
       if: ${{ github.event.pull_request }}
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
 
-    - uses: fuxingloh/multi-labeler@v1
+    - uses: fuxingloh/multi-labeler@fb9bc28b2d65e406ffd208384c5095793c3fd59a # v1.8.0
       with:
         github-token: "${{secrets.GITHUB_TOKEN}}"
         config-path: .github/regex_labeler.yml

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -13,17 +13,22 @@ on:
     branches:         
     - master
 
+permissions:
+  contents: read
 
 jobs:
   yamllint:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: write  # for karancode/yamllint-github-action to post comments on PRs
     name: Yamllint
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
     - name: 'Yamllint'
-      uses: karancode/yamllint-github-action@master
+      uses: karancode/yamllint-github-action@dd59165b84d90d37fc919c3c7dd84c7e37cd6bfb # master
       with:
         yamllint_comment: true
       env:
@@ -34,10 +39,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
     - name: Set up Python 3.x
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@75f3110429a8c05be0e1bf360334e4cced2b63fa # v2.3.3
       with:
         python-version: '3.x'
 


### PR DESCRIPTION
Part of https://github.com/adoptium/adoptium/issues/187
Fix GitHub action dependencies to specific hashes.
Includes review of versions being used.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
