### PR TITLE
Nagios - Change references of ci.adoptopenjdk.net to ci.adoptium.net - check_agent_plugin

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/additional_plugins/nagios_server_plugins/check_agent
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/additional_plugins/nagios_server_plugins/check_agent
@@ -27,7 +27,7 @@ if ! command -v jq &> /dev/null; then
   exit 3
 fi
 
-CURL_RESPONSE=$(curl -s https://ci.adoptopenjdk.net/computer/$1/api/json?pretty=true)
+CURL_RESPONSE=$(curl -s https://ci.adoptium.net/computer/$1/api/json?pretty=true)
 if [[ $? != 0 ]]; then
   echo "UNKNOWN- Failed to get agent information"
   exit 3


### PR DESCRIPTION
Update the nagios server plugin check_agent to use the new URL.

Ref: Issue #2932 

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR