### PR TITLE
inventory: Remove decommissioned marist test host.

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -166,7 +166,6 @@ hosts:
           macos11-arm64-2: {ip: 199.7.163.52, user: Administrator}
 
       - marist:
-          sles12-s390x-1: {ip: 148.100.86.128}
           rhel7-s390x-1: {ip: 148.100.84.26, user: linux1, description: test machine in marist cloud}
           rhel8-s390x-1: {ip: 148.100.84.52, user: linux1, description: test machine in marist cloud}
           rhel7-s390x-2: {ip: 148.100.74.92}


### PR DESCRIPTION
Fixes issue #1655 

Remove marist test host, as machine has been replaced, and this one should be decomissioned.

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR
- [X] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Host will be removed from nagios & jenkins, once this PR is merged.
