### PR TITLE
unixPb: Skip MacOS package upgrade on 10.15 and under

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
@@ -23,6 +23,16 @@
   debug:
     var: macos_version_number
 
+- name: Set homebrew path (x64)
+  set_fact:
+    homebrew_path: /usr/local/bin/brew
+  when: ansible_architecture == "x86_64"
+
+- name: Set homebrew path (Arm64)
+  set_fact:
+    homebrew_path: /opt/homebrew/bin/brew
+  when: ansible_architecture == "arm64"
+
 - name: Configure system-wide Bash profile
   become: yes
   copy:
@@ -57,7 +67,7 @@
 
 - name: Check if Homebrew is already installed
   stat:
-    path: /usr/local/bin/brew
+    path: "{{ homebrew_path }}"
   register: brew
 
 - name: Install Homebrew
@@ -71,7 +81,7 @@
   become_user: "{{ ansible_user }}"
   homebrew:
     upgrade_all: yes
-  when: "macos_version_number is version('10.14', '>')"
+  when: "macos_version_number is version('10.15', '>')"
   tags:
     - brew_upgrade
 
@@ -93,20 +103,7 @@
 - name: Update Casks
   become: yes
   become_user: "{{ ansible_user }}"
-  command: /usr/local/bin/brew cu
-  when:
-    - ansible_architecture != "arm64"
-  tags:
-    - brew_cu
-    - skip_ansible_lint
-
-# Skipping linting as no situation where this can't run (lint error 301)
-- name: Update Casks (Arm64)
-  become: yes
-  become_user: "{{ ansible_user }}"
-  command: /opt/homebrew/bin/brew cu
-  when:
-    - ansible_architecture == "arm64"
+  command: "{{ homebrew_path }}" cu -y
   tags:
     - brew_cu
     - skip_ansible_lint

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
@@ -103,7 +103,7 @@
 - name: Update Casks
   become: yes
   become_user: "{{ ansible_user }}"
-  command: "{{ homebrew_path }}" cu -y
+  command: "{{ homebrew_path }} cu -y"
   tags:
     - brew_cu
     - skip_ansible_lint

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
@@ -71,7 +71,7 @@
   become_user: "{{ ansible_user }}"
   homebrew:
     upgrade_all: yes
-  when: "macos_version_number is version('10.13', '>')"
+  when: "macos_version_number is version('10.14', '>')"
   tags:
     - brew_upgrade
 


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

10.15 has been out of support for some time now, https://endoflife.date/macos

```
TASK [Common : Upgrade installed packages] *************************************
fatal: [test-macstadium-macos1015-x64-1]: FAILED! => {"changed": false, "msg": "Warning: You are using macOS 10.15.\nWe (and Apple) do not provide support for this old version.\nIt is expected behaviour that some formulae will fail to build in this old version.\nIt is expected behaviour that Homebrew will be buggy and slow.\nDo not create any issues about this on Homebrew's GitHub repositories.\nDo not create any issues even if you think this message is unrelated.\nAny opened issues will be immediately closed without response.\nDo not ask for help from Homebrew or its maintainers on social media.\nYou may ask for help in Homebrew's discussions but are unlikely to receive a response.\nTry to figure out the problem yourself and submit a fix as a pull request.\nWe will review it but may or may not accept it.\n\nError: Your Xcode (10.3) is too outdated.\nPlease update to Xcode 12.4 (or delete it).\nXcode can be updated from the App Store."}
```

This task needs to be skipped on macos boxes that are 10.15 and under until we can provide a patching solution ourselves or upgrade the machines, I am in favour of the latter.

I've added the -y flag to the cask update command because it hangs on a `y/N` prompt. This must be new, I cant recall having this problem before.
