### PR TITLE
NagiosPB: Fix: Create missing nagios users home directory

### DIFF
--- a/ansible/playbooks/nagios/roles/Nagios_Server/tasks/install_nagios_core.yml
+++ b/ansible/playbooks/nagios/roles/Nagios_Server/tasks/install_nagios_core.yml
@@ -95,6 +95,14 @@
     state: present
   become: yes
 
+- name: Create nagios user's home folder
+  file:
+    path: /home/nagios
+    state: directory
+    owner: "nagios"
+    group: nagios
+    mode: 0700
+
 - name: Restart Nagios
   service:
     name: nagios


### PR DESCRIPTION
The nagios server core installation creates a nagios user, but doesn't create its home directory.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
(https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [X] VPC/QPC not applicable for this PR

