### PR TITLE
UnixPB: Script to provide GPG signature verification for downloaded binaries

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/group_vars/all/adoptopenjdk_variables.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/group_vars/all/adoptopenjdk_variables.yml
@@ -32,3 +32,10 @@ Vendor_Playbook: /Vendor_Files/Vendor_Playbook/Vendor.yml
 
 # Default BootJDK installed
 bootjdk: hotspot
+
+# GPG Public Keys
+key:
+  curl: 27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2 # Daniel Stenberg <daniel@haxx.se>
+  apache: CE8075A251547BEE249BC151A2115AE15F6B8B72 # Stefan Bodewig <bodewig@apache.org>
+  autoconf: A7A16B4A2527436A # Eric Blake <eblake@redhat.com>
+  

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/group_vars/all/adoptopenjdk_variables.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/group_vars/all/adoptopenjdk_variables.yml
@@ -36,6 +36,8 @@ bootjdk: hotspot
 # GPG Public Keys
 key:
   curl: 27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2 # Daniel Stenberg <daniel@haxx.se>
-  apache: CE8075A251547BEE249BC151A2115AE15F6B8B72 # Stefan Bodewig <bodewig@apache.org>
+  apache_ant: CE8075A251547BEE249BC151A2115AE15F6B8B72 # Stefan Bodewig <bodewig@apache.org>
+  apache_maven: B02137D875D833D9B23392ECAE5A7FB608A0221C # Robert Scholte <rfscholte@apache.org>
   autoconf: A7A16B4A2527436A # Eric Blake <eblake@redhat.com>
-  
+  cmake: EC8FEF3A7BFB4EDA # Brad King <brad.king@kitware.com>
+  gmake: 96B047156338B6D4 # Paul Smith (Mad Scientist) <psmith@gnu.org>

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Alpine.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Alpine.yml
@@ -19,6 +19,7 @@ Build_Tool_Packages:
   - freetype
   - freetype-dev
   - grep
+  - gnupg
   - libdwarf                      # OpenJ9
   - libdwarf-dev                  # OpenJ9
   - libx11

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Fedora.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Fedora.yml
@@ -18,6 +18,7 @@ Build_Tool_Packages:
   - flex                          # OpenJ9
   - fontconfig-devel
   - freetype-devel
+  - gnupg
   - gcc
   - gcc-c++
   - gettext

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -18,6 +18,7 @@ Build_Tool_Packages:
   - flex                          # OpenJ9
   - fontconfig-devel
   - freetype-devel
+  - gnupg
   - gcc
   - gcc-c++
   - gettext

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Solaris.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Solaris.yml
@@ -21,6 +21,7 @@ Build_Tool_Packages:
   - wget
   - curl
   - gmake
+  - gnupg
   - gtar
   - xz
   - zip

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
@@ -17,6 +17,7 @@ Build_Tool_Packages:
   - gcc
   - gettext
   - git
+  - gnupg
   - libasound2-dev
   - libcups2-dev
   - libcurl4-openssl-dev

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ant/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ant/tasks/main.yml
@@ -41,6 +41,12 @@
     state: directory
     mode: '0755'
   when: ansible_distribution == "Solaris"
+  tags: ant
+
+- name: GPG Signature verification
+  script: ../Supporting_Scripts/package_signature_verification.sh -f /tmp/apache-ant-1.10.5-bin.zip -sl "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.zip.asc" -k {{ key.apache_ant }}
+  when: ant_installed.rc != 0
+  tags: ant
 
 - name: Extract ant
   unarchive:
@@ -57,6 +63,7 @@
     state: directory
     mode: '0755'
   when: ansible_distribution != "MacOSX"
+  tags: ant
 
 - name: Create /usr/local/bin/ant symlink
   file:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/autoconf/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/autoconf/tasks/main.yml
@@ -27,6 +27,15 @@
     - ((autoconf_version.rc == 0) and (autoconf_version.stdout is version_compare('2.69', operator='lt')))
   tags: autoconf-2.69
 
+- name: GPG Signature verification
+  script: ../Supporting_Scripts/package_signature_verification.sh -f /tmp/autoconf-2.69.tar.gz -sl "https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz.sig" -k {{ key.autoconf }}
+  when:
+    - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS")
+    - ansible_distribution_major_version == "6"
+    - ansible_architecture == "x86_64"
+    - ((autoconf_version.rc == 0) and (autoconf_version.stdout is version_compare('2.69', operator='lt')))
+  tags: autoconf-2.69
+
 - name: Extract Autoconf v2.69
   unarchive:
     src: /tmp/autoconf-2.69.tar.gz

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/cmake/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/cmake/tasks/main.yml
@@ -43,6 +43,7 @@
   when:
     - (cmake_installed.rc != 0 ) or (cmake_installed.rc == 0 and cmake_version.stdout is version_compare(cmakeVersion, operator='lt'))
     - ansible_architecture != "armv7l"
+    - not (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6")
     - (ansible_distribution != "openSUSE")
   tags: cmake
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/cmake/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/cmake/tasks/main.yml
@@ -37,6 +37,15 @@
     - (ansible_distribution != "openSUSE")
   tags: cmake
 
+# The checksum file of the download is checked, not the binary itself. The checksum in the download step is equal to the one in the file
+- name: GPG Signature verification
+  script: ../Supporting_Scripts/package_signature_verification.sh -fl "https://github.com/Kitware/CMake/releases/download/v3.11.4/cmake-3.11.4-SHA-256.txt" -sl "https://github.com/Kitware/CMake/releases/download/v3.11.4/cmake-3.11.4-SHA-256.txt.asc" -k {{ key.cmake }}
+  when:
+    - (cmake_installed.rc != 0 ) or (cmake_installed.rc == 0 and cmake_version.stdout is version_compare(cmakeVersion, operator='lt'))
+    - ansible_architecture != "armv7l"
+    - (ansible_distribution != "openSUSE")  
+  tags: cmake
+
 - name: Extract cmake
   unarchive:
     src: /tmp/cmake-{{ cmakeVersion }}.tar.gz

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/cmake/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/cmake/tasks/main.yml
@@ -43,7 +43,7 @@
   when:
     - (cmake_installed.rc != 0 ) or (cmake_installed.rc == 0 and cmake_version.stdout is version_compare(cmakeVersion, operator='lt'))
     - ansible_architecture != "armv7l"
-    - (ansible_distribution != "openSUSE")  
+    - (ansible_distribution != "openSUSE")
   tags: cmake
 
 - name: Extract cmake

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/curl/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/curl/tasks/main.yml
@@ -48,7 +48,7 @@
   script: ../Supporting_Scripts/package_signature_verification.sh -f /tmp/curl-{{ curl_latest }}.tar.gz -sl "https://github.com/curl/curl/releases/download/curl-7_79_1/curl-7.79.1.tar.gz.asc" -k {{ key.curl }}
   when:
     - ansible_distribution != "MacOSX"
-    - ((not curl_version.stdout) or ((curl_version.stdout) and (curl_version.stdout is version_compare(curl_oldest, operator='lt', strict=True))))  
+    - ((not curl_version.stdout) or ((curl_version.stdout) and (curl_version.stdout is version_compare(curl_oldest, operator='lt', strict=True))))
   tags: curl
 
 - name: Extract curl

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/curl/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/curl/tasks/main.yml
@@ -46,8 +46,11 @@
 
 - name: GPG Signature verification
   script: ../Supporting_Scripts/package_signature_verification.sh -f /tmp/curl-{{ curl_latest }}.tar.gz -sl "https://github.com/curl/curl/releases/download/curl-7_79_1/curl-7.79.1.tar.gz.asc" -k {{ key.curl }}
+  when:
+    - ansible_distribution != "MacOSX"
+    - ((not curl_version.stdout) or ((curl_version.stdout) and (curl_version.stdout is version_compare(curl_oldest, operator='lt', strict=True))))  
   tags: curl
-  
+
 - name: Extract curl
   unarchive:
     src: /tmp/curl-{{ curl_latest }}.tar.gz

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/curl/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/curl/tasks/main.yml
@@ -44,6 +44,10 @@
     - ((not curl_version.stdout) or ((curl_version.stdout) and (curl_version.stdout is version_compare(curl_oldest, operator='lt', strict=True))))
   tags: curl
 
+- name: GPG Signature verification
+  script: ../Supporting_Scripts/package_signature_verification.sh -f /tmp/curl-{{ curl_latest }}.tar.gz -sl "https://github.com/curl/curl/releases/download/curl-7_79_1/curl-7.79.1.tar.gz.asc" -k {{ key.curl }}
+  tags: curl
+  
 - name: Extract curl
   unarchive:
     src: /tmp/curl-{{ curl_latest }}.tar.gz

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gmake/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gmake/tasks/main.yml
@@ -17,6 +17,7 @@
 # This SHA was determined by SHA after verifying the public key pulled from ubuntu's keyserver
 - name: Set make sha256sum
   set_fact: makeVersionSHA=9fc7a9783d3d2ea002aa1348f851875a2636116c433677453cc1d1acc3fc4d55
+  tags: goodmake_source
 
 - name: Test if self-built make {{ makeVersion }} is available
   shell: /usr/local/bin/make --version >/dev/null
@@ -36,7 +37,16 @@
     dest: /tmp/make-{{ makeVersion }}.tar.gz
     mode: 0440
     checksum: sha256:{{ makeVersionSHA }}
+  when:
+    - ((((ansible_distribution == "SLES" or ansible_distribution == "openSUSE") and ansible_distribution_major_version == "12") or
+      (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "14")) and
+      ansible_architecture == "x86_64") or
+      ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and ansible_distribution_major_version|int < 8)
+    - goodmake_installed.rc != 0
+  tags: goodmake_source
 
+- name: GPG Signature verification
+  script: ../Supporting_Scripts/package_signature_verification.sh -f /tmp/make-{{ makeVersion }}.tar.gz -sl "https://ftp.gnu.org/gnu/make/make-4.1.tar.gz.sig" -k {{ key.gmake }}
   when:
     - ((((ansible_distribution == "SLES" or ansible_distribution == "openSUSE") and ansible_distribution_major_version == "12") or
       (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "14")) and

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/maven/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/maven/tasks/main.yml
@@ -25,6 +25,11 @@
   when: maven_installed.rc != 0 and ansible_distribution == "Solaris"
   tags: maven
 
+- name: GPG Signature verification
+  script: ../Supporting_Scripts/package_signature_verification.sh -f /tmp/apache-maven-3.6.3-bin.tar.gz -sl "https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz.asc" -k {{ key.apache_maven }}
+  when: maven_installed.rc != 0
+  tags: maven
+
 - name: Extract Apache Maven v3.6.3
   unarchive:
    src: /tmp/apache-maven-3.6.3-bin.tar.gz

--- a/ansible/playbooks/Supporting_Scripts/package_signature_verification.sh
+++ b/ansible/playbooks/Supporting_Scripts/package_signature_verification.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+set -eu
+
+FILEPATH=""
+FILELINK=""
+SIGPATH=""
+SIGLINK=""
+
+usage() {
+
+	echo "Usage of script:
+  -f Path to file (cannot be used with -fl)
+  -fl Link to file (cannot be used with -f)
+  -s Path to signature file (asc/sig) (cannot be used with -sl)
+  -sl Link to signature file (asc/sig) (cannot be used with -s)
+  -k Key fingerprint"
+}
+
+#Verify parameters
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -f)
+      FILEPATH="$2"
+      shift 2
+      ;;
+    -fl)
+      FILELINK="$2"
+      shift 2
+      ;;
+    -s)
+      SIGPATH="$2"
+      shift 2
+      ;;
+    -sl)
+      SIGLINK="$2"
+      shift 2
+      ;;
+    -k)
+      KEY="$2"
+      shift 2 
+      ;;
+    -*|--*)
+      echo "Unknown option $1"
+      usage;
+      exit 1
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [ ! -z "$FILEPATH" ] && [ ! -z "$FILELINK" ]; then
+  echo "Use -f or -fl, not both"
+  usage
+  exit 1
+fi
+
+if [ ! -z "$SIGPATH" ] && [ ! -z "$SIGLINK" ]; then
+  echo "Use -s or -sl, not both"
+  usage
+  exit 1
+fi
+
+if [ ! -z "$FILEPATH" ]; then
+  if [ -f "$FILEPATH" ]; then
+    FILE=$FILEPATH
+  else
+    echo "The file does not exist"
+    exit 1
+  fi
+elif [ ! -z "$FILELINK" ]; then
+  wget -q $FILELINK -O binary.tar.gz
+  FILE="binary.tar.gz"
+else
+  echo "Use either -f or -fl"
+  usage
+  exit 1
+fi
+
+if [ ! -z "$SIGPATH" ]; then
+  if [ -f "$SIGPATH" ]; then
+    SIG=$SIGPATH
+  else
+    echo "The signature file does not exist"
+    exit 1
+  fi
+elif [ ! -z "$SIGLINK" ]; then
+  wget -q $SIGLINK -O sigfile
+  SIG="sigfile"
+else
+  echo "Use either s or -sl"
+  usage
+  exit 1
+fi
+
+if [ ! -z "$FILE" ] && [ ! -z "$SIG" ] && [ ! -z "$KEY" ]; then
+	gpg --keyserver keyserver.ubuntu.com --recv-keys $KEY
+	gpg --verify $SIG $FILE
+  rm $SIG
+else
+	echo "Variables not valid"
+	usage
+	exit 1
+fi


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/2233

Left to do

- [x] Add the rest of the public keys to variables file
- [x] Use the script in the roles which need it

Example of usage:
```
./package_signature_verification.sh -s path_to_sig_file (or -sl sigfile_url) -f path_to_binary (or -fl binary_url) -k public_key
```
I'm still undecided whether to import all of the gpg keys at the beginning of the playbook, or at each role which uses it
