### PR TITLE
UnixPB: Add symlinks for libffi.so.6 on SLES12 & SLES15

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/SLES.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/SLES.yml
@@ -322,3 +322,25 @@
     - (ansible_architecture == "x86_64") or (ansible_architecture == "s390x")
     - not expat_installed.stat.exists
   tags: expat
+
+- name: Add libffi6 symlink for (SLES12, s390x)
+  file:
+    src: /usr/lib64/libffi.so.4
+    dest: /usr/lib64/libffi.so.6
+    owner: root
+    group: root
+    state: link
+  when:
+    - (ansible_distribution_major_version == "12" and ansible_architecture == "s390x")
+  tags: libffi_sles
+
+- name: Add libffi6 symlink for (SLES15, s390x)
+  file:
+    src: /usr/lib64/libffi.so.7
+    dest: /usr/lib64/libffi.so.6
+    owner: root
+    group: root
+    state: link
+  when:
+    - (ansible_distribution_major_version == "15" and ansible_architecture == "s390x")
+  tags: libffi_sles


### PR DESCRIPTION
Update unix playbooks for SLES12 and SLES15 to create a symlink for libffi.so.6, to the relevant installed version.

Fixes Build [#1058](https://github.com/adoptium/temurin-build/issues/1058)

VPC Running at : https://ci.adoptium.net/job/VagrantPlaybookCheck/1617/

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
