### PR TITLE
Dockerstatic: Move gnupg and curl to top of deb11 dockerfile

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.deb11
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.deb11
@@ -33,7 +33,7 @@ RUN chmod -R og-rwx /home/jenkins/.ssh
 # RUN service ssh start
 RUN mkdir /var/run/sshd
 CMD ["/usr/sbin/sshd","-D"]
-RUN apt-get install git curl make gcc gnupg xvfb libxrender-dev libxi-dev libxtst-dev fontconfig fakeroot -y
+RUN apt-get install git make gcc xvfb libxrender-dev libxi-dev libxtst-dev fontconfig fakeroot -y
 # ENTRYPOINT /usr/lib/jvm/jdk17/bin/java
 EXPOSE 21
 # Start with docker run -p 2211:22 UUID

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.deb11
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.deb11
@@ -1,7 +1,7 @@
 FROM debian:bullseye
 # Install Base Requirements
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
-RUN apt-get update && apt-get install -y perl openssh-server unzip zip wget apt-utils
+RUN apt-get update && apt-get install -y perl openssh-server unzip zip wget apt-utils gnupg curl
 RUN echo "y" | ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -P ""
 RUN apt-get update
 


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

The dockerfile needs curl and gnupg at the beginning of the dockerfile for the curl and gnupg commands later in the image build