### PR TITLE
Decommissioning of old Marist s390x systems

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/jckservices_iptables/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/jckservices_iptables/tasks/main.yml
@@ -61,10 +61,7 @@
     jump: ACCEPT
   with_items:
     # List comes from https://github.com/temurin-compliance/infrastructure/blob/master/ansible/inventory.yml
-    - 148.100.84.95 # jck-marist-ubuntu2004-s390x-1
-    - 148.100.84.175 # jck-marist-ubuntu2004-s390x-2
     - 148.100.74.16 # jck-marist-ubuntu2004-s390x-3
-    - 148.100.84.144 # jck-marist-rhel7-s390x-1
     - 148.100.74.223 # jck-marist-rhel7-s390x-2
     - 129.33.196.193 # jck-ibm-aix71-ppc64-1
     - 129.33.196.194 # jck-ibm-aix71-ppc64-2


### PR DESCRIPTION
Removes jck-marist-rhel7-s390x-1, jck-marist-ubuntu2004-s390x-1, jck-marist-ubuntu2004-s390x-2 nodes. EF issue #2214 https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2214

Signed-off-by: Paweł Stankiewicz <pawel.stankiewicz@eclipse-foundation.org>