### PR TITLE
Ansible: Nagios: Fix service group matching and parameterise.

### DIFF
--- a/ansible/playbooks/nagios/roles/Nagios_Config/defaults/main.yml
+++ b/ansible/playbooks/nagios/roles/Nagios_Config/defaults/main.yml
@@ -10,3 +10,6 @@ Input_Path: /tmp/ansible_inventory.yml
 
 # Output Path
 Output_Path: /usr/local/nagios/etc/servers
+
+# Ansible Inventory Host Group Types To Monitor -- Maps To Nagios Service Groups
+Nagios_Service_Types: 'build test dockerhost'

--- a/ansible/playbooks/nagios/roles/Nagios_Config/scripts/Create_Nagios_Server_Configurations.py
+++ b/ansible/playbooks/nagios/roles/Nagios_Config/scripts/Create_Nagios_Server_Configurations.py
@@ -15,10 +15,9 @@ try:
 except ImportError:
     import ConfigParser as configparser
 
-valid_types = ('build', 'dockerhost', 'test')
-
 Input_Path = sys.argv[1]
 Output_Path = sys.argv[2]
+Nagios_Service_Types = sys.argv[3]
 
 def main():
 
@@ -78,15 +77,19 @@ def parse_yaml(hosts, config):
                         hostname = '{}-{}{}{}'.format(host_type, provider_name, delimiter, host)
                         export[host_type]['hosts'].append(hostname)
                         hostvars = {}
-                        if (host_type) in (valid_types):
-                            formatted_name = host_type+'-'+provider_name+'-'+host
-                            # Creates a file with the .cfg extension using the output
-                            with open(f"{Output_Path}/{formatted_name}.cfg", "w") as f:
-                                f.write(f"Configuration for {formatted_name}")
 
-                        export[host_type]['hosts'].sort()
+                        service_list=Nagios_Service_Types.split(" ")
+
+                        for service in service_list:
+                            if host_type==service:
+                                formatted_name = host_type+'-'+provider_name+'-'+host
+                                # Creates a file with the .cfg extension using the output
+                                with open(f"{Output_Path}/{formatted_name}.cfg", "w") as f:
+                                    f.write(f"Configuration for {formatted_name}")
+
+                                    export[host_type]['hosts'].sort()
     return export
 
 if __name__ == "__main__":
-   
+
     main()

--- a/ansible/playbooks/nagios/roles/Nagios_Config/tasks/Create_Nagios_Server_Configurations.yml
+++ b/ansible/playbooks/nagios/roles/Nagios_Config/tasks/Create_Nagios_Server_Configurations.yml
@@ -1,3 +1,3 @@
 ---
 - name: Run Create Nagios Server Configurations script
-  script: ../scripts/Create_Nagios_Server_Configurations.py {{Input_Path}} {{Output_Path}}
+  script: ../scripts/Create_Nagios_Server_Configurations.py "{{Input_Path}}" "{{Output_Path}}" "{{Nagios_Service_Types}}"


### PR DESCRIPTION
Fixes #2876 

Parameterise the valid service groups from the ansible inventory file, and fix service group matching so that when dockerhost is a valid host type, the docker-xxxx machines are not included in error.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR
