### PR TITLE
unixPb: Fix various errors in Unix playbook

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
@@ -148,7 +148,7 @@
 # Used for JCK printer tests
 - name: Check if PDFwriter is installed
   stat:
-    path: /Users/Shared/PDFwriter/
+    path: /Users/Shared/PDFwriter
   register: pdfwriter
   tags: jck_tools
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -117,7 +117,7 @@
     dest: /tmp/libffi6_3.2.1-8_s390x.deb
     force: no
     mode: 0755
-    checksum: 05e456a2e8ad9f20db846ccb96c483235c3243e27025c3e8e8e358411fd48be9
+    checksum: sha256:05e456a2e8ad9f20db846ccb96c483235c3243e27025c3e8e8e358411fd48be9
   when:
     - (ansible_distribution_major_version == "20" and ansible_architecture == "s390x") or
       (ansible_distribution_major_version == "22" and ansible_architecture == "s390x")

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/main.yml
@@ -91,7 +91,7 @@
     url: https://raw.githubusercontent.com/justintime/nagios-plugins/master/check_mem/check_mem.pl
     dest: /usr/local/nagios/libexec/check_mem
     mode: 0755
-    checksum: sha256:788a5e696470ea469d82806f9fb9fa144224e16d4af67f535d287e5ada1e6789
+    checksum: sha256:bd6476a3ea399aa6653c359c415be23ca485431e609642f44f456493270789ce
   when:
     - Nagios_Plugins == "Enabled"
     - ansible_distribution != "Solaris"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_MacOSX.yml
@@ -33,7 +33,7 @@
 # See: https://github.com/adoptium/infrastructure/issues/1716#issuecomment-764713146
 - name: Symlink to plugins (arm64)
   file:
-    src: /opt/homebrew/Cellar/nagios-plugins/2.3.3/sbin/
+    src: /opt/homebrew/Cellar/nagios-plugins/2.4.4/sbin/
     dest: /usr/local/nagios/libexec
     state: link
   become: yes

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/curl/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/curl/tasks/main.yml
@@ -109,6 +109,8 @@
   tags: curl
 
 - name: Install latest version of curl for MacOS
+  become: yes
+  become_user: "{{ ansible_user }}"
   homebrew:
     name: curl
     state: latest


### PR DESCRIPTION

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Better to put all of these in one pr than separate.

- Fixed the path of PDFwriter installed on MacOS so the playbooks stop reinstalling the package.
- Typo on checksum on libffi6_3.2.1-8_s390x.deb
- Updated SHA of https://raw.githubusercontent.com/justintime/nagios-plugins/master/check_mem/check_mem.pl, recent update to the perl file, https://github.com/justintime/nagios-plugins/commit/f5e1599a601654f3fd827e50d1b34cc25df29764
- On Macos11, `nagios-plugins` is v2.4.4. I updated the path there
- Installing curl on MacOS via homebrew needs
```
become: yes
become_user: "{{ ansible_user }}"
```

