### PR TITLE
ansible: rebrand build-osuosl-aix71-ppc64-2 

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -66,8 +66,8 @@ hosts:
 
       - osuosl:
           aix71-ppc64-1: {ip: 140.211.9.10, description: p8-aix1-adopt01.osuosl.org, 7100-04-04-1717}
-          aix71-ppc64-2: {ip: 140.211.9.12, description: p8-aix1-adopt02.osuosl.org, 7100-04-04-1717}
-          aix72-ppc64-1: {ip: 140.211.9.166, description: adopt10, 7200-00-02-1614}
+          aix72-ppc64-1: {ip: 140.211.9.166, description: p8-java1-adopt10.osuosl.org, 7200-02-04-1914}
+          aix72-ppc64-2: {ip: 140.211.9.12, description: p8-aix1-adopt02.osuosl.org, 7200-02-04-1914}
           centos74-ppc64le-1: {ip: 140.211.168.138}
           centos74-ppc64le-2: {ip: 140.211.168.117}
 


### PR DESCRIPTION
as build-osuosl-aix72-ppc64-2

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Fixes: #3068