### PR TITLE
UnixPB - Update Marist cloud.cfg file to prevent overwriting of /etc/hosts

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Providers/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Providers/tasks/main.yml
@@ -65,3 +65,20 @@
   tags:
     - providers
     - adoptopenjdk
+
+###########
+# Marist  #
+###########
+
+# Marist machines need their host template updated for changes to /etc/hosts to persist
+- name: Update /etc/cloud/cloud.cfg file - To remove update hosts function
+  lineinfile:
+    dest: /etc/cloud/cloud.cfg
+    regexp: "^.*update_etc_hosts.*$"
+    state: absent
+  when:
+    - provider_name.rc == 0
+    - provider_name.stdout == "marist"
+  tags:
+    - providers
+    - adoptopenjdk


### PR DESCRIPTION
As per EF issue.. https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2169 

Fixes #3079 

Update /etc/cloud/cloud.cfg file to remove the `- update_etc_hosts` line

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR

Tested Locally In Vagrant With Appropriate Hostnames, works correctly.

root@vagrant-marist-adoptopenjdkU20:/etc/cloud# diff cloud.cfg cloud.backup
22a23
>  - update_etc_hosts

