### PR TITLE
inventory: Remove 2 decommissioned marist boxes

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -164,8 +164,6 @@ hosts:
           macos11-arm64-2: {ip: 199.7.163.52, user: Administrator}
 
       - marist:
-          rhel7-s390x-1: {ip: 148.100.84.26, user: linux1, description: test machine in marist cloud}
-          rhel8-s390x-1: {ip: 148.100.84.52, user: linux1, description: test machine in marist cloud}
           rhel7-s390x-2: {ip: 148.100.74.92}
           rhel8-s390x-2: {ip: 148.100.74.2}
           sles12-s390x-2: {ip: 148.100.74.193}


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

test-marist-rhel7-s390x-1 and rhel8-s390x-1 were decommissioned a while back. Just forgot to remove them from the inventory file. They are not present in jenkins