### PR TITLE
doc: Add information on adoptium server backups

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,6 +157,7 @@ Wherever possible, prefix the commit message with the area which you are changin
 - plugins:
 - inventory:
 - github:
+- tools:
 
 ## Further Docs
 

--- a/README.md
+++ b/README.md
@@ -114,27 +114,9 @@ TODO Need to check all of this
 
 ### Backups
 
-The following items are stored in GitHub.
-
-* Source code, System deployment scripts (Ansible), Instructions/How to Information
-
-|  Description | Storage Location | Frequency  |
-|---|---|---|
-| Jenkins (ci) - Configuration and Settings | localhost `/mnt/backup-server/jenkins_backup` | Daily |
-| Nagios - Configuration and Settings | localhost `/root/backups` | Weekly |
-| AWX - Configuration and Settings | not currently backed up | N/A |
-
-### Questions
-
-Backup schedule:
-
-* How often should be backup?
-* Where should it be stored?
-
-Backup retention:
-
-* How long should be keep it?
-* How many copies?
+These are taken on a daily basis, and one per month is currently kept
+"forever" on our backup server. Details are now in a
+[separate document](docs/Backups.md)
 
 ### OS Patch Management
 

--- a/docs/Backups.md
+++ b/docs/Backups.md
@@ -1,0 +1,35 @@
+# Adoptium critical server backup policy
+
+The main servers used as jenkins agents contain no permanent information on
+them so is not backed up. A new deployment of the appropriate playbooks is
+expected to be able to set up the machines from scratch without any
+problems.
+
+The other servers are backed up on a daily basis. Currently these occur to
+the machine that runs our Bastillion server in `~backups`.
+
+Jenkins performs its own backups with the "thinbackup" plugin which takes
+one "full" backup on the first of the month, and daily increemental backups
+thereafter. Prior to April 2023 this was a full backup on Monday, and
+inrementals for the rest of the week.
+
+A number of changes were made in March 2023 to reduce the amount of space
+that the backups require as some superfluous material was being retained.
+
+Product | Size/day | What is backed up
+--- | --- | ---
+bastillion | 21Mb | Full product backup with database
+nagios | 140Mb | Entire /usr/local/nagios (Now excludes `nagiosgraph.log` and `archives`)
+TRSS | 650Mb | Mongodump of database
+jenkins | ~16Mb (*) | config.xmls, plus text file with plugin list
+
+(*) - In addition to the 16Mb, `.tar.xz` backups (~45Mb) of the "full"
+thinbackup files on the jenkins server will also be taken when new ones are
+available (Currently once per month) so the total will be around 18Mb/day on
+average.
+
+Older backups will be automatically cleared, but the ones dated on the first
+of the month will always be retained.
+
+The script that performs this work is at
+https://github.com/adoptium/infrastructure/blob/master/ansible/tools/run_backup.sh

--- a/tools/run_backups
+++ b/tools/run_backups
@@ -1,0 +1,49 @@
+#!/bin/sh
+set -x
+cd /home/backups || exit 1
+echo $(date +%T) : Starting backups of jenkins config.xml files ...
+ssh jenkins@ci.adoptium.net 'ls -1 /home/jenkins/.jenkins/plugins/*.?pi | while read FILENAME; do basename $FILENAME ; unzip -p $FILENAME META-INF/MANIFEST.MF | sort -d | grep "Short-Name\|Long-Name\|Plugin-Version" ; echo --- ; done > /home/jenkins/.jenkins/pluginVersions.txt'
+#ssh jenkins@ci.adoptopenjdk.net 'tar czf - $(find . -name config.xml )' > jenkins/jenkins.$(date +%Y%m%d).tar.gz
+ssh jenkins@ci.adoptium.net 'find . \( -name config.xml -o -name pluginVersions.txt \) | grep -v config-history | tar czf - -T -' > jenkins/jenkins.$(date +%Y%m%d).tar.gz
+ssh jenkins@ci.adoptium.net 
+#echo $(date +%T) : I would delete $(ls -1 jenkins/jenkins.*.gz | grep -v 20....01.tar.gz | head -n -3)
+rm -v $(ls -1 jenkins/jenkins.*.gz | grep -v 20....01.tar.gz | head -n -3)
+echo $(date +%T) : Backup up jenkins thin backup file if there has is one ...
+# scp jenkins@ci.adoptopenjdk.net:/mnt/backup-server/jenkins_backup_v2/adopt_jenkins_$(date -d yesterday +%y%m%d).tar.xz jenkins/
+
+LASTTHINBACKUP=$(ssh jenkins@ci.adoptium.net "cd /mnt/backup-server/jenkins_thinbackup && ls -rtd FULL* | tail -1")
+LASTTHINBACKUPLOCALDATE=$(echo $LASTTHINBACKUP | cut -d- -f2- | cut -d_ -f1 | tr -d -)
+if [ -z "$LASTTHINBACKUPLOCALDATE=" ]; then
+  echo $(date +%T) :  FORMAT ERROR in last thin backup date - cannot take backup
+else
+  if [ ! -r jenkins/thinbackup.${LASTTHINBACKUPLOCALDATE}.tar.xz ]; then
+    echo $(date +%T) : Backup up last full thinbackup from $LASTTHINBACKUP ...
+    ssh jenkins@ci.adoptium.net tar cJf - -C /mnt/backup-server/jenkins_thinbackup $LASTTHINBACKUP > jenkins/thinbackup.${LASTTHINBACKUPLOCALDATE}.tar.xz
+  else
+    echo $(date +%T) : No new full thinbackup - skipping
+  fi
+fi
+# Not deleting yet until I have a good algorithm for the dates
+# rm -v $(ls -1 jenkins/thinbackup.*.xz | grep -v 20....01.tar.gz | head -n -3)
+
+#ls /mnt/backup-server/*2
+#adopt_jenkins_000000.tar.xz adopt_jenkins_200416.tar.xz
+
+echo $(date +%T) : Backing up /usr/local/nagios ...
+ssh nagios@nagios.adoptopenjdk.net tar czf - --exclude=nagiosgraph.log --exclude=archives /usr/local/nagios > nagios/nagios.$(date +%Y%m%d).tar.gz
+#echo $(date +%T) : I would delete $(ls -1 nagios/nagios.*.gz | grep -v 20....01.tar.gz | head -n -3)
+rm -v $(ls -1 nagios/nagios.*.gz | grep -v 20....01.tar.gz | head -n -3)
+
+echo $(date +%T) : Backing up Bastillion-jetty directory ...
+tar czf bastillion/bastillion.$(date +%Y%m%d).tar.gz -C /home/bastillion Bastillion-jetty
+#echo $(date +%T) : I would delete $(ls -1 bastillion/bastillion.*.gz | grep -v 20....01.tar.gz | head -n -3)
+
+echo $(date +%T) : Backing up TRSS using mongodump ...
+ssh backups@54.78.186.5 mongodump --archive --db=exampleDb | xz > trss/trss.$(date +%Y%m%d).tar.xz
+#echo $(date +%T) : I would delete $(ls -1 trss/trss.*.?z | grep -v 20....01.tar..z | head -n -3)
+rm -v $(ls -1 trss/trss.*.?z | grep -v 20....01.tar..z | head -n -3)
+
+echo $(date +%T) : Backing up jenkins userContent via rsync
+rsync -arv jenkins@ci.adoptium.net:userContent jenkins
+
+echo $(date +%T) : All done

--- a/tools/run_backups
+++ b/tools/run_backups
@@ -3,13 +3,11 @@ set -x
 cd /home/backups || exit 1
 echo $(date +%T) : Starting backups of jenkins config.xml files ...
 ssh jenkins@ci.adoptium.net 'ls -1 /home/jenkins/.jenkins/plugins/*.?pi | while read FILENAME; do basename $FILENAME ; unzip -p $FILENAME META-INF/MANIFEST.MF | sort -d | grep "Short-Name\|Long-Name\|Plugin-Version" ; echo --- ; done > /home/jenkins/.jenkins/pluginVersions.txt'
-#ssh jenkins@ci.adoptopenjdk.net 'tar czf - $(find . -name config.xml )' > jenkins/jenkins.$(date +%Y%m%d).tar.gz
 ssh jenkins@ci.adoptium.net 'find . \( -name config.xml -o -name pluginVersions.txt \) | grep -v config-history | tar czf - -T -' > jenkins/jenkins.$(date +%Y%m%d).tar.gz
 ssh jenkins@ci.adoptium.net 
 #echo $(date +%T) : I would delete $(ls -1 jenkins/jenkins.*.gz | grep -v 20....01.tar.gz | head -n -3)
 rm -v $(ls -1 jenkins/jenkins.*.gz | grep -v 20....01.tar.gz | head -n -3)
 echo $(date +%T) : Backup up jenkins thin backup file if there has is one ...
-# scp jenkins@ci.adoptopenjdk.net:/mnt/backup-server/jenkins_backup_v2/adopt_jenkins_$(date -d yesterday +%y%m%d).tar.xz jenkins/
 
 LASTTHINBACKUP=$(ssh jenkins@ci.adoptium.net "cd /mnt/backup-server/jenkins_thinbackup && ls -rtd FULL* | tail -1")
 LASTTHINBACKUPLOCALDATE=$(echo $LASTTHINBACKUP | cut -d- -f2- | cut -d_ -f1 | tr -d -)
@@ -23,11 +21,7 @@ else
     echo $(date +%T) : No new full thinbackup - skipping
   fi
 fi
-# Not deleting yet until I have a good algorithm for the dates
 # rm -v $(ls -1 jenkins/thinbackup.*.xz | grep -v 20....01.tar.gz | head -n -3)
-
-#ls /mnt/backup-server/*2
-#adopt_jenkins_000000.tar.xz adopt_jenkins_200416.tar.xz
 
 echo $(date +%T) : Backing up /usr/local/nagios ...
 ssh nagios@nagios.adoptopenjdk.net tar czf - --exclude=nagiosgraph.log --exclude=archives /usr/local/nagios > nagios/nagios.$(date +%Y%m%d).tar.gz


### PR DESCRIPTION
Fixes https://github.com/adoptium/infrastructure/issues/1295

For ease of reviewing feel free to start browsing the formatted pages at https://github.com/sxa/infrastructure/tree/backupdocs#backups

Note that the script being added here is the one that has been used live on the server for sometime other than me changing backticks to `$(...)` which is a known thing that upsets the linter so the functionality is basically sound ;-)

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [x] other documentation is changed or added (if applicable)
