### PR TITLE
unixPB: Add MS system fonts to Alpine DockerStatic docker files.

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alp311
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alp311
@@ -1,8 +1,11 @@
 FROM alpine:3.11
 
 RUN apk --update add bash shadow openssh-server openssh-client unzip zip wget git curl make gcc perl xvfb \
-        libxrender libxi libxtst procps musl-dev perl-doc alsa-lib libx11 fontconfig libxext freetype zlib fakeroot gnupg
+        libxrender libxi libxtst procps musl-dev perl-doc alsa-lib libx11 msttcorefonts-installer fontconfig libxext freetype zlib fakeroot gnupg
 RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -P ""
+
+## Ensure Fonts Are Updated (Issue https://github.com/adoptium/infrastructure/issues/3039)
+RUN update-ms-fonts
 
 # Get latest jdk17 ga
 RUN wget -q 'https://api.adoptium.net/v3/binary/latest/17/ga/alpine-linux/x64/jdk/hotspot/normal/eclipse?project=jdk' -O /tmp/jdk17.tar.gz
@@ -18,7 +21,7 @@ RUN wget -O /tmp/ant-contrib.tgz  https://sourceforge.net/projects/ant-contrib/f
 RUN echo "d085f59349edf22a93d835aa30aea2521ed39bdb99d57d941f1ebd8d115a561bb28aecc781915ff2a0d9f7caf7bae536cdda0910bb432b2a4bce8b7b90c2903b  /tmp/ant.zip" > /tmp/ant.sha512
 RUN echo "0fd2771dca2b8b014a4cb3246715b32e20ad5d26754186d82eee781507a183d5e63064890b95eb27c091c93c1209528a0b18a6d7e6901899319492a7610e74ad  /tmp/ant-contrib.tgz" >> /tmp/ant.sha512
 RUN sha512sum -c /tmp/ant.sha512
-RUN unzip -q -d /usr/local /tmp/ant.zip 
+RUN unzip -q -d /usr/local /tmp/ant.zip
 RUN tar xpfz /tmp/ant-contrib.tgz -C /usr/local/apache-ant-1.10.9/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
 RUN ln -s /usr/local/apache-ant-1.10.9/bin/ant /usr/bin/ant
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alp312
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alp312
@@ -1,8 +1,11 @@
 FROM alpine:3.12
 
 RUN apk --update add bash shadow openssh-server openssh-client unzip zip wget git curl make gcc perl xvfb \
-        libxrender libxi libxtst procps musl-dev perl-doc alsa-lib libx11 fontconfig libxext freetype zlib fakeroot gnupg
+        libxrender libxi libxtst procps musl-dev perl-doc alsa-lib libx11 msttcorefonts-installer fontconfig libxext freetype zlib fakeroot gnupg
 RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -P ""
+
+## Ensure Fonts Are Updated (Issue https://github.com/adoptium/infrastructure/issues/3039)
+RUN update-ms-fonts
 
 # Get latest jdk17 ga
 RUN wget -q 'https://api.adoptium.net/v3/binary/latest/17/ga/alpine-linux/x64/jdk/hotspot/normal/eclipse?project=jdk' -O /tmp/jdk17.tar.gz
@@ -18,7 +21,7 @@ RUN wget -O /tmp/ant-contrib.tgz  https://sourceforge.net/projects/ant-contrib/f
 RUN echo "d085f59349edf22a93d835aa30aea2521ed39bdb99d57d941f1ebd8d115a561bb28aecc781915ff2a0d9f7caf7bae536cdda0910bb432b2a4bce8b7b90c2903b  /tmp/ant.zip" > /tmp/ant.sha512
 RUN echo "0fd2771dca2b8b014a4cb3246715b32e20ad5d26754186d82eee781507a183d5e63064890b95eb27c091c93c1209528a0b18a6d7e6901899319492a7610e74ad  /tmp/ant-contrib.tgz" >> /tmp/ant.sha512
 RUN sha512sum -c /tmp/ant.sha512
-RUN unzip -q -d /usr/local /tmp/ant.zip 
+RUN unzip -q -d /usr/local /tmp/ant.zip
 RUN tar xpfz /tmp/ant-contrib.tgz -C /usr/local/apache-ant-1.10.9/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
 RUN ln -s /usr/local/apache-ant-1.10.9/bin/ant /usr/bin/ant
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alp313
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alp313
@@ -1,8 +1,11 @@
 FROM alpine:3.13
 
 RUN apk --update add bash shadow openssh-server openssh-client unzip zip wget git curl make gcc perl xvfb \
-        libxrender libxi libxtst procps musl-dev perl-doc alsa-lib libx11 fontconfig libxext freetype zlib fakeroot gnupg
+        libxrender libxi libxtst procps musl-dev perl-doc alsa-lib libx11 msttcorefonts-installer fontconfig libxext freetype zlib fakeroot gnupg
 RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -P ""
+
+## Ensure Fonts Are Updated (Issue https://github.com/adoptium/infrastructure/issues/3039)
+RUN update-ms-fonts
 
 # Get latest jdk17 ga
 RUN wget -q 'https://api.adoptium.net/v3/binary/latest/17/ga/alpine-linux/x64/jdk/hotspot/normal/eclipse?project=jdk' -O /tmp/jdk17.tar.gz
@@ -18,7 +21,7 @@ RUN wget -O /tmp/ant-contrib.tgz  https://sourceforge.net/projects/ant-contrib/f
 RUN echo "d085f59349edf22a93d835aa30aea2521ed39bdb99d57d941f1ebd8d115a561bb28aecc781915ff2a0d9f7caf7bae536cdda0910bb432b2a4bce8b7b90c2903b  /tmp/ant.zip" > /tmp/ant.sha512
 RUN echo "0fd2771dca2b8b014a4cb3246715b32e20ad5d26754186d82eee781507a183d5e63064890b95eb27c091c93c1209528a0b18a6d7e6901899319492a7610e74ad  /tmp/ant-contrib.tgz" >> /tmp/ant.sha512
 RUN sha512sum -c /tmp/ant.sha512
-RUN unzip -q -d /usr/local /tmp/ant.zip 
+RUN unzip -q -d /usr/local /tmp/ant.zip
 RUN tar xpfz /tmp/ant-contrib.tgz -C /usr/local/apache-ant-1.10.9/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
 RUN ln -s /usr/local/apache-ant-1.10.9/bin/ant /usr/bin/ant
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alp314
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alp314
@@ -1,8 +1,11 @@
 FROM alpine:3.14
 
 RUN apk --update add bash shadow openssh-server openssh-client unzip zip wget git curl make gcc perl xvfb \
-        libxrender libxi libxtst procps musl-dev perl-doc alsa-lib libx11 fontconfig libxext freetype zlib fakeroot gnupg
+        libxrender libxi libxtst procps musl-dev perl-doc alsa-lib libx11 msttcorefonts-installer fontconfig libxext freetype zlib fakeroot gnupg
 RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -P ""
+
+## Ensure Fonts Are Updated (Issue https://github.com/adoptium/infrastructure/issues/3039)
+RUN update-ms-fonts
 
 # Get latest jdk17 ga
 RUN wget -q 'https://api.adoptium.net/v3/binary/latest/17/ga/alpine-linux/x64/jdk/hotspot/normal/eclipse?project=jdk' -O /tmp/jdk17.tar.gz


### PR DESCRIPTION
Amend the dockerstatic dockerfiles for Alpine containers to include the Microsoft core fonts package(s) and configure appropriately.

Issue #3039 relates, but once this PR has been merged, the alpine images and containers will need to be updated with this fix.

I've tested that the creation of docker images, and containers with these docker files work.

Similar issue for EF infra has been raised. https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3039

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR
