### PR TITLE
NagiosPB: Remove Encrypted nagios secrets file from linter.

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -21,3 +21,4 @@ skip_list:
 
 exclude_paths:
   - ./ansible/playbooks/adoptopenjdk_variables.yml # See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1926
+  - ./ansible/playbooks/nagios/secrets_setup_server.enc # Contains Secure Information So Removed From Linter


### PR DESCRIPTION
Exclude the encrypted nagios secrets file , so that the linter checks pass.

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR

