### PR TITLE
inventory: Add win2022 machines and update windows docs for installing jenkins agent as a service.

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -42,6 +42,8 @@ hosts:
           win2012r2-x64-1: {ip: 51.132.23.101, user: adoptopenjdk}
           win2012r2-x64-2: {ip: 51.132.22.249, user: adoptopenjdk}
           win2016-x64-1: {ip: 51.104.239.17, user: adoptopenjdk}
+          win2022-x64-1: {ip: 172.187.129.163, user: adoptopenjdk}
+          win2022-x64-2: {ip: 172.187.176.15, user: adoptopenjdk}
 
       - digitalocean:
           centos69-x64-2: {ip: 167.71.130.191}

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/README.md
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/README.md
@@ -8,14 +8,46 @@ Note: If setting up a win2012r2 machine, `[Net.ServicePointManager]::SecurityPro
 
 2) Run the playbook on the machine, without skipping the 'adoptopenjdk' and 'jenkins' tags. (See [this](https://github.com/adoptium/infrastructure/blob/master/ansible/README.md) for more information).
 
-3) Login to the Jenkins user on the machine via RDP.
+3) Login as the Jenkins user on the machine via RDP, and ensure access can be gained, and create 2 directories, one for the jenkins workspace ( typically called workspace, and a parallel directory called agent.
 
-4) On the machine, in a web browser, login to [ci.adoptium.net](https://ci.adoptium.net/), create a new node and download/run the `slave-agent.jnlp`. [IcedTea-Web](https://adoptopenjdk.net/icedtea-web.html) (or another `javaws` implementation) will need to be installed to run the `.jnlp` file.
+4) On any machine, in a web browser, login to [ci.adoptium.net](https://ci.adoptium.net/), create a new node ( best done as a copy of an existing node ), but ensure the launch option is set to "Launch Agent By Connecting It To A Controller"
 
-5) Install the Jenkins agent as a service, by clicking 'File > Install as a Service'. This will require the Administrator credentials.
+5) Login as the administrator user on the machine via RDP, and download the relevant [WinSW - Windows Service Wrapper](https://github.com/winsw/winsw/releases/) executable for the platform, e.g [WinSW-x64.exe](https://github.com/winsw/winsw/releases/download/v2.12.0/WinSW-x64.exe)  and copy the downloaded file to the agent directory created in step 3.
 
-6) Ensure the Jenkins Agent starts as the Jenkins user, under the 'Properties/Log On` tab of the 'Jenkins agent' service.
+6) In the created agent directory, rename the file downloaded in step 5) from WinSW-x64.exe to something meaningful, e.g. JenkinsAgentService.exe
 
-7) If done correctly, under the `C:\Users\jenkins\` directory, there will be a series of `jenkins-slave.*` files, as well as the default Windows home folders, such as 'Desktop','Contacts' and 'Documents' etc.
+7) Create an accompanying XML file in the agent directory, and give it the same name as the renamed executable, but with an xml file extension, e.g JenkinsAgentService.xml.
 
-8) Ensure you have signed out of ci.adoptium.net
+8) Now edit the xml file and populate the file in a similar fashion to the below, the key , edit the fields from the example shown below as appropriate:
+   - **id** :  This should be set to a unique name for the windows service
+   - **name** : This should be set to a descriptive name, and will be the name of the service displayed on the screen in windows
+   - **description** : This should be set to a meaningful description
+   - **executable** : This should be set to the full path to the  java executable, that will be used to run the jenkins agent.
+   - **arguments** This can be obtained from the node configuration page in Jenkins, the *xxxxxx* should reflect the name of the node being created in jenkins, and the *yyyyyyyy* string will be an encoded hex string, used for passing the jenkins user password
+   - **download from** the URL here should be changed to match the jenkins server name, from which the service can download the agent.jar
+
+	All other fields can be left as in the example.
+
+>     <service>
+>       <id>Jenkins</id>
+>       <name>Jenkins</name>
+>      <description>This service runs an agent for Jenkins automation server.</description>
+>      <executable>C:\openjdk\jdk-17\bin\java.exe</executable>
+>      <arguments>-Xrs -jar "%BASE%\agent.jar" -jnlpUrl https://ci.adoptium.net/computer/xxxxxxxxxx/jenkins-agent.jnlp -secret yyyyyyyyyyyyy -workDir=F:\workspace</arguments>
+>      <logmode>rotate</logmode>
+>      <onfailure action="restart" />
+>        <download from="https://ci.adoptium.net/jnlpJars/agent.jar" to="%BASE%\agent.jar"/>
+>      </service>
+
+9)  As the windows administrator, open an elevated command prompt, and now create the Jenkins agent service by following this process :
+
+	 - cd to the agent directory ( where the executable and xml file are stored )
+	 - run the executable with a parameter install (e.g **.\JenkinsAgentService.exe INSTALL**)
+ 
+	 You should get confirmation prompts on screen that the service has been created.
+	 
+	- Next open the windows services dialog, and identify the Jenkins service that has just been created. Right click on the service and select **Properties** from the pop up menu.
+	- Select the log on tab from the dialog, and change the logon type from local system account to the jenkins account, and enter the password for the jenkins user, followed by **Ok**
+	
+	You should now get some confirmations, that the Jenkins user has been granted the log on as a service permission, and you should be able to start the service, and check that the agent is online and available in Jenkins.
+

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/README.md
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/README.md
@@ -46,8 +46,7 @@ Note: If setting up a win2012r2 machine, `[Net.ServicePointManager]::SecurityPro
  
 	 You should get confirmation prompts on screen that the service has been created.
 	 
-	- Next open the windows services dialog, and identify the Jenkins service that has just been created. Right click on the service and select **Properties** from the pop up menu.
-	- Select the log on tab from the dialog, and change the logon type from local system account to the jenkins account, and enter the password for the jenkins user, followed by **Ok**
+	- Next open the windows services dialog, and identify the Jenkins service that has just been created. Right click on the service and select **Start** from the pop up menu.
 	
-	You should now get some confirmations, that the Jenkins user has been granted the log on as a service permission, and you should be able to start the service, and check that the agent is online and available in Jenkins.
+The jenkins service should then be started.
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/README.md
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/README.md
@@ -46,7 +46,11 @@ Note: If setting up a win2012r2 machine, `[Net.ServicePointManager]::SecurityPro
  
 	 You should get confirmation prompts on screen that the service has been created.
 	 
-	- Next open the windows services dialog, and identify the Jenkins service that has just been created. Right click on the service and select **Start** from the pop up menu.
+	- Next open the windows services dialog, and identify the Jenkins service that has just been created. Right click on the service and select **Properties** from the pop up menu.
+	- Select the log on tab from the dialog, and change the logon type from local system account to the jenkins account, and enter the password for the jenkins user, followed by **Ok**
+	- Finally right click on the service, and select **Start** from the pop up menu.
+	
+	You should now get some confirmations, that the Jenkins user has been granted the log on as a service permission, and you should be able to start the service, and check that the agent is online and available in Jenkins.
 	
 The jenkins service should then be started.
 


### PR DESCRIPTION
Fixes #2938 

Add new windows 2022 machines to inventory, and update the windows playbook documentation on how to install the jenkins agent as a service.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] other documentation is changed or added (if applicable)
- [X] VPC/QPC not applicable for this PR
- [X] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Jenkins : https://ci.adoptium.net/computer/build-azure-win2022-x64-1/ & https://ci.adoptium.net/computer/build-azure-win2022-x64-2/
Nagios :  https://nagios.adoptopenjdk.net/nagios/cgi-bin/extinfo.cgi?type=1&host=build-azure-win2022-x64-1 & https://nagios.adoptopenjdk.net/nagios/cgi-bin/extinfo.cgi?type=1&host=build-azure-win2022-x64-2