### PR TITLE
ansible: remove test-osuosl-aix72-ppc64-[3,4]

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -134,8 +134,6 @@ hosts:
           aix715-ppc64-4: {ip: 140.211.9.169, description: p8-java1-adopt08.osuosl.org, 7100-05-06-2028}
           aix72-ppc64-1: {ip: 140.211.9.28, description: p8-aix1-adopt03.osuosl.org, 7200-04-02-2028}
           aix72-ppc64-2: {ip: 140.211.9.36, description: p8-aix1-adopt04.osuosl.org, 7200-02-05-1938}
-          aix72-ppc64-3: {ip: 140.211.9.163, description: p8-java1-adopt09.osuosl.org, 7X00-TL-SP-YYWW}
-          aix72-ppc64-4: {ip: 140.211.9.166, description: p8-java1-adopt10.osuosl.org, 7X00-TL-SP-YYWW}
           centos74-ppc64le-1: {ip: 140.211.168.228, user: centos}
           centos74-ppc64le-2: {ip: 140.211.168.217, user: centos}
           ubuntu1604-ppc64le-1: {ip: 140.211.168.227, user: ubuntu}


### PR DESCRIPTION
test-osuosl-aix72-ppc64-3 was never built
test-osuosl-aix72-ppc64-4 is (also) known (and configured) as build-osuosl-aix72-ppc64-1

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)

- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Fixes #3052 

- bastillion/nagios/jenkins will need to be updated/verified by someone else. I do not have access.