### PR TITLE
Temporarily remove the centos6 build from centos7_docker_image_updater

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,14 +3,6 @@ pipeline {
     stages {
         stage('Docker Build') {
             parallel { 
-                stage('CentOS6 x64') {
-                    agent {
-                        label "dockerBuild&&linux&&x64"
-                    } 
-                    steps {
-                        dockerBuild('amd64', 'centos6', 'Dockerfile.CentOS6')
-                    }
-                }
                 stage('CentOS7 x64') {
                     agent {
                         label "dockerBuild&&linux&&x64"
@@ -91,12 +83,6 @@ def dockerManifest() {
     docker.withRegistry('https://index.docker.io/v1/', 'dockerhub') {
         git poll: false, url: 'https://github.com/adoptium/infrastructure.git'
         sh '''
-            # Centos6
-            export TARGET="adoptopenjdk/centos6_build_image"
-            AMD64=$TARGET:linux-amd64
-            docker manifest create $TARGET $AMD64
-            docker manifest annotate $TARGET $AMD64 --arch amd64 --os linux
-            docker manifest push $TARGET
             # Centos7
             export TARGET="adoptopenjdk/centos7_build_image"
             AMD64=$TARGET:linux-amd64


### PR DESCRIPTION
ref https://github.com/adoptium/infrastructure/issues/2753

We are seeing failures in the centos6 build of the centos7_docker_image_updater pipeline, https://ci.adoptium.net/job/centos7_docker_image_updater/. Seeing as I have no ETA on when I can get this fixed, I am temporarily removing it from the pipeline as it is holding up the Docker Manifest stage of that job
