### PR TITLE
inventory: Remove two old AWS machines

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -85,9 +85,6 @@ hosts:
 
   - docker:
 
-      - aws:
-          ubuntu1604-x64-1: {ip: 34.253.28.27, user: ubuntu}
-
       - equinix:
           ubuntu2004-armv8-1: {ip: 139.178.82.146, description: Ampere eMag}
 
@@ -126,7 +123,6 @@ hosts:
       - aws:
           rhel76-armv8-1: {ip: 18.202.36.216, user: ec2-user}
           rhel8-x64-1: {ip: 54.246.216.49}
-          ubuntu1804-armv8-1: {ip: 34.243.202.254}
 
       - inspira:
           solaris10u11-sparcv9-1: {}


### PR DESCRIPTION
Ref: https://github.com/adoptium/infrastructure/issues/2911#issuecomment-1411860221 https://github.com/adoptium/infrastructure/issues/2465 https://github.com/adoptium/infrastructure/issues/1843 - these have been marked offline to verify that their removal will not cause problems and so can now be safely deleted.

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] VPC/QPC not applicable for this PR
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
