### PR TITLE
aixPb: Simplify conditions for when to transfer compiler packages

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/xlc_v13/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/xlc_v13/tasks/main.yml
@@ -8,14 +8,8 @@
   register: xlc13
   tags: xlc13
 
-- name: Announce all is ready and move on
-  debug:
-    msg: "xlc_v13.1.3 installed, skipping download and installation"
-  when: xlc13.stat.isdir is defined and xlc13.stat.isdir
-  tags: xlc13
-
 - name: Unpack and install Vendor Files
-  when: xlc13.stat.isdir is undefined or xlc13.stat.isdir is false
+  when: xlc13.stat.isdir is undefined
   tags: [xlc13, vendor_files]
   block:
     - name: Transfer and Extract XLC13

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/xlc_v16/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/xlc_v16/tasks/main.yml
@@ -8,14 +8,8 @@
   register: xlc16
   tags: xlc16
 
-- name: "Debug: xlc16 installed, skipping download and installation"
-  debug:
-    msg: "xlc16 installed, skipping download and installation"
-  when: xlc16.stat.exists and xlc16.stat.isdir
-  tags: xlc16
-
 - name: Vendor File processing
-  when: xlc16.stat.exists is false
+  when: xlc16.stat.isdir is undefined
   tags: [xlc16, vendor_files]
   block:
     - name: Transfer and Extract XLC16


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

The `xlc13.stat.isdir is false` and the `xlc16.stat.exists is false `conditions do not resolve correctly when both packages are present on the machine. Simplifying them this way makes them work, and I have removed the 'Everythings OK message' because I feel it is not necessary (if everything wasnt ok it would fail and that would be your indication)

```
"msg": "The conditional check 'xlc13.stat.isdir is undefined or xlc13.stat.isdir is false' failed. The error was: template error while templating string: no test named 'false'. String: {% if xlc13.stat.isdir is undefined or xlc13.stat.isdir is false %} True {% else %} False {% endif %}\n\n
The error appears to be in
 '/tmp/awx_1248_x1wyqy0a/project/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/xlc_v13/tasks/main.yml': line 21, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\n
The offending line appears to be:\n\n
  block:\n    - name: Transfer and Extract XLC13\n      ^ here\n"}
```

```
fatal: [test-osuosl-aix715-ppc64-1]: FAILED! => {"msg": "The conditional check 'xlc16.stat.exists is false' failed. The error was: template error while templating string: no test named 'false'. String: {% if xlc16.stat.exists is false %} True {% else %} False {% endif %}\n\nThe error appears to be in 
'/tmp/awx_1257_yoq379b0/project/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/xlc_v16/tasks/main.yml': line 21, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n  block:\n    - name: Transfer and Extract XLC16\n 
     ^ here\n"}
```