### PR TITLE
inventory: Remove 139.178.86.243 from build label hosts, add to dockerhosts dockerhost-equinix-ubuntu2204-armv8-1

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -72,9 +72,6 @@ hosts:
           centos74-ppc64le-1: {ip: 140.211.168.138}
           centos74-ppc64le-2: {ip: 140.211.168.117}
 
-      - equinix:
-          centos8-armv8-1: {ip: 139.178.86.243, description: Altra}
-
       - scaleway:
           ubuntu1604-x64-1: {ip: 51.15.46.107}
 
@@ -108,6 +105,7 @@ hosts:
           ubuntu2204-x64-1: {ip: 145.40.113.173, description: Intel Xeon Gold 40 core}
           ubuntu2004-x64-1: {ip: 145.40.114.58, description: AMD EPYC 7401P 24 core}
           ubuntu2004-armv8-1: {ip: 147.75.35.203, description: Ampere Altra 160 core, 512Gb}
+          ubuntu2204-armv8l-1: {ip: 139.178.86.243, description: Ampere Altra 160 core, 512Gb}
 
       - osuosl:
           ubuntu2004-ppc64le-1: {ip: 140.211.168.214}

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -105,7 +105,7 @@ hosts:
           ubuntu2204-x64-1: {ip: 145.40.113.173, description: Intel Xeon Gold 40 core}
           ubuntu2004-x64-1: {ip: 145.40.114.58, description: AMD EPYC 7401P 24 core}
           ubuntu2004-armv8-1: {ip: 147.75.35.203, description: Ampere Altra 160 core, 512Gb}
-          ubuntu2204-armv8l-1: {ip: 139.178.86.243, description: Ampere Altra 160 cores, 512Gb}
+          ubuntu2204-armv8-1: {ip: 139.178.86.243, description: Ampere Altra 160 cores, 512Gb}
 
       - osuosl:
           ubuntu2004-ppc64le-1: {ip: 140.211.168.214}

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -82,9 +82,6 @@ hosts:
           win2012r2-x64-1: {ip: 169.48.4.138, user: Administrator}
           win2012r2-x64-2: {ip: 169.48.4.142, user: Administrator}
 
-      - spearhead:
-          freebsd12-x64-1: {ip: 185.131.222.224}
-
   - docker:
 
       - aws:
@@ -129,10 +126,6 @@ hosts:
           rhel76-armv8-1: {ip: 18.202.36.216, user: ec2-user}
           rhel8-x64-1: {ip: 54.246.216.49}
           ubuntu1804-armv8-1: {ip: 34.243.202.254}
-
-      - gdams:
-          debian10-riscv64-1: {ip: gdams.ddns.net}
-          debian10-riscv64-2: {ip: gdams.ddns.net, port: 2222}
 
       - inspira:
           solaris10u11-sparcv9-1: {}

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -105,7 +105,7 @@ hosts:
           ubuntu2204-x64-1: {ip: 145.40.113.173, description: Intel Xeon Gold 40 core}
           ubuntu2004-x64-1: {ip: 145.40.114.58, description: AMD EPYC 7401P 24 core}
           ubuntu2004-armv8-1: {ip: 147.75.35.203, description: Ampere Altra 160 core, 512Gb}
-          ubuntu2204-armv8l-1: {ip: 139.178.86.243, description: Ampere Altra 160 core, 512Gb}
+          ubuntu2204-armv8l-1: {ip: 139.178.86.243, description: Ampere Altra 160 cores, 512Gb}
 
       - osuosl:
           ubuntu2004-ppc64le-1: {ip: 140.211.168.214}


### PR DESCRIPTION
The ansible infrastructure inventory requires updates, following the rebuild/recommision of dockerhost-equinix-ubuntu2204-armv8-1 (139.178.86.243) and the removal of defunct risc9 (gdams) and spearhead machines

Fixes #2851 

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR
- [X] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
