### PR TITLE
inventory: Add osuosl aarch64 machine

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -70,6 +70,7 @@ hosts:
           aix72-ppc64-2: {ip: 140.211.9.12, description: p8-aix1-adopt02.osuosl.org, 7200-02-04-1914}
           centos74-ppc64le-1: {ip: 140.211.168.138}
           centos74-ppc64le-2: {ip: 140.211.168.117}
+          ubuntu2204-aarch64-1: {ip: 140.211.169.57}
 
       - scaleway:
           ubuntu1604-x64-1: {ip: 51.15.46.107}


### PR DESCRIPTION
Add build-osuosl-ubuntu2204-aarch64-1 to inventory.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR
- [X] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
