### PR TITLE
aixPB: add check for each of the RBAC auth used in the config

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/rbac/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/rbac/tasks/main.yml
@@ -57,7 +57,7 @@
 
 - name: Update RBAC Security Tables to kernel
   shell: setkst
-  when: ojdk_exists.rc == 2 OR rtclk_exists.rc == 2 OR rtcore_exists.rc == 2
+  when: ojdk_exists.rc == 2 or rtclk_exists.rc == 2 or rtcore_exists.rc == 2
   tags: rbac
 
 # Assign security attributes to commands in list

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/rbac/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/rbac/tasks/main.yml
@@ -10,37 +10,55 @@
 # See also: https://github.com/adoptium/infrastructure/pull/2052 (not merged)
 #########################################################################
 ---
-- name: Check if auth already exists
+- name: Check if auth ojdk already exists
+  shell: lsauth ojdk
+  register: ojdk_exists
+  failed_when: ojdk_exists.rc != 0 and ojdk_exists.rc != 2
+  changed_when: false
+  tags: rbac
+
+- name: Check if auth ojdk.rtclk already exists
   shell: lsauth ojdk.rtclk
   register: rtclk_exists
   failed_when: rtclk_exists.rc != 0 and rtclk_exists.rc != 2
   changed_when: false
   tags: rbac
 
-- name: Update RBAC to include new authorizations
-  when: rtclk_exists.rc == 2
+- name: Check if auth ojdk.proccore already exists
+  shell: lsauth ojdk.proccore
+  register: rtcore_exists
+  failed_when: rtcore_exists.rc != 0 and rtcore_exists.rc != 2
+  changed_when: false
   tags: rbac
-  block:
-    - name: Top-level authorization
-      shell:
-        mkauth dfltmsg="Top-Level authorization for AdoptOpenJava Project" ojdk
-      register: _ojdk
-      failed_when: _ojdk.rc != 0 and _ojdk.rc != 17
-    - name: RealTime Clock Authorization
-      shell:
-        mkauth dfltmsg="PV_PROC_RTCLK for metronome garbage collection policy" ojdk.rtclk
-      register: _rtclk
-      failed_when: _rtclk.rc != 0 and _rtclk.rc != 17
-    - name: CORE DUMP Authorization
-      shell:
-        mkauth dfltmsg="PV_PROC_CORE for to allow process core dumps" ojdk.proccore
-      register: _rtcore
-      failed_when: _rtclk.rc != 0 and _rtclk.rc != 17
-    - name: RealTime Clock Role
-      shell:
-        mkrole authorizations='ojdk.rtclk,ojdk.proccore' dfltmsg='Adoptium Role for testing' rtclk
-    - name: Update Security Tables
-      shell: setkst
+
+- name: Create auth ojdk
+  when: ojdk_exists.rc == 2
+  shell:
+    mkauth dfltmsg="Top-Level authorization for AdoptOpenJava Project" ojdk
+  register: _ojdk
+  failed_when: _ojdk.rc != 0 and _ojdk.rc != 17
+  tags: rbac
+
+- name: Create auth ojdk.rtclk
+  when: rtclk_exists.rc == 2
+  shell:
+    mkrole authorizations='ojdk.rtclk,ojdk.proccore' dfltmsg='Adoptium Role for testing' ojdk.rtclk
+  register: _rtclk
+  failed_when: _rtclk.rc != 0 and _rtclk.rc != 17
+  tags: rbac
+
+- name: Create auth ojdk.proccore
+  when: rtcore_exists.rc == 2
+  shell:
+    mkauth dfltmsg="PV_PROC_CORE for to allow process core dumps" ojdk.proccore
+  register: _rtcore
+  failed_when: _rtcore.rc != 0 and _rtcore.rc != 17
+  tags: rbac
+
+- name: Update RBAC Security Tables to kernel
+  shell: setkst
+  when: ojdk_exists.rc == 2 OR rtclk_exists.rc == 2 OR rtcore_exists.rc == 2
+  tags: rbac
 
 # Assign security attributes to commands in list
 # The tag here is not passed to the included_task, the tag skips


### PR DESCRIPTION
       and make auth as needed before calling loop

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
