### PR TITLE
inv: Add LoongArch64 machines

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -89,6 +89,9 @@ hosts:
       - spearhead:
           freebsd12-x64-1: {ip: 185.131.222.224}
 
+      - loongson:
+              loongnix20-loongarch64-1: {ip: 114.242.206.180, port: 25817, user: loongson}
+
   - docker:
 
       - aws:
@@ -213,3 +216,6 @@ hosts:
           ubuntu1604-x64-1: {ip: 169.48.4.141}
           win2012r2-x64-1: {ip: 169.48.4.131, user: Administrator}
           win2012r2-x64-2: {ip: 169.48.4.139, user: Administrator}
+
+      - loongson:
+              loongnix20-loongarch64-1: {ip: 114.242.206.180, port: 25817, user: loongson}

--- a/ansible/plugins/inventory/adoptopenjdk_yaml.py
+++ b/ansible/plugins/inventory/adoptopenjdk_yaml.py
@@ -39,7 +39,7 @@ except ImportError:
 
 valid = {
   # taken from nodejs/node.git: ./configure
-  'arch': ('armv7', 'armv8', 'ppc64le', 'ppc64', 'x64', 's390x', 'arm64', 'sparcv9' , 'riscv64'),
+  'arch': ('armv7', 'armv8', 'ppc64le', 'ppc64', 'x64', 's390x', 'arm64', 'sparcv9' , 'riscv64', 'loongarch64'),
 
   # valid roles - add as necessary
   'type': ('build', 'docker', 'dockerhost', 'infrastructure', 'test', 'jck'),
@@ -49,7 +49,7 @@ valid = {
         'macstadium', 'macincloud', 'ibmcloud', 'spearhead', 'siteox',
         'equinix', 'linaro','digitalocean', 'ibm', 'godaddy',
         'aws', 'inspira', 'equinix_esxi', 'nine', 'gdams', 'skytap',
-        'hetzner')
+        'hetzner', 'loongson')
 }
 
 def main():


### PR DESCRIPTION
According to add a new machine manual: https://github.com/adoptium/infrastructure/wiki/Adding-a-new-machine, I'm submitting this PR for advice.

The information on this machine is as follows:
```
Architecture:        loongarch64
Byte Order:          Little Endian
CPU(s):              4
On-line CPU(s) list: 0-3
Thread(s) per core:  1
Core(s) per socket:  4
Socket(s):           1
NUMA node(s):        1
Model name:          Loongson-3A5000
CPU max MHz:         2500.0000
CPU min MHz:         225.0000
BogoMIPS:            3194.88
L1d cache:           64K
L1i cache:           64K
L2 cache:            256K
L3 cache:            16384K
NUMA node0 CPU(s):   0-3
```

