### PR TITLE
docker: add RHEL7 dockerfile for s390x builds

### DIFF
--- a/ansible/docker/Dockerfile.RHEL7
+++ b/ansible/docker/Dockerfile.RHEL7
@@ -1,0 +1,38 @@
+FROM registry.access.redhat.com/rhel7
+# This dockerfile should be built using:
+#  docker build --no-cache -t rhel7_build_image -f ansible/docker/Dockerfile.RHEL7 --build-arg ROSIUSER=******* --build-arg ROSIPW=******* --build-arg git_sha=******* `pwd`
+ARG ROSIUSER
+ARG ROSIPW
+RUN sed -i 's/\(def in_container():\)/\1\n    return False/g' /usr/lib64/python*/*-packages/rhsm/config.py
+RUN subscription-manager register --username=${ROSIUSER} --password=${ROSIPW} --auto-attach
+RUN subscription-manager repos --enable rhel-7-for-system-z-optional-rpms
+# ^^ Optional repo needed for Xvfb
+
+ARG git_sha
+ARG user=jenkins
+
+RUN yum -y update; yum install -y sudo
+RUN yum --enablerepo=rhel-7-server-ansible-2-for-system-z-rpms install -y ansible
+RUN yum clean all
+
+COPY . /ansible
+
+RUN echo "localhost ansible_connection=local" > /ansible/hosts
+
+RUN set -eux; \
+ cd /ansible; \
+ ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml -e "git_sha=$git_sha" --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit,locales,ntp_time"
+# ^^^ locales ommitted because locale-gen isn't present on RHEL and the ones we install aren't there by default
+
+RUN rm -rf /ansible; yum remove ansible; yum clean all
+
+RUN groupadd -g 1003 ${user}
+RUN useradd -c "Jenkins user" -d /home/${user} -u 1002 -g 1003 -m ${user}
+
+ENV \
+    JDK7_BOOT_DIR="/usr/lib/jvm/java-1.7.0-openjdk" \
+    JDK8_BOOT_DIR="/usr/lib/jvm/java-1.8.0-openjdk" \
+    JDK10_BOOT_DIR="/usr/lib/jvm/jdk-10" \
+    JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"
+RUN subscription-manager unregister
+

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -15,6 +15,7 @@ Build_Tool_Packages:
   - curl
   - cups-devel
   - elfutils-libelf-devel
+  - file
   - flex                          # OpenJ9
   - fontconfig-devel
   - freetype-devel


### PR DESCRIPTION
Fixes https://github.com/adoptium/infrastructure/issues/2731

Note that this has been hard coded with UID1002 which is the `jenkins` user ID as it is deployed on our Marist/s390x hosts. Other systems may vary, and will result in the error from https://github.com/adoptium/infrastructure/issues/2834

Requires https://github.com/adoptium/ci-jenkins-pipelines/pull/611 to be usable. We should also consider if this can reasonably be added into the [docker image updater](https://ci.adoptium.net/job/centos7_docker_image_updater/) job or have another way to update these images when required.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
