### PR TITLE
unixPb: Install docker on SLES15 s390x not SLES12

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/SLES.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/SLES.yml
@@ -91,57 +91,54 @@
     - (ansible_distribution_major_version == "12" and ansible_distribution_version != "12.5")
   tags: build_tools
 
-- name: Test if  Git Is Installed At /usr/local/bin
-  shell: /usr/local/bin/git --version >/dev/null
-  failed_when: false
-  register: git_installed
-  changed_when: false
-  when:
-    - (ansible_distribution_major_version == "12" and ansible_distribution_version == "12.5")
-  tags:
-    - build_tools
+- name: Install Git SLES 12 SP5
+  when: (ansible_distribution_major_version == "12" and ansible_distribution_version == "12.5")
+  block:
+    - name: Test if  Git Is Installed At /usr/local/bin
+      shell: /usr/local/bin/git --version >/dev/null
+      failed_when: false
+      register: git_installed
+      changed_when: false
+      tags:
+        - build_tools
 
-- name: Test if git is installed at the correct version
-  shell: /usr/local/bin/git --version | sed -e 's/git version //g' | awk -F'[.]' '{print $1 "." $2}'
-  when:
-    - git_installed.rc == 0 and
-      (ansible_distribution_major_version == "12" and ansible_distribution_version == "12.5")
-  register: git_version
-  changed_when: false
-  tags:
-    - build_tools
+    - name: Test if git is installed at the correct version
+      shell: /usr/local/bin/git --version | sed -e 's/git version //g' | awk -F'[.]' '{print $1 "." $2}'
+      when:
+        - git_installed.rc == 0
+      register: git_version
+      changed_when: false
+      tags:
+        - build_tools
 
-- name: Get Git Source
-  get_url:
-    url: https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.31.0.tar.gz
-    dest: /tmp/git-2.31.0.tar.gz
-    mode: 0440
-    checksum: sha256:bc6168777883562569144d536e8a855b12d25d46870d95188a3064260d7784ee
-  when:
-    - (ansible_distribution_major_version == "12" and ansible_distribution_version == "12.5") and
-      (git_installed.rc != 0) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.31', operator='lt'))
+    - name: Get Git Source
+      get_url:
+        url: https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.31.0.tar.gz
+        dest: /tmp/git-2.31.0.tar.gz
+        mode: 0440
+        checksum: sha256:bc6168777883562569144d536e8a855b12d25d46870d95188a3064260d7784ee
+      when:
+        - (git_installed.rc != 0) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.31', operator='lt'))
 
-- name: Extract git 2.31.0 source
-  shell: gzip -cd git-2.31.0.tar.gz | tar xpf -
-  args:
-    chdir: /tmp
-  when:
-    - (ansible_distribution_major_version == "12" and ansible_distribution_version == "12.5") and
-      (git_installed.rc != 0) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.31', operator='lt'))
-  tags:
-    - build_tools
+    - name: Extract git 2.31.0 source
+      shell: gzip -cd git-2.31.0.tar.gz | tar xpf -
+      args:
+        chdir: /tmp
+      when:
+        - (git_installed.rc != 0) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.31', operator='lt'))
+      tags:
+        - build_tools
 
-- name: Compile Git 2.31.0
-  shell: |
-    cd /tmp/git-2.31.0
-    ./configure
-    gmake -j4
-    gmake install
-  when:
-    - (ansible_distribution_major_version == "12" and ansible_distribution_version == "12.5") and
-      (git_installed.rc != 0) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.31', operator='lt'))
-  tags:
-    - build_tools
+  - name: Compile Git 2.31.0
+    shell: |
+      cd /tmp/git-2.31.0
+      ./configure
+      gmake -j4
+      gmake install
+    when:
+      - (git_installed.rc != 0) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.31', operator='lt'))
+    tags:
+      - build_tools
 
 - name: Install additional build tools for SLES 11
   package: "name={{ item }} state=latest"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/SLES.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/SLES.yml
@@ -29,8 +29,7 @@
 
 - name: Add Devel-Tools repository (SLES15)
   zypper_repository:
-    name: devel-tools
-    repo: "https://download.opensuse.org/repositories/devel:/tools/SLE_15_SP3/"
+    repo: https://download.opensuse.org/repositories/devel:/tools/15.4/devel:tools.repo
     auto_import_keys: yes
     state: present
   when:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/SLES.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/SLES.yml
@@ -129,16 +129,16 @@
       tags:
         - build_tools
 
-  - name: Compile Git 2.31.0
-    shell: |
-      cd /tmp/git-2.31.0
-      ./configure
-      gmake -j4
-      gmake install
-    when:
-      - (git_installed.rc != 0) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.31', operator='lt'))
-    tags:
-      - build_tools
+    - name: Compile Git 2.31.0
+      shell: |
+        cd /tmp/git-2.31.0
+        ./configure
+        gmake -j4
+        gmake install
+      when:
+        - (git_installed.rc != 0) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.31', operator='lt'))
+      tags:
+        - build_tools
 
 - name: Install additional build tools for SLES 11
   package: "name={{ item }} state=latest"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
@@ -47,10 +47,10 @@
         use: auto       # automatic select package manager to use yum, apt and so on
       when: ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version >= "7")) or (ansible_distribution == "Ubuntu" or ansible_distribution == "Debian")
 
-    - name: Install for SLES12 # zypper does not support in package module
+    - name: Install for SLES15 # zypper does not support in package module
       include_tasks: sles.yml
       when:
-        - ansible_distribution == "SLES" and ansible_distribution_major_version == "12"
+        - ansible_distribution == "SLES" and ansible_distribution_major_version == "15"
 
     ################
     # Post Install #

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
@@ -62,7 +62,7 @@
         append: yes
         state: present
       when:
-        - (ansible_distribution == "Ubuntu" or ansible_distribution == "Debian") or (ansible_distribution == "SLES" and ansible_distribution_major_version == "12") or ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS" ) and ansible_distribution_major_version == "7")
+        - (ansible_distribution == "Ubuntu" or ansible_distribution == "Debian") or (ansible_distribution == "SLES" and ansible_distribution_major_version == "15") or ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS" ) and ansible_distribution_major_version == "7")
         - ansible_architecture != "riscv64"
       tags:
         - jenkins
@@ -74,7 +74,7 @@
         append: yes
         state: present
       when:
-        - (ansible_distribution == "Ubuntu" or ansible_distribution == "Debian") or (ansible_distribution == "SLES" and ansible_distribution_major_version == "12") or ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS" ) and ansible_distribution_major_version == "7")
+        - (ansible_distribution == "Ubuntu" or ansible_distribution == "Debian") or (ansible_distribution == "SLES" and ansible_distribution_major_version == "15") or ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS" ) and ansible_distribution_major_version == "7")
         - ansible_architecture != "riscv64"
         - Nagios_Plugins == "Enabled"
       tags:
@@ -86,7 +86,7 @@
     state: started
     enabled: yes
   when:
-    - (ansible_distribution == "Ubuntu" or ansible_distribution == "Debian") or (ansible_distribution == "SLES" and ansible_distribution_major_version == "12") or ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS" ) and ansible_distribution_major_version == "7")
+    - (ansible_distribution == "Ubuntu" or ansible_distribution == "Debian") or (ansible_distribution == "SLES" and ansible_distribution_major_version == "15") or ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS" ) and ansible_distribution_major_version == "7")
     - ansible_architecture != "riscv64"
   tags:
     - docker

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/sles.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/sles.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add Docker Repo for SLES12
   community.general.zypper_repository:
-    name: docker
+    # name: docker
     repo: https://download.docker.com/linux/sles/docker-ce.repo
     state: present
     auto_import_keys: yes

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/sles.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/sles.yml
@@ -1,14 +1,10 @@
 ---
-- name: Add Docker Repo for SLES12
-  community.general.zypper_repository:
-    name: docker
-    repo: https://download.docker.com/linux/sles/docker-ce.repo
-    state: present
-    auto_import_keys: yes
+- name: Add Docker Repo for SLES15
+  command: zypper ar https://download.docker.com/linux/sles/docker-ce.repo
   when:
-    - ansible_architecture == "x86_64"
+    - ansible_architecture == "x86_64" or ansible_architecture == "s390x"
 
-- name: Install Docker on SLES12
+- name: Install Docker on SLES15
   zypper:
     pkg: "{{ item }}"
     state: latest
@@ -18,7 +14,7 @@
     - docker-ce-cli
     - containerd.io
   when:
-    - ansible_architecture == "x86_64"
+    - ansible_architecture == "x86_64" or ansible_architecture == "s390x"
   tags:
     # TODO: Package installs should not use latest
     - skip_ansible_lint

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/sles.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/sles.yml
@@ -1,6 +1,12 @@
 ---
 - name: Add Docker Repo for SLES12
-  command: zypper ar https://download.docker.com/linux/sles/docker-ce.repo
+  # command: zypper ar https://download.docker.com/linux/sles/docker-ce.repo
+  community.general.zypper_repository:
+    name: docker-ce-stable
+    repo: https://download.docker.com/linux/sles/15/s390x/stable
+    state: present
+    auto_import_keys: true
+    autorefresh: true
 
 - name: Install Docker on SLES12
   zypper:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/sles.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/sles.yml
@@ -4,8 +4,11 @@
   when:
     - ansible_architecture == "x86_64" or ansible_architecture == "s390x"
 
-- name: Add repo for container-selinux
-  command: zypper ar https://download.opensuse.org/repositories/security:SELinux/SLE_15_SP3/security:SELinux.repo
+- name: Add security repo for container-selinux
+  community.general.zypper_repository:
+    repo: https://download.opensuse.org/repositories/security:SELinux/SLE_15_SP3/security:SELinux.repo
+    state: present
+    auto_import_keys: yes
   when:
     - ansible_architecture == "x86_64" or ansible_architecture == "s390x"
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/sles.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/sles.yml
@@ -4,6 +4,11 @@
   when:
     - ansible_architecture == "x86_64" or ansible_architecture == "s390x"
 
+- name: Add repo for container-selinux
+  command: zypper ar https://download.opensuse.org/repositories/security:SELinux/SLE_15_SP3/security:SELinux.repo
+  when:
+    - ansible_architecture == "x86_64" or ansible_architecture == "s390x"
+
 - name: Install Docker on SLES15
   zypper:
     pkg: "{{ item }}"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/sles.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/sles.yml
@@ -1,12 +1,12 @@
 ---
 - name: Add Docker Repo for SLES12
-  # command: zypper ar https://download.docker.com/linux/sles/docker-ce.repo
   community.general.zypper_repository:
-    name: docker-ce-stable
-    repo: https://download.docker.com/linux/sles/15/s390x/stable
+    name: docker
+    repo: https://download.docker.com/linux/sles/docker-ce.repo
     state: present
-    auto_import_keys: true
-    autorefresh: true
+    auto_import_keys: yes
+  when:
+    - ansible_architecture == "x86_64"
 
 - name: Install Docker on SLES12
   zypper:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/sles.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/sles.yml
@@ -1,10 +1,6 @@
 ---
 - name: Add Docker Repo for SLES12
-  community.general.zypper_repository:
-    # name: docker
-    repo: https://download.docker.com/linux/sles/docker-ce.repo
-    state: present
-    auto_import_keys: yes
+  command: zypper ar https://download.docker.com/linux/sles/docker-ce.repo
 
 - name: Install Docker on SLES12
   zypper:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NVidia_Cuda_Toolkit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NVidia_Cuda_Toolkit/tasks/main.yml
@@ -135,6 +135,7 @@
   register: nvidia_cuda_toolkit_download
   until: nvidia_cuda_toolkit_download is not failed
   when:
+    - cuda_installed.stat.isdir is not defined
     - (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16")
     - ansible_architecture == "ppc64le"
   tags: nvidia_cuda_toolkit
@@ -143,6 +144,7 @@
   apt_key:
     url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/ppc64el/7fa2af80.pub
   when:
+    - cuda_installed.stat.isdir is not defined
     - (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16")
     - ansible_architecture == "ppc64le"
   tags: nvidia_cuda_toolkit


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Some fixes for errors I came across while testing the s390x parts of our playbook

https://download.opensuse.org/repositories/devel:/tools/SLE_15_SP3/ is expired, replaced with https://download.opensuse.org/repositories/devel:/tools/15.4/devel:tools.repo

The installation of Git 2.31.0 failed unless put in its own block

Remove install tasks for docker on sles 12, instead install it on sles15 s390x and x64

Add conditions for Nvidia toolkit role to prevent reinstalling it
