### PR TITLE
unixPB: Stop installing two JDK8s on Alpine

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
@@ -128,6 +128,7 @@
     - ansible_distribution != "MacOSX"
     - not ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and ansible_distribution_major_version == "6")
     - ansible_os_family != "Solaris"
+    - ansible_distribution != "Alpine"
     - adoptopenjdk_installed.rc != 0
   tags: adoptopenjdk_install
 


### PR DESCRIPTION
Fixes https://github.com/adoptium/infrastructure/issues/2843

```
    "msg": "src file does not exist, use \"force=yes\" if you really want to create the link: /usr/lib/jvm/jdk-11.0.16.1+1\n/usr/lib/jvm/jdk-11.0.17+8",
    "path": "/usr/lib/jvm/jdk-11",
    "src": "/usr/lib/jvm/jdk-11.0.16.1+1\n/usr/lib/jvm/jdk-11.0.17+8"
```

Shoudl fix the regular failures on this platform in https://ci.adoptopenjdk.net/job/centos7_docker_image_updater/

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR - Doesn't check Alpine, and issues with xlinux will be caught in the PR checks.
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
