### PR TITLE
Ansible: Ansible Linter related fixes

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -18,6 +18,10 @@ skip_list:
   - 'fqcn-builtins'  # Disable error introduced in ansible-lint 6.X (https://github.com/ansible/ansible-lint/pull/1908)
   - 'name[template]' # Jinja templates should only be at the end of ‘name’.
   - 'template-instead-of-copy' # Replaced upstream in https://github.com/ansible/ansible-lint/pull/2512
+  - 'no-free-form' # Exclude As Requires Significant Changes ( 196 changes required )
+  - 'fqcn[action]' # Exclude As Requires Significant Changes ( 249 changes required )
+  - 'args[module]' # Exclude Experimental Rule Validation ( Prevents 4 experimental warnings )
+
 
 exclude_paths:
   - ./ansible/playbooks/adoptopenjdk_variables.yml # See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1926

--- a/.github/workflows/build_vagrant.yml
+++ b/.github/workflows/build_vagrant.yml
@@ -5,7 +5,7 @@ on:
     paths:
     - .github/workflows/build_vagrant.yml
     - ansible/playbooks/AdoptOpenJDK_Unix_Playbook/**
-    branches:         
+    branches:
     - master
 
 permissions:
@@ -57,7 +57,7 @@ jobs:
         echo "[127.0.0.1]:${vagrantPORT}" >> playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx
         [ ! -r $HOME/.ssh/known_hosts ] && touch $HOME/.ssh/known_hosts && chmod 644 $HOME/.ssh/known_hosts
         ssh-keygen -R $(cat playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx)
-        sed -i -e "s/.*hosts:.*/- hosts: all/g" playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+        sed -i -e "s/.*hosts:.*/  hosts: all/g" playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
         awk '{print}/^\[defaults\]$/{print "private_key_file = id_rsa"; print "timeout = 60"; print "remote_tmp = $HOME/.ansible/tmp"}' < ansible.cfg > ansible.cfg.tmp && mv ansible.cfg.tmp ansible.cfg
 
     - name: Run Ansible Playbook

--- a/.github/workflows/build_wsl.yml
+++ b/.github/workflows/build_wsl.yml
@@ -62,7 +62,7 @@ jobs:
         ansible_password=Ansible_password123!
         ansible_become=false
         EOF
-        sed -i -e "s/.*hosts:.*/hosts: all/g" playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+        sed -i -e "s/.*hosts:.*/  hosts: all/g" playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
 
     - name: Run Ansible Playbook
       working-directory: ansible

--- a/.github/workflows/build_wsl.yml
+++ b/.github/workflows/build_wsl.yml
@@ -9,7 +9,7 @@ on:
     paths:
     - .github/workflows/build_wsl.yml
     - ansible/playbooks/AdoptOpenJDK_Windows_Playbook/**
-    branches:         
+    branches:
     - master
 
 # Cancel existing runs if user makes another push.
@@ -62,7 +62,7 @@ jobs:
         ansible_password=Ansible_password123!
         ansible_become=false
         EOF
-        sed -i -e "s/.*hosts:.*/- hosts: all/g" playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+        sed -i -e "s/.*hosts:.*/hosts: all/g" playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
 
     - name: Run Ansible Playbook
       working-directory: ansible

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
@@ -4,7 +4,8 @@
 # --------------- AIX ---------------  #
 ########################################
 
-- hosts: all
+- name: Ansible AIX playbook
+  hosts: all
   remote_user: root
   become: true
   environment:

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/X11/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/X11/tasks/main.yml
@@ -16,6 +16,7 @@
 # /usr/lpp/X11/include/X11/extensions X11.adt.ext
 # /usr/lpp/X11.vfb                    X11.vfb
 - name: Examine X11 base requirements
+  tags: x11
   block:
    - name: Verify X11.base
      stat:
@@ -37,7 +38,6 @@
       _x11rdy: "{{ ((_base.stat.islnk is defined) and _base.stat.islnk)
          and _ext.stat.exists
          and _vfb.stat.exists }}"
-  tags: x11
 
 - name: Halt when X11.base Not Ready
   fail: msg="X11.base is required for AIXToolbox OSS needed later! Cannot proceed."

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/ant/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/ant/tasks/main.yml
@@ -4,6 +4,9 @@
 # Needs yum tag - so when yum is skipped, unarchive does not fail
 ---
 - name: Ant package processing
+  tags:
+    - ant
+    - yum
   block:
     - name: Checking for Ant availability
       stat:
@@ -25,6 +28,3 @@
     - name: Create symlink for ant
       file: src=/opt/apache-ant-1.9.9/bin/ant dest=/usr/bin/ant state=link
       when: ant.stat.islnk is not defined
-  tags:
-    - ant
-    - yum

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/ant_contrib/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/ant_contrib/tasks/main.yml
@@ -5,6 +5,9 @@
 # so, also tagged as yum
 ---
 - name: Process ant-contrib
+  tags:
+    - ant-contrib
+    - yum
   block:
     - name: Checking for ant-contrib availability
       stat:
@@ -34,6 +37,3 @@
       with_items:
         - /tmp/ant-contrib
         - /tmp/ant-contrib-1.0b2-bin.tar.gz
-  tags:
-    - ant-contrib
-    - yum

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/bootjdk/tasks/openjdk.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/bootjdk/tasks/openjdk.yml
@@ -3,6 +3,15 @@
 ###########
 ---
 - name: Install OpenJDK from adoptopenjdk
+  vars:
+    os_img: "aix/ppc64/jdk"
+    heap: "normal"
+    impl: "hotspot"
+    new_baseurl: "https://api.adoptium.net/v3/binary/latest"
+    new_vendor: "eclipse"
+    baseurl: "https://api.adoptopenjdk.net/v3/binary/latest"
+    vendor: "adoptopenjdk"
+    project: "{{ heap }}/{{ vendor }}?project=jdk"
   block:
     - name: Verify space in /usr
       include_tasks: chfs.yml
@@ -101,12 +110,3 @@
   # versions - the playbook shall continue to use adoptopenjdk.net
   # and adoptopenjdk as URL and vendor
   # In short, only jvm_impl (impl) changes!
-  vars:
-    os_img: "aix/ppc64/jdk"
-    heap: "normal"
-    impl: "hotspot"
-    new_baseurl: "https://api.adoptium.net/v3/binary/latest"
-    new_vendor: "eclipse"
-    baseurl: "https://api.adoptopenjdk.net/v3/binary/latest"
-    vendor: "adoptopenjdk"
-    project: "{{ heap }}/{{ vendor }}?project=jdk"

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/rbac/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/rbac/tasks/main.yml
@@ -18,6 +18,8 @@
   tags: rbac
 
 - name: Update RBAC to include new authorizations
+  when: rtclk_exists.rc == 2
+  tags: rbac
   block:
     - name: Top-level authorization
       shell:
@@ -39,8 +41,6 @@
         mkrole authorizations='ojdk.rtclk,ojdk.proccore' dfltmsg='Adoptium Role for testing' rtclk
     - name: Update Security Tables
       shell: setkst
-  when: rtclk_exists.rc == 2
-  tags: rbac
 
 # Assign security attributes to commands in list
 # The tag here is not passed to the included_task, the tag skips

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/rbac/tasks/setsecattr.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/rbac/tasks/setsecattr.yml
@@ -5,6 +5,7 @@
 ########################################################################
 ---
 - name: "Tagged Block for setting security attributes on {{ rbac_cmd }}"
+  tags: rbac
   block:
     - name: "Verify file {{ rbac_cmd }} exists"
       stat:
@@ -12,6 +13,7 @@
       register: _exists
 
     - name: "Add authorization to command {{ rbac_cmd }}"
+      when: _exists.stat.exists and _exists.stat.isreg
       block:
         - name: "Add authorization to command {{ rbac_cmd }}"
           shell:
@@ -23,5 +25,3 @@
 
         - name: Update Security Tables
           shell: setkst
-      when: _exists.stat.exists and _exists.stat.isreg
-  tags: rbac

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/security/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/security/tasks/main.yml
@@ -5,6 +5,7 @@
 #########################################################################
 ---
 - name: Remove obsolete agent (for Director, FSM based system management)
+  tags: aixsec
   block:
     - name: Disable inetd on boot
       shell: /usr/sbin/chrctcp -S -d inetd
@@ -25,4 +26,3 @@
       register: _installp
       changed_when: _installp.rc == 0
       when: _lslpp.rc == 0
-  tags: aixsec

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/users/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/users/tasks/main.yml
@@ -41,27 +41,27 @@
 
 # zeus and nagios are not getting user_attributes so "in-lining" their management
 - name: Zeus account management
+  tags:
+    - zeus_user
+    - adoptopenjdk
   block:
     - name: Assign username variable
       set_fact:
         username: zeus
-    - name: create account
+    - name: Create account
       include_tasks: create_user.yml
     - name: Perform customization for zeus
       include_tasks: "{{ username }}.yml"
-  tags:
-    - zeus_user
-    - adoptopenjdk
 
 - name: Nagios account management
+  tags:
+    - nagios
+    - adoptopenjdk
   block:
     - name: Assign username variable
       set_fact:
         username: nagios
-    - name: create account
+    - name: Create account
       include_tasks: create_user.yml
     - name: Perform customization for zeus
       include_tasks: "{{ username }}.yml"
-  tags:
-    - nagios
-    - adoptopenjdk

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/users/tasks/nagios.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/users/tasks/nagios.yml
@@ -8,6 +8,7 @@
   register: nagios_lib
 
 - name: Install nagios libexec
+  when: nagios_lib.stat.exists == False
   block:
     - name: Transfer over Nagios Image
       copy:
@@ -37,8 +38,6 @@
         src: /opt/nagios
         dest: /usr/local/nagios
         state: link
-
-  when: nagios_lib.stat.exists == False
 
 - name: Add {{ username }} key
   authorized_key:

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/users/tasks/zeus.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/users/tasks/zeus.yml
@@ -16,6 +16,7 @@
   when: sudoers.stat.exists and sudoers.stat.isreg and Superuser_Account == "Enabled"
 
 - name: "Customize {{ username }}"
+  when: pubkey is defined and pubkey.stat.exists
   block:
     - name: Add key
       authorized_key:
@@ -30,7 +31,6 @@
         state: present
         regexp: '^zeus'
         line: 'zeus ALL=(ALL) NOPASSWD: ALL'
-  when: pubkey is defined and pubkey.stat.exists
 
 - name: Warn about missing authorization for zeus
   debug:

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/xlc_v13/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/xlc_v13/tasks/main.yml
@@ -15,6 +15,8 @@
   tags: xlc13
 
 - name: Unpack and install Vendor Files
+  when: xlc13.stat.isdir is undefined or xlc13.stat.isdir is false
+  tags: [xlc13, vendor_files]
   block:
     - name: Transfer and Extract XLC13
       unarchive:
@@ -39,8 +41,6 @@
       file:
         path: /tmp/usr
         state: absent
-  when: xlc13.stat.isdir is undefined or xlc13.stat.isdir is false
-  tags: [xlc13, vendor_files]
 
 - name: TestIBM XLC13
   command: /opt/IBM/xlC/13.1.3/bin/xlc -qversion

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/xlc_v16/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/xlc_v16/tasks/main.yml
@@ -15,6 +15,8 @@
   tags: xlc16
 
 - name: Vendor File processing
+  when: xlc16.stat.exists is false
+  tags: [xlc16, vendor_files]
   block:
     - name: Transfer and Extract XLC16
       unarchive:
@@ -39,8 +41,6 @@
       file:
         path: /tmp/usr
         state: absent
-  when: xlc16.stat.exists is false
-  tags: [xlc16, vendor_files]
 
 - name: Query xlC version
   command: /opt/IBM/xlC/16.1.0/bin/xlc -qversion

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/yum/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/yum/tasks/main.yml
@@ -37,6 +37,9 @@
 # new python installed via yum. During the second pass this block is skipped.
 ##############################################################################
 - name: "Install yum bundle from AIXToolbox (block #1)"
+  when: _yum.stat.islnk is not defined
+  tags:
+    - yum
   block:
     - name: Ensure dest exists
       file:
@@ -72,11 +75,10 @@
 
     - name: Install yum bundle
       command: rpm -i /tmp/yum/*.rpm
-  when: _yum.stat.islnk is not defined
-  tags:
-    - yum
 
 - name: "Update yum installation (Block #2)"
+  tags:
+    - yum
   block:
     - name: Remove /tmp/yum, if present
       file:
@@ -100,8 +102,6 @@
 
     - name: Ensure AIX_Toolbox_71 repo is enabled
       shell: yum-config-manager --enable AIX_Toolbox_71
-  tags:
-    - yum
 
 ##############################################################################
 # YUM AIXToolbox integration is installed

--- a/ansible/playbooks/AdoptOpenJDK_ITW_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_ITW_Playbook/main.yml
@@ -2,11 +2,12 @@
 #############################################
 # Install build requirements for IcedTeaWeb #
 #############################################
-
-- hosts: all
+- name: Ansible IcedTeaWeb playbook
+  hosts: all
   gather_facts: yes
   tasks:
-    - block:
+    - name: Load Variables
+      block:
       # Set standard variables
         - name: Load AdoptOpenJDKs variable file
           include_vars: group_vars/all/adoptopenjdk_variables.yml

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/dockerhost.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/dockerhost.yml
@@ -6,10 +6,12 @@
 # It can be defined as 'all' or a specific group which the host belongs to.
 # For example, it can be 'all' or 'x86' for when a host is in the group 'x86'.
 #- hosts: "{{ Groups | default('localhost:docker:!*zos*:!*win*:!*aix*') }}"
-- hosts: all
+- name: Ansible dockerhost playbook
+  hosts: all
   gather_facts: yes
   tasks:
-    - block:
+    - name: Load Variables
+      block:
       # Set standard variables
         - name: Load AdoptOpenJDKs variable file
           include_vars: group_vars/all/adoptopenjdk_variables.yml

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/git-hg-jenkins.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/git-hg-jenkins.yml
@@ -2,10 +2,12 @@
 #######################################################
 # AdoptOpenJDK - Ansible Playbook for git-hg machines #
 #######################################################
-- hosts: all
+- name: Ansible playbook for git-hg machines
+  hosts: all
   gather_facts: yes
   tasks:
-    - block:
+    - name: Load Variables
+      block:
       # Set standard variables
         - name: Load AdoptOpenJDKs variable file
           include_vars: group_vars/all/adoptopenjdk_variables.yml

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/linux_installer_setup.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/linux_installer_setup.yml
@@ -1,8 +1,10 @@
 ---
-- hosts: all
+- name: Run Installer Playbook
+  hosts: all
   gather_facts: yes
   tasks:
-    - block:
+    - name: Set Variables
+      block:
       # Set standard variables
         - name: Load AdoptOpenJDKs variable file
           include_vars: group_vars/all/adoptopenjdk_variables.yml

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -5,10 +5,12 @@
 # Groups can be passed in as a command-line variable in Ansible playbook.
 # It can be defined as 'all' or a specific group which the host belongs to.
 # For example, it can be 'all' or 'x86' for when a host is in the group 'x86'.
-- hosts: "{{ Groups | default('localhost:build:test:perf:jck:!*zos*:!*win*:!*aix*') }}"
+- name: Ansible Unix playbook
+  hosts: "{{ Groups | default('localhost:build:test:perf:jck:!*zos*:!*win*:!*aix*') }}"
   gather_facts: yes
   tasks:
-    - block:
+    - name: Run Tasks
+      block:
       # Set standard variables
         - name: Load AdoptOpenJDKs variable file
           include_vars: group_vars/all/adoptopenjdk_variables.yml

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Alpine.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Alpine.yml
@@ -98,6 +98,7 @@
 
 - name: Install JDK for aarch64
   when: ansible_architecture == "aarch64"
+  tags: build_tools
   block:
     - name: Check if Temurin jdk8 is installed
       stat:
@@ -219,4 +220,3 @@
         state: link
       when:
         - not zulu18_installed.stat.exists
-  tags: build_tools

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
@@ -111,6 +111,8 @@
   tags: patch_update
 
 - name: Remove expired cert \"DST Root CA X3\"
+  when: (ansible_distribution_major_version == "8") and (ansible_architecture == "x86_64")
+  tags: patch_update
   block:
     - name: Deselect certificate from ca-certificates.conf
       replace:
@@ -121,9 +123,6 @@
 
     - name: Refresh ca-certificates
       command: "update-ca-certificates --fresh"
-
-  when: (ansible_distribution_major_version == "8") and (ansible_architecture == "x86_64")
-  tags: patch_update
 
 ############################
 # Build Packages and tools #

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode/tasks/main.yml
@@ -21,6 +21,7 @@
   when: apple_variables is not defined
 
 - name: Install Xcode
+  when: apple_variables is defined
   block:
     - name: Ensure Ruby is installed for xcode-install
       become: yes
@@ -101,4 +102,3 @@
 
     - name: Set Xcode switch path to "/Applications/Xcode.app"
       shell: sudo xcode-select --switch "/Applications/Xcode.app"
-  when: apple_variables is defined

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/trss.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/trss.yml
@@ -3,14 +3,16 @@
 # AdoptOpenJDK Ansible TRSS Playbook       #
 # Currently supports Ubuntu 18 on x64 only #
 ############################################
-- hosts: all
+- name: Ansible TRSS Playbook
+  hosts: all
   user: root
   become: yes
   vars:
     TRSS_working_dir: "/home/jenkins/openjdk-test-tools/TestResultSummaryService"
     TRSS_config_path: "/data/db/credentials/trssConf.json"
   tasks:
-    - block:
+    - name: Run TRSS Tasks
+      block:
         - name: Load AdoptOpenJDKs variable file
           include_vars: group_vars/all/adoptopenjdk_variables.yml
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/ubuntu-jckservices.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/ubuntu-jckservices.yml
@@ -4,10 +4,12 @@
 # -------- Ubuntu 20 (tested on x64) -------- #
 ###############################################
 
-- hosts: all
+- name: Ansibl JCK Services Playbook
+  hosts: all
   gather_facts: yes
   tasks:
-    - block:
+    - name: Load Variables
+      block:
         - name: Load AdoptOpenJDKs variable file
           include_vars: group_vars/all/adoptopenjdk_variables.yml
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -21,8 +21,8 @@
 # Groups can be passed in as a command-line variable in Ansible playbook.
 # It can be defined as 'all' or a specific group which the host belongs to.
 # For example, it can be 'all' or 'x86' for when a host is in the group 'x86'.
-# - name: Ansible Windows playbook
-- hosts: "{{ Groups | default('build*win*:test*win*') }}"
+- name: Ansible Windows playbook
+  hosts: "{{ Groups | default('build*win*:test*win*') }}"
   gather_facts: yes
   tasks:
     - name: Load Standard Variables

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -21,8 +21,8 @@
 # Groups can be passed in as a command-line variable in Ansible playbook.
 # It can be defined as 'all' or a specific group which the host belongs to.
 # For example, it can be 'all' or 'x86' for when a host is in the group 'x86'.
-- name: Ansible Windows playbook
-  hosts: "{{ Groups | default('build*win*:test*win*') }}"
+# - name: Ansible Windows playbook
+  - hosts: "{{ Groups | default('build*win*:test*win*') }}"
   gather_facts: yes
   tasks:
     - name: Load Standard Variables

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -21,10 +21,12 @@
 # Groups can be passed in as a command-line variable in Ansible playbook.
 # It can be defined as 'all' or a specific group which the host belongs to.
 # For example, it can be 'all' or 'x86' for when a host is in the group 'x86'.
-- hosts: "{{ Groups | default('build*win*:test*win*') }}"
+- name: Ansible Windows playbook
+  hosts: "{{ Groups | default('build*win*:test*win*') }}"
   gather_facts: yes
   tasks:
-    - block:
+    - name: Load Standard Variables
+      block:
       # Set standard variables
         - name: Load AdoptOpenJDKs variable file
           include_vars: group_vars/all/adoptopenjdk_variables.yml

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -22,7 +22,7 @@
 # It can be defined as 'all' or a specific group which the host belongs to.
 # For example, it can be 'all' or 'x86' for when a host is in the group 'x86'.
 # - name: Ansible Windows playbook
-  - hosts: "{{ Groups | default('build*win*:test*win*') }}"
+- hosts: "{{ Groups | default('build*win*:test*win*') }}"
   gather_facts: yes
   tasks:
     - name: Load Standard Variables

--- a/ansible/playbooks/nagios/roles/Nagios_Config/tasks/Get_Ansible_Inventory.yml
+++ b/ansible/playbooks/nagios/roles/Nagios_Config/tasks/Get_Ansible_Inventory.yml
@@ -1,5 +1,5 @@
 ---
 - name: Download Ansible Inventory File
   get_url:
-     url: "{{inventory_path}}"
-     dest: "{{Input_Path}}"
+     url: "{{ inventory_path }}"
+     dest: "{{ Input_Path }}"


### PR DESCRIPTION
Correct a number of ansible linter errors related to structure / task names etc.

Also add 3 new exclusions to the linter excludes, as a large number of changes would need to be made and tested.

  - 'no-free-form' # Exclude As Requires Significant Changes ( 196 changes required )
  - 'fqcn[action]' # Exclude As Requires Significant Changes ( 249 changes required )
  - 'args[module]' # Exclude Experimental Rule Validation ( Prevents 4 experimental warnings )

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR