### PR TITLE
WindowsPB: add logs to windows playbook

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -33,6 +33,9 @@
   # Roles #
   #########
   roles:
+    - role: logs
+      position: "Start"
+      tags: always
     - Debug
     - role: Get_Vendor_Files
       tags: [vendor_files, adoptopenjdk, jenkins]
@@ -77,3 +80,6 @@
     - Dragonwell                  # Dragonwell bootstrap image
     - role: Thunderbird
       tags: [Thunderbird, jck, adoptopenjdk]
+    - role: logs
+      position: "End"
+      tags: always

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/logs/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/logs/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+# Updates $HOME/ansible.log with the date and time of latest ansible playbook run
+
+- name: Set Log path
+  set_fact:
+    log_path: 'C:\Users\{{ ansible_user }}'
+
+- name: Get Date and Time
+  shell: date +%Y-%m-%d\ %H:%M:%S
+  delegate_to: localhost
+  register: date_output
+
+- name: Get Latest git commit SHA
+  shell: git rev-parse HEAD
+  register: git_output
+  delegate_to: localhost
+  ignore_errors: yes
+  when: git_sha is not defined
+
+- name: Set git_output to git_sha
+  set_fact:
+    git_sha: "{{ git_output.stdout }}"
+  when: git_sha is not defined
+
+- name: Update Log File
+  win_lineinfile:
+    create: yes
+    path: '{{ log_path }}\ansible.log'
+    insertafter: EOF
+    line: "{{ position }} {{ date_output.stdout }} {{ git_sha }}"


### PR DESCRIPTION

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Seems sensible to add the logs feature to the windows playbook too. Will add to AIX playbook soon.

I've kept the feature which allows you to pass in the sha using  --extra-vars 'git_sha=$gitsha'

Log file will be created in C:\Users\Admin\ansible.log. Some machines have Administrator or adoptopenjdk as their admin user, for which this role accommodates 