### PR TITLE
ansible: Decommissioning of old solaris/x64 systems

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/jckservices_iptables/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/jckservices_iptables/tasks/main.yml
@@ -72,8 +72,6 @@
     - 20.61.136.213 # jck-skytap-aix71-ppc64-2
     - 20.61.222.79 # jck-skytap-aix72-ppc64-3
     - 12.202.69.3 # jck-siteox-solaris10u11-sparcv9-1
-    - 147.75.85.211 # jck-equinix_esxi-solaris10u11-x64-1
-    - 147.75.85.214 # jck-equinix_esxi-solaris10u11-x64-2
     - 178.62.54.114 # jck-digitalocean-ubuntu2004-x64-1
     - 188.166.144.71 # jck-digitalocean-ubuntu2004-x64-2
     - 147.75.83.133 # jck-equinix-ubuntu2004-x64-1


### PR DESCRIPTION
Removes jck-equinix_esxi-solaris10u11-x64-1, jck-equinix_esxi-solaris10u11-x64-2 EF issue #2428 https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2428

Signed-off-by: Pawel Stankiewicz <pawel.stankiewicz@eclipse-foundation.org>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [ x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
