### PR TITLE
unixPB: Add perl-IPC-Cmd to Redhat/CentOS installs for OpenSSL v3

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -45,6 +45,7 @@ Build_Tool_Packages:
   - perl-devel
   - perl-Digest-SHA
   - perl-GD
+  - perl-IPC-Cmd                  # required for openssl v3 compiles
   - perl-libwww-perl
   - perl-Time-HiRes
   - pigz
@@ -82,7 +83,6 @@ Additional_Build_Tools_CentOS_x86:
   - glibc.i686                    # a dependency required for executing a 32-bit C binary
   - glibc-devel.i686              # a dependency required for executing a 32-bit C binary
   - libstdc++.i686                # a dependency required for executing a 32-bit C binary
-  - perl-IPC-Cmd                  # required for openssl v3 compiles
 
 Additional_Build_Tools_CentOS8_Stream:
   - libdwarf.x86_64

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -41,6 +41,7 @@ Build_Tool_Packages:
   - mpfr-devel
   - openssl-devel
   - perl-devel
+  - perl-IPC-Cmd                  # required for openssl v3 compiles
   - pkgconfig
   - systemtap-sdt-devel
   - unzip
@@ -71,7 +72,6 @@ Additional_Build_Tools_RHEL_x86:
   - glibc.i686                    # a dependency required for executing a 32-bit C binary
   - glibc-devel.i686              # a dependency required for executing a 32-bit C binary
   - libstdc++.i686                # a dependency required for executing a 32-bit C binary
-  - perl-IPC-Cmd                  # required for openssl v3 compiles
 
 Additional_Build_Tools_RHEL_ppc64:
   - glibc.ppc                     # a dependency required for executing a 32-bit C binary


### PR DESCRIPTION
* compiling openssl v3 within container or system requires this package
* see https://github.com/eclipse-openj9/openj9/pull/14930

These were added in https://github.com/adoptium/infrastructure/pull/2855 but in the wrong place. perl-IPC-Cmd is required for all platforms.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
