### PR TITLE
Workflow: Migrate QEMU playbook check to github workflow

### DIFF
--- a/.github/workflows/build_qemu.yml
+++ b/.github/workflows/build_qemu.yml
@@ -30,7 +30,7 @@ jobs:
             distro: ubuntu18.04
           - arch: s390x
             distro: ubuntu18.04
-          - arch: riscv
+          - arch: riscv64
             distro: ubuntu22.04
           # - arch: armv7
           #   distro: jessie

--- a/.github/workflows/build_qemu.yml
+++ b/.github/workflows/build_qemu.yml
@@ -1,0 +1,54 @@
+name: Build QEMU
+
+on:
+  pull_request:
+    paths:
+    - .github/workflows/build_qemu.yml
+    - ansible/playbooks/AdoptOpenJDK_Unix_Playbook/**
+    branches:         
+    - master
+
+permissions:
+  contents: read
+
+jobs:
+  build_job:
+    # The host should always be linux
+    runs-on: ubuntu-18.04
+    name: Build on ${{ matrix.distro }} ${{ matrix.arch }}
+
+    strategy:
+      matrix:
+        include:
+          - arch: aarch64
+            distro: ubuntu18.04
+          - arch: aarch64
+            distro: buster
+          - arch: ppc64le
+            distro: ubuntu18.04
+          - arch: s390x
+            distro: ubuntu18.04
+          - arch: armv7
+            distro: jessie
+
+    steps:
+      - uses: actions/checkout@v2.1.0
+      
+      - name: Run on architecture
+        uses: uraimo/run-on-arch-action@v2.3.0
+
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ${{ matrix.distro }}
+      
+      - name: Install Ansible
+        run: |
+          apt -y update
+          apt -y install ansible
+
+      - name: Run the UNIX playbook
+        run: |
+        echo "localhost ansible_user=runner ansible_connection=local" > ansible/hosts
+        set -eux
+        cd ansible
+        sudo ansible-playbook -i hosts --extra-vars 'git_sha=${{ github.sha }}' playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="adoptopenjdk,jenkins"

--- a/.github/workflows/build_qemu.yml
+++ b/.github/workflows/build_qemu.yml
@@ -39,11 +39,13 @@ jobs:
         with:
           arch: ${{ matrix.arch }}
           distro: ${{ matrix.distro }}
-      
-      - name: Install Ansible
         run: |
           apt -y update
           apt -y install ansible
+          echo "localhost ansible_user=runner ansible_connection=local" > ansible/hosts
+          set -eux
+          cd ansible
+          sudo ansible-playbook -i hosts --extra-vars 'git_sha=${{ github.sha }}' playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="adoptopenjdk,jenkins"
 
       - name: Run the UNIX playbook
         run: |

--- a/.github/workflows/build_qemu.yml
+++ b/.github/workflows/build_qemu.yml
@@ -36,7 +36,6 @@ jobs:
 
       - name: Run on architecture
         uses: uraimo/run-on-arch-action@v2.3.0
-
         with:
           arch: ${{ matrix.arch }}
           distro: ${{ matrix.distro }}
@@ -48,7 +47,7 @@ jobs:
 
       - name: Run the UNIX playbook
         run: |
-        echo "localhost ansible_user=runner ansible_connection=local" > ansible/hosts
-        set -eux
-        cd ansible
-        sudo ansible-playbook -i hosts --extra-vars 'git_sha=${{ github.sha }}' playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="adoptopenjdk,jenkins"
+          echo "localhost ansible_user=runner ansible_connection=local" > ansible/hosts
+          set -eux
+          cd ansible
+          sudo ansible-playbook -i hosts --extra-vars 'git_sha=${{ github.sha }}' playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="adoptopenjdk,jenkins"

--- a/.github/workflows/build_qemu.yml
+++ b/.github/workflows/build_qemu.yml
@@ -45,5 +45,5 @@ jobs:
             echo "localhost ansible_user=runner ansible_connection=local" > ansible/hosts
             set -eux
             cd ansible
-            if [[ "${{ matrix.distro }}" == "buster" ]] ; then export interp=/usr/bin/python3 ; else export interp=/usr/bin/python; fi
-            sudo ansible-playbook -i hosts --extra-vars 'git_sha=${{ github.sha }} ansible_python_interpreter=$interp' playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,adoptopenjdk,jenkins"
+            if [[ "${{ matrix.distro }}" == "buster" ]] ; then export interpVar="ansible_python_interpreter=/usr/bin/python3" ; fi
+            sudo ansible-playbook -i hosts --extra-vars 'git_sha=${{ github.sha }} $interpVar' playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,adoptopenjdk,jenkins"

--- a/.github/workflows/build_qemu.yml
+++ b/.github/workflows/build_qemu.yml
@@ -45,5 +45,5 @@ jobs:
             echo "localhost ansible_user=runner ansible_connection=local" > ansible/hosts
             set -eux
             cd ansible
-            if [[ "${{ matrix.distro }}" == "buster" ]] ; then export interpVar="ansible_python_interpreter=/usr/bin/python3" ; fi
-            sudo ansible-playbook -i hosts --extra-vars 'git_sha=${{ github.sha }} ${interpVar}' playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,adoptopenjdk,jenkins"
+            if [ ! -e /usr/bin/python ] ; then ln -s /usr/bin/python3 /usr/bin/python ; fi
+            sudo ansible-playbook -i hosts --extra-vars 'git_sha=${{ github.sha }}' playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,adoptopenjdk,jenkins"

--- a/.github/workflows/build_qemu.yml
+++ b/.github/workflows/build_qemu.yml
@@ -41,7 +41,7 @@ jobs:
           distro: ${{ matrix.distro }}
           run: |
             apt -y update
-            apt -y install ansible
+            apt -y install ansible sudo
             echo "localhost ansible_user=runner ansible_connection=local" > ansible/hosts
             set -eux
             cd ansible

--- a/.github/workflows/build_qemu.yml
+++ b/.github/workflows/build_qemu.yml
@@ -45,4 +45,4 @@ jobs:
             echo "localhost ansible_user=runner ansible_connection=local" > ansible/hosts
             set -eux
             cd ansible
-            sudo ansible-playbook -i hosts --extra-vars 'git_sha=${{ github.sha }}' playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="adoptopenjdk,jenkins"
+            sudo ansible-playbook -i hosts --extra-vars 'git_sha=${{ github.sha }}' playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,adoptopenjdk,jenkins"

--- a/.github/workflows/build_qemu.yml
+++ b/.github/workflows/build_qemu.yml
@@ -45,4 +45,4 @@ jobs:
             echo "localhost ansible_user=runner ansible_connection=local" > ansible/hosts
             set -eux
             cd ansible
-            sudo ansible-playbook -i hosts --extra-vars 'git_sha=${{ github.sha }}' playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,adoptopenjdk,jenkins"
+            sudo ansible-playbook -i hosts --extra-vars 'git_sha=${{ github.sha }} ansible_python_interpreter=/usr/bin/python3' playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,adoptopenjdk,jenkins"

--- a/.github/workflows/build_qemu.yml
+++ b/.github/workflows/build_qemu.yml
@@ -45,4 +45,5 @@ jobs:
             echo "localhost ansible_user=runner ansible_connection=local" > ansible/hosts
             set -eux
             cd ansible
-            sudo ansible-playbook -i hosts --extra-vars 'git_sha=${{ github.sha }} ansible_python_interpreter=/usr/bin/python3' playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,adoptopenjdk,jenkins"
+            if [[ "${{ matrix.distro }}" == "buster" ]] ; then export interp=/usr/bin/python3 ; else export interp=/usr/bin/python; fi
+            sudo ansible-playbook -i hosts --extra-vars 'git_sha=${{ github.sha }} ansible_python_interpreter=$interp' playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,adoptopenjdk,jenkins"

--- a/.github/workflows/build_qemu.yml
+++ b/.github/workflows/build_qemu.yml
@@ -28,8 +28,8 @@ jobs:
             distro: ubuntu18.04
           - arch: s390x
             distro: ubuntu18.04
-          - arch: armv7
-            distro: jessie
+          # - arch: armv7
+          #   distro: jessie
 
     steps:
       - uses: actions/checkout@v2.1.0

--- a/.github/workflows/build_qemu.yml
+++ b/.github/workflows/build_qemu.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v2.1.0
 
       - name: Run on architecture
-        uses: uraimo/run-on-arch-action@v2.3.0
+        uses: uraimo/run-on-arch-action@v2.4.0
         with:
           arch: ${{ matrix.arch }}
           distro: ${{ matrix.distro }}

--- a/.github/workflows/build_qemu.yml
+++ b/.github/workflows/build_qemu.yml
@@ -46,4 +46,4 @@ jobs:
             set -eux
             cd ansible
             if [ ! -e /usr/bin/python ] ; then ln -s /usr/bin/python3 /usr/bin/python ; fi
-            sudo ansible-playbook -i hosts --extra-vars 'git_sha=${{ github.sha }}' playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,swap_file,adoptopenjdk,jenkins"
+            sudo ansible-playbook -i hosts --extra-vars 'git_sha=${{ github.sha }}' playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,ntp_time,swap_file,adoptopenjdk,jenkins"

--- a/.github/workflows/build_qemu.yml
+++ b/.github/workflows/build_qemu.yml
@@ -39,10 +39,10 @@ jobs:
         with:
           arch: ${{ matrix.arch }}
           distro: ${{ matrix.distro }}
-        run: |
-          apt -y update
-          apt -y install ansible
-          echo "localhost ansible_user=runner ansible_connection=local" > ansible/hosts
-          set -eux
-          cd ansible
-          sudo ansible-playbook -i hosts --extra-vars 'git_sha=${{ github.sha }}' playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="adoptopenjdk,jenkins"
+          run: |
+            apt -y update
+            apt -y install ansible
+            echo "localhost ansible_user=runner ansible_connection=local" > ansible/hosts
+            set -eux
+            cd ansible
+            sudo ansible-playbook -i hosts --extra-vars 'git_sha=${{ github.sha }}' playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="adoptopenjdk,jenkins"

--- a/.github/workflows/build_qemu.yml
+++ b/.github/workflows/build_qemu.yml
@@ -46,4 +46,4 @@ jobs:
             set -eux
             cd ansible
             if [ ! -e /usr/bin/python ] ; then ln -s /usr/bin/python3 /usr/bin/python ; fi
-            sudo ansible-playbook -i hosts --extra-vars 'git_sha=${{ github.sha }}' playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,adoptopenjdk,jenkins"
+            sudo ansible-playbook -i hosts --extra-vars 'git_sha=${{ github.sha }}' playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,swap_file,adoptopenjdk,jenkins"

--- a/.github/workflows/build_qemu.yml
+++ b/.github/workflows/build_qemu.yml
@@ -30,8 +30,8 @@ jobs:
             distro: ubuntu18.04
           - arch: s390x
             distro: ubuntu18.04
-          - arch: riscv64
-            distro: ubuntu22.04
+          # - arch: riscv64
+          #   distro: ubuntu22.04
           # - arch: armv7
           #   distro: jessie
 

--- a/.github/workflows/build_qemu.yml
+++ b/.github/workflows/build_qemu.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.1.0
-      
+
       - name: Run on architecture
         uses: uraimo/run-on-arch-action@v2.3.0
 

--- a/.github/workflows/build_qemu.yml
+++ b/.github/workflows/build_qemu.yml
@@ -5,14 +5,16 @@ on:
     paths:
     - .github/workflows/build_qemu.yml
     - ansible/playbooks/AdoptOpenJDK_Unix_Playbook/**
-    branches:         
+    branches:       
     - master
+    types: [ labeled ]
 
 permissions:
   contents: read
 
 jobs:
   build_job:
+    if: ${{ github.event.label.name == 'QEMU-playbook-check' }}
     # The host should always be linux
     runs-on: ubuntu-18.04
     name: Build on ${{ matrix.distro }} ${{ matrix.arch }}

--- a/.github/workflows/build_qemu.yml
+++ b/.github/workflows/build_qemu.yml
@@ -46,10 +46,3 @@ jobs:
           set -eux
           cd ansible
           sudo ansible-playbook -i hosts --extra-vars 'git_sha=${{ github.sha }}' playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="adoptopenjdk,jenkins"
-
-      - name: Run the UNIX playbook
-        run: |
-          echo "localhost ansible_user=runner ansible_connection=local" > ansible/hosts
-          set -eux
-          cd ansible
-          sudo ansible-playbook -i hosts --extra-vars 'git_sha=${{ github.sha }}' playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="adoptopenjdk,jenkins"

--- a/.github/workflows/build_qemu.yml
+++ b/.github/workflows/build_qemu.yml
@@ -28,6 +28,8 @@ jobs:
             distro: ubuntu18.04
           - arch: s390x
             distro: ubuntu18.04
+          - arch: riscv
+            distro: ubuntu22.04
           # - arch: armv7
           #   distro: jessie
 

--- a/.github/workflows/build_qemu.yml
+++ b/.github/workflows/build_qemu.yml
@@ -46,4 +46,4 @@ jobs:
             set -eux
             cd ansible
             if [[ "${{ matrix.distro }}" == "buster" ]] ; then export interpVar="ansible_python_interpreter=/usr/bin/python3" ; fi
-            sudo ansible-playbook -i hosts --extra-vars 'git_sha=${{ github.sha }} $interpVar' playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,adoptopenjdk,jenkins"
+            sudo ansible-playbook -i hosts --extra-vars 'git_sha=${{ github.sha }} ${interpVar}' playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,adoptopenjdk,jenkins"

--- a/.github/workflows/build_qemu.yml
+++ b/.github/workflows/build_qemu.yml
@@ -46,4 +46,4 @@ jobs:
             set -eux
             cd ansible
             if [ ! -e /usr/bin/python ] ; then ln -s /usr/bin/python3 /usr/bin/python ; fi
-            sudo ansible-playbook -i hosts --extra-vars 'git_sha=${{ github.sha }}' playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,ntp_time,swap_file,adoptopenjdk,jenkins"
+            sudo ansible-playbook -i hosts --extra-vars 'git_sha=${{ github.sha }}' playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,jenkins,docker,ntp_time,swap_file,adoptopenjdk,jenkins"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -54,9 +54,11 @@
       when:
         - ansible_distribution != "MacOSX"
         - ansible_distribution != "Solaris" # These steps fail on Solaris
+      tags: adoptopenjdk
     - role: Crontab
       when:
         - ansible_distribution != "MacOSX"
+      tags: adoptopenjdk
     - role: NTP_TIME
       when: ansible_distribution != "MacOSX"
     - gcc_48


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Migrated QEMU playbook check functionality. Relevant docs here https://github.com/uraimo/run-on-arch-action

The gh action does not support riscv, so that will still need to remain in QPC.

This yaml file is alot easier to maintain than the entire QPC jenkins job, and its alot easier to add new arch distro combos