### PR TITLE
UnixPB: Add new nagios plugin for monitoring docker container workspaces

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
@@ -67,6 +67,19 @@
       tags:
         - jenkins
 
+    - name: Add Nagios user to the docker group for Ubuntu, Debian, SLES12, CentOS7  and RHEL7
+      user:
+        name: nagios
+        groups: docker
+        append: yes
+        state: present
+      when:
+        - (ansible_distribution == "Ubuntu" or ansible_distribution == "Debian") or (ansible_distribution == "SLES" and ansible_distribution_major_version == "12") or ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS" ) and ansible_distribution_major_version == "7")
+        - ansible_architecture != "riscv64"
+        - Nagios_Plugins == "Enabled"
+      tags:
+        - docker
+
 - name: Enable and Start Docker Service for Ubuntu, Debian, SLES12, CentOS7  and RHEL7
   service:
     name: docker

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/additional_plugins/check_container_spaces
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/additional_plugins/check_container_spaces
@@ -1,0 +1,66 @@
+#! /usr/bin/env bash
+
+## Define Variables
+
+#WarnThreshold=500 ## 10Gb
+#ErrorThreshold=100000   ## 20Gb
+WarnThreshold=$(expr $1)
+ErrorThreshold=$(expr $2)
+
+## Get Running Container IDs
+containerDets=$(docker ps --format "{{.Names}},{{.ID}}")
+
+##containerIds=$(docker ps -q)
+
+for container in $containerDets
+do
+	containerName=`echo $container| cut -d, -f1`
+	containerID=`echo $container| cut -d, -f2`
+	#echo "Name = "$containerName
+	#echo "ID = "$containerID
+	workspaceSpace=$(docker exec $containerID sh -c "if [ -d /home/jenkins/workspace ] ; then du -s /home/jenkins/workspace | awk '{print $3}' ; else echo 0 ; fi" 2> /dev/null)
+	workSpace=`echo $workspaceSpace|cut -d" " -f1`
+
+	## Create Lists Of Errors And Warnings
+	if [ $workSpace -gt $ErrorThreshold ]
+	then
+		## Add Container Name To ErrorList
+		ErrorList="$ErrorList,$containerName,$containerID"
+		# echo "Errors In "$ErrorList
+	else
+		if [ $workSpace -gt $WarnThreshold ] && [ $workSpace -lt $ErrorThreshold ]
+		then
+			WarnList="$WarnList,$containerName,$containerID"
+			#echo "Warnings In "$WarnList
+		else
+			echo "OK" > /dev/null
+		fi
+	fi
+done
+
+warncount=`echo $WarnList | wc -c`
+errorcount=`echo $ErrorList | wc -c`
+
+if  [ $errorcount -gt 1 ] && [ $warncount -gt 1 ] 
+then
+        echo "CRITICAL - These Docker Containers Have Extremely Large Workspaces: "$ErrorList
+	echo "WARNING - These Docker Containers Have Large Workspaces :"$WarnList
+        exit 2
+else
+	if [ $errorcount -gt 1 ] && [ $warncount -le 1 ]
+	then
+		echo "CRITICAL - These Docker Containers Have Extremely Large Workspaces: "$ErrorList
+		exit 2
+	else
+		if [ $warncount -gt 1 ]
+		then
+			echo "WARNING - These Docker Containers Have Large Workspaces: "$WarnList
+			exit 1
+		else
+			echo "OK - All Workspaces Are Within Defined Limits"
+			exit 0
+		fi
+	fi
+fi
+echo "UNKNOWN - PLEASE CHECK DOCKER CONTAINERS"
+exit 3

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/main.yml
@@ -101,3 +101,10 @@
   when:
     - Nagios_Plugins == "Enabled"
     - ansible_distribution == "Solaris"
+
+- name: Install Get Container Health Plugin
+  - name: Copy check_timesync plugin
+    copy:
+      src: roles/Nagios_Plugins/tasks/additional_plugins/check_container_spaces
+      dest: /usr/local/nagios/libexec/check_container_spaces
+      mode: 0755


### PR DESCRIPTION
Fixes Issue #2929 

Create a new plugin to monitor the container health on dockerhosts ( currently to monitor the jenkins workspace sizes, warn at 10Gb, Critical at 20Gb )

This requires the new plugin to be installed alongside the other plugins, the and the nagios user to be added to the docker user group.

Configuration of the thresholds can be done in the xxxxxx.server.cfg file on the nagios server itself.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)

