### PR TITLE
winPb: Update vs2019 installation to use defined layout

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
@@ -3,12 +3,75 @@
 # Visual Studio Community 2019 #
 ################################
 
+- name: Register AdoptOpenJDK Var
+  ansible.builtin.set_fact:
+    AdoptYes: false
+
+- name: Set AdoptOpenJDK Var If Running With AdoptOpenJDK Tag
+  ansible.builtin.set_fact:
+    AdoptYes: true
+  tags: adoptopenjdk
+
 - name: Test if VS 2019 is installed
   win_stat:
     path: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community'
   register: vs2019_installed
   tags: MSVS_2019
 
+- name: Test if VS 2019 Layout is available
+  stat: path=/Vendor_Files/windows/VS2019_layout.16.11.32106.67.zip
+  register: vs2019_layout_available
+  delegate_to: localhost
+  run_once: true
+  tags: MSVS_2019
+
+- name: Transfer VS2019 Layout File
+  win_copy:
+    src: /Vendor_Files/windows/VS2019_layout.16.11.32106.67.zip
+    dest: C:\TEMP\VS2019_Layout.zip
+    remote_src: no
+  when: (vs2019_layout_available.stat.exists)
+
+# Check For The Transferred File & Exit If AdoptOpenJDK Run
+- name: Check If Layout Has Transferred
+  win_stat:
+    path: 'C:\TEMP\VS2019_Layout.zip'
+  register: vs2019_layout_ready
+  tags: MSVS_2019
+
+# Exit Play If No VS2019 Layout & AdoptOpenJDK = true
+# This Is Defined Behaviour - This Shouldnt Occur But If It Does, Its Captured Here
+- name: Exit With Error When No Layout Within AdoptOpenJDK
+  fail:
+    msg: "The VS2019 Layout File Appears To Be Missing From The Vendor_Files"
+  when: (not vs2019_layout_ready.stat.exists) and ( AdoptYes|bool == true)
+  tags: MSVS_2019
+
+# Install VS2019 From Layout For AdoptOpenJDK
+- name: Unzip VS2019 Layout
+  win_unzip:
+    src: C:\TEMP\VS2019_Layout.zip
+    dest: C:\TEMP
+  when: (vs2019_layout_ready.stat.exists)
+  tags: MSVS_2019
+
+- name: Run Visual Studio 2019 Installer From Layout
+  win_shell: |
+      Start-Process -Wait -FilePath 'C:\temp\VSLayout2019\vs_community.exe' -ArgumentList '--nocache --quiet --norestart --wait --noweb --add Microsoft.VisualStudio.Workload.NativeDesktop --includeRecommended --includeOptional --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.ATL.ARM64 --add Microsoft.VisualStudio.Component.VC.MFC.ARM64'
+  args:
+    executable: powershell
+  when: (vs2019_layout_ready.stat.exists) and (not vs2019_installed.stat.exists)
+  tags: MSVS_2019
+
+## Check If VS2019 Has Been Installed From Layout Even If Not AdoptOpenJDK
+
+- name: Test if VS 2019 is installed
+  win_stat:
+    path: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community'
+  register: vs2019_installed
+  tags: MSVS_2019
+
+# Download & Install VS2019 When No Layout & Not AdoptOpenJDK
 # This is the target that you're redirected to when you go to https://aka.ms/vs/16/release/vs_community.exe
 - name: Download Visual Studio Community 2019
   win_get_url:
@@ -17,14 +80,15 @@
     checksum_algorithm: sha256
     dest: 'C:\temp\vs_community19.exe'
     force: no
-  when: (not vs2019_installed.stat.exists)
+  when: (not vs2019_installed.stat.exists) and ( AdoptYes|bool == false)
   tags: MSVS_2019
 
-- name: Install Visual Studio Community 2019
-  win_shell: 'C:\temp\vs_community19.exe --wait --add Microsoft.VisualStudio.Workload.NativeDesktop;includeRecommended;includeOptional --quiet --norestart'
+- name: Run Visual Studio 2019 Installer From Download
+  win_shell: |
+      Start-Process -Wait -FilePath 'C:\temp\vs_community19.exe' -ArgumentList '--wait --add Microsoft.VisualStudio.Workload.NativeDesktop --includeRecommended --includeOptional --quiet --norestart'
   args:
-    executable: cmd
-  when: (not vs2019_installed.stat.exists)
+    executable: powershell
+  when: (not vs2019_installed.stat.exists) and ( AdoptYes|bool == false)
   register: vs2019_error
   failed_when: vs2019_error.rc != 0 and vs2019_error.rc != 3010
   tags: MSVS_2019
@@ -33,7 +97,7 @@
   win_shell: Start-Process -FilePath 'C:\temp\vs_community19.exe' -Wait -NoNewWindow -ArgumentList
     'modify --installPath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community" --quiet
     --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.ATL.ARM64 --add Microsoft.VisualStudio.Component.VC.MFC.ARM64'
-  when: (not vs2019_installed.stat.exists)
+  when: (not vs2019_installed.stat.exists) and ( AdoptYes|bool == false)
   tags: MSVS_2019
 
 - name: Register Visual Studio Community 2019 DIA SDK shared libraries
@@ -41,6 +105,8 @@
   with_items:
     - C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\DIA SDK\bin\msdia140.dll
     - C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\DIA SDK\bin\amd64\msdia140.dll
+  when: (not vs2019_installed.stat.exists)
+  # when: (not vs2019_installed.stat.exists) and ( AdoptYes|bool == false)
   tags: MSVS_2019
 
 - name: Reboot machine after Visual Studio installation

--- a/ansible/vagrant/Vagrantfile.Windows2022.Core
+++ b/ansible/vagrant/Vagrantfile.Windows2022.Core
@@ -1,0 +1,52 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Runs Powershell as an administator and does the following:
+#  - Gets/executes an Ansible provided script that configures WinRM to allow Ansible to communicate over it.
+#  - Resizes the disk to ~100GB, in line with the 'disksize.size = 100GB' option in the config below
+
+$script = <<SCRIPT
+Start-Process powershell -Verb runAs
+
+
+wget https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile .\\ConfigureRemotingForAnsible.ps1
+.\\ConfigureRemotingForAnsible.ps1 -CertValidityDays 9999
+.\\ConfigureRemotingForAnsible.ps1 -EnableCredSSP
+.\\ConfigureRemotingForAnsible.ps1 -ForceNewSSLCert
+.\\ConfigureRemotingForAnsible.ps1 -SkipNetworkProfileCheck
+
+# Retrieving disk's current size
+$currentDiskSize =(Get-Partition -DriveLetter c | select Size)
+$currentDiskSize =($currentDiskSize -replace "[^0-9]" , "")
+# The size the disk should be, in bytes (130GB)
+$diskSizeBoundary = 139586437120
+# Changing the disksize to max supported size (~130GB)
+if ([long]$currentDiskSize -lt $diskSizeBoundary) {
+        echo "Resizing disk to max size"
+        $size = (Get-PartitionSupportedSize -DriveLetter c); Resize-Partition -DriveLetter c -Size $size.SizeMax
+}else {
+        echo "Disk is already at max size"
+}
+
+Start-Process cmd -Verb runAs
+winrm set winrm/config/service '@{AllowUnencrypted="true"}'
+SCRIPT
+
+# 2 = version of configuration file for Vagrant 1.1+ leading up to 2.0.x
+Vagrant.configure("2") do |config|
+
+  config.vm.define :adoptopenjdkW2022 do |adoptopenjdkW2022|
+    adoptopenjdkW2022.vm.box = "gusztavvargadr/windows-server-2022-standard-core"
+    adoptopenjdkW2022.vm.hostname = "adoptopenjdkW2022"
+    adoptopenjdkW2022.vm.communicator = "winrm"
+    adoptopenjdkW2022.vm.synced_folder ".", "/vagrant"
+    adoptopenjdkW2022.vm.network :private_network, type: "dhcp"
+    adoptopenjdkW2022.vm.provision "shell", inline: $script, privileged: false
+    adoptopenjdkW2022.disksize.size = '130GB'
+  end
+  config.vm.provider "virtualbox" do |v|
+    v.gui = false
+    v.memory = 5120
+    v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
+  end
+end


### PR DESCRIPTION
Update Windows Playbook to install VS2019 from a pre-defined layout, defined as part of https://github.com/adoptium/temurin-build/issues/2978.

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)