### PR TITLE
inventory: decommission win 2016 build server

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -41,7 +41,6 @@ hosts:
       - azure:
           win2012r2-x64-1: {ip: 51.132.23.101, user: adoptopenjdk}
           win2012r2-x64-2: {ip: 51.132.22.249, user: adoptopenjdk}
-          win2016-x64-1: {ip: 51.104.239.17, user: adoptopenjdk}
           win2022-x64-1: {ip: 172.187.129.163, user: adoptopenjdk}
           win2022-x64-2: {ip: 172.187.176.15, user: adoptopenjdk}
 


### PR DESCRIPTION
The server is no longer needed as we've switched win aarch64 builds to win2022

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
