### PR TITLE
unixPB: RISC-V updates and use `docker.io` on Ubuntu 20+

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -65,13 +65,17 @@
       when: ansible_distribution != "MacOSX"
     - gcc_48
     - role: gcc_7                 # OpenJ9
+      when: ansible_architecture != "riscv64"
       tags: [build_tools, build_tools_openj9]
     - role: gcc_9                 # Dragonwell
       tags: [build_tools]
+      when: ansible_architecture != "riscv64"
     - role: gcc_10                # JDK17+
       tags: [build_tools]
+      when: ansible_architecture != "riscv64"
     - role: gcc_11                # JDK19+
       tags: [build_tools]
+      when: ansible_architecture != "riscv64"
     - role: Xcode
       when: ansible_distribution == "MacOSX"
       tags: [build_tools, xcode, adoptopenjdk]

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -131,6 +131,13 @@
 ####################
 # Set default Java #
 ####################
+
+- name: Install 'openjdk-8-jdk' package
+  package:
+    name: locales
+    state: present
+  when: ansible_architecture != "riscv64"
+
 - name: Set default java version for x86_64
   alternatives:
     name: java

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
@@ -41,7 +41,6 @@ Build_Tool_Packages:
   - libxtst-dev
   - make
   - ntp
-  - openjdk-8-jdk
   - pigz
   - pkg-config
   - systemtap-sdt-dev

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
@@ -45,7 +45,15 @@
           - docker-ce
         state: latest   # TODO: Package installs should not use latest
         use: auto       # automatic select package manager to use yum, apt and so on
-      when: ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version >= "7")) or (ansible_distribution == "Ubuntu" or ansible_distribution == "Debian")
+      when: ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version >= "7")) or ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int < 20) or ansible_distribution == "Debian")
+
+    - name: Install default docker on Ubuntu 22+
+      package:
+        name:
+          - docker.io
+        state: latest   # TODO: Package installs should not use latest
+        use: auto       # automatic select package manager to use yum, apt and so on
+      when: ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int >= 20) or ansible_distribution == "Debian")
 
     - name: Install for SLES15 # zypper does not support in package module
       include_tasks: sles.yml

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/ubuntu.yml
@@ -11,6 +11,7 @@
     state: present
   when:
     - ansible_architecture == "x86_64"
+    - ansible_distribution_major_version | int < 20
 
 - name: Add Docker Repo for Ubuntu s390x
   apt_repository:
@@ -18,6 +19,7 @@
     state: present
   when:
     - ansible_architecture == "s390x"
+    - ansible_distribution_major_version | int < 20
 
 - name: Add Docker Repo for Ubuntu ppc64le
   apt_repository:
@@ -25,6 +27,7 @@
     state: present
   when:
     - ansible_architecture == "ppc64le"
+    - ansible_distribution_major_version | int < 20
 
 - name: Add Docker Repo for Ubuntu aarch64
   apt_repository:
@@ -32,6 +35,7 @@
     state: present
   when:
     - ansible_architecture == "aarch64"
+    - ansible_distribution_major_version | int < 20
 
 - name: Add Docker Repo for Ubuntu armv7l
   apt_repository:
@@ -39,6 +43,7 @@
     state: present
   when:
     - ansible_architecture == "armv7l"
+    - ansible_distribution_major_version | int < 20
 
 - name: Install Docker prerequisites for Ubuntu
   apt:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/1670/
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Likely supercedes https://github.com/adoptium/infrastructure/pull/2850 as this has extra changes and makes the `docker.io` install not specific to RISC-V

This will allow us to easily set up the rest of the PLCTlab machines as per https://github.com/adoptium/infrastructure/issues/3078