### PR TITLE
aixPb: Ignore failure of disable_sendmail task

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/disable_sendmail/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/disable_sendmail/tasks/main.yml
@@ -2,10 +2,16 @@
 ####################
 # Disable sendmail #
 ####################
+- name: Check if sendmail is installed
+  stat:
+    path: /usr/sbin/sendmail
+  register: sendmail_installed
+  tags: sendmail
+
 - name: Ensure sendmail is stopped
   service: name=sendmail state=stopped
+  when: sendmail_installed.stat exists
   tags: sendmail
-  ignore_errors: yes
 
 - name: Ensure sendmail is disabled
   replace:

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/disable_sendmail/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/disable_sendmail/tasks/main.yml
@@ -5,6 +5,7 @@
 - name: Ensure sendmail is stopped
   service: name=sendmail state=stopped
   tags: sendmail
+  ignore_errors: yes
 
 - name: Ensure sendmail is disabled
   replace:

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/disable_sendmail/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/disable_sendmail/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: Ensure sendmail is stopped
   service: name=sendmail state=stopped
-  when: sendmail_installed.stat exists
+  when: sendmail_installed.stat.exists is true
   tags: sendmail
 
 - name: Ensure sendmail is disabled

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/disable_sendmail/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/disable_sendmail/tasks/main.yml
@@ -8,14 +8,16 @@
   register: sendmail_installed
   tags: sendmail
 
-- name: Ensure sendmail is stopped
-  service: name=sendmail state=stopped
-  when: sendmail_installed.stat.exists is true
+- name: Stop and disable sendmail
+  when: sendmail_installed.stat.exists
   tags: sendmail
+  block:
 
-- name: Ensure sendmail is disabled
-  replace:
-    dest: /etc/rc.tcpip
-    regexp: '^ *(start /usr/lib/sendmail (.+)\n)'
-    replace: '#\1'
-  tags: sendmail
+    - name: Ensure sendmail is stopped
+      service: name=sendmail state=stopped
+
+    - name: Ensure sendmail is disabled
+      replace:
+        dest: /etc/rc.tcpip
+        regexp: '^ *(start /usr/lib/sendmail (.+)\n)'
+        replace: '#\1'


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/3086

On some machines the `Ensure sendmail is stopped` task fails and on some it passes

```
TASK [disable_sendmail : Ensure sendmail is stopped] ***************************
ok: [build-osuosl-aix71-ppc64-1] => {"changed": false, "name": "sendmail", "state": "stopped"}
fatal: [build-osuosl-aix72-ppc64-2]: FAILED! => {"changed": false, "msg": "0513-086 The sendmail Group is not on file.\n"}
ok: [test-osuosl-aix715-ppc64-2] => {"changed": false, "name": "sendmail", "state": "stopped"}
ok: [test-osuosl-aix715-ppc64-1] => {"changed": false, "name": "sendmail", "state": "stopped"}
fatal: [build-osuosl-aix72-ppc64-1]: FAILED! => {"changed": false, "msg": "0513-086 The sendmail Group is not on file.\n"}
ok: [test-osuosl-aix72-ppc64-1] => {"changed": false, "name": "sendmail", "state": "stopped"}
fatal: [test-osuosl-aix72-ppc64-3]: FAILED! => {"changed": false, "msg": "0513-086 The sendmail Group is not on file.\n"}
ok: [test-osuosl-aix72-ppc64-2] => {"changed": false, "name": "sendmail", "state": "stopped"}
fatal: [test-osuosl-aix72-ppc64-4]: FAILED! => {"changed": false, "msg": "0513-086 The sendmail Group is not on file.\n"}
```
The task that follows, https://github.com/adoptium/infrastructure/blob/e9c555980680e72a4ecb748d254fec942761ef8f/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/disable_sendmail/tasks/main.yml#L9, disables sendmail by commenting it out in `/etc/rc.tcpip`. This works on the machines on which the previous task fails, so i am comfortable adding `ignore_errors` on the previous task so that it does not interrupt the flow of the playbook