### PR TITLE
UnixPB : Install LibFFI6 On Ubuntu 20/22 on s390x

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -110,6 +110,22 @@
   with_items: "{{ Additional_Packages_Ubuntu18 }}"
   when:
     - ansible_distribution_major_version == "18"
+  
+- name: Download LibFFI6 v3.2.1_8 For Ubuntu 20 or 22 on S390X
+  get_url:
+    url: https://mirrors.mit.edu/ubuntu-ports/pool/main/libf/libffi/libffi6_3.2.1-8_s390x.deb
+    dest: /tmp/libffi6_3.2.1-8_s390x.deb
+    force: no
+    mode: 0755
+    checksum: 05e456a2e8ad9f20db846ccb96c483235c3243e27025c3e8e8e358411fd48be9
+  when:
+    - (ansible_architecture == "s390x") and (ansible_distribution_major_version == "20" or ansible_distribution_major_version == "22 )
+ 
+- name: Install LibFFI6 v3.2.1_8 For Ubuntu 20 or 22 on S390X
+  apt: deb="/tmp/libffi6_3.2.1-8_s390x.deb"
+  when:
+    - (ansible_architecture == "s390x") and (ansible_distribution_major_version == "20" or ansible_distribution_major_version == "22 )
+  
 
 ####################
 # Set default Java #

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -121,13 +121,12 @@
   when:
     - (ansible_distribution_major_version == "20" and ansible_architecture == "s390x") or
       (ansible_distribution_major_version == "22" and ansible_architecture == "s390x")
- 
+      
 - name: Install LibFFI6 v3.2.1_8 For Ubuntu 20 or 22 on S390X
   apt: deb="/tmp/libffi6_3.2.1-8_s390x.deb"
   when:
     - (ansible_distribution_major_version == "20" and ansible_architecture == "s390x") or
       (ansible_distribution_major_version == "22" and ansible_architecture == "s390x")
-  
 
 ####################
 # Set default Java #

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -119,12 +119,14 @@
     mode: 0755
     checksum: 05e456a2e8ad9f20db846ccb96c483235c3243e27025c3e8e8e358411fd48be9
   when:
-    - (ansible_architecture == "s390x") and (ansible_distribution_major_version == "20" or ansible_distribution_major_version == "22 )
+    - (ansible_distribution_major_version == "20" and ansible_architecture == "s390x") or
+      (ansible_distribution_major_version == "22" and ansible_architecture == "s390x")
  
 - name: Install LibFFI6 v3.2.1_8 For Ubuntu 20 or 22 on S390X
   apt: deb="/tmp/libffi6_3.2.1-8_s390x.deb"
   when:
-    - (ansible_architecture == "s390x") and (ansible_distribution_major_version == "20" or ansible_distribution_major_version == "22 )
+    - (ansible_distribution_major_version == "20" and ansible_architecture == "s390x") or
+      (ansible_distribution_major_version == "22" and ansible_architecture == "s390x")
   
 
 ####################

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -110,7 +110,7 @@
   with_items: "{{ Additional_Packages_Ubuntu18 }}"
   when:
     - ansible_distribution_major_version == "18"
-  
+
 - name: Download LibFFI6 v3.2.1_8 For Ubuntu 20 or 22 on S390X
   get_url:
     url: https://mirrors.mit.edu/ubuntu-ports/pool/main/libf/libffi/libffi6_3.2.1-8_s390x.deb
@@ -121,7 +121,7 @@
   when:
     - (ansible_distribution_major_version == "20" and ansible_architecture == "s390x") or
       (ansible_distribution_major_version == "22" and ansible_architecture == "s390x")
-      
+
 - name: Install LibFFI6 v3.2.1_8 For Ubuntu 20 or 22 on S390X
   apt: deb="/tmp/libffi6_3.2.1-8_s390x.deb"
   when:


### PR DESCRIPTION
Install libffi6.dev.so.6 for Ubuntu 20/22 on s390x machines

Fixes #2830 

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)

VPC Run : https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/OS=Ubuntu2004,label=vagrant/1583/console
