### PR TITLE
inventory: Add new windows 2022 build machine

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -78,6 +78,7 @@ hosts:
       - ibmcloud:
           win2012r2-x64-1: {ip: 169.48.4.138, user: Administrator}
           win2012r2-x64-2: {ip: 169.48.4.142, user: Administrator}
+          win2022-x64-1: {ip: 52.118.206.11, user: Administrator}
 
       - spearhead:
           freebsd12-x64-1: {ip: 185.131.222.224}


### PR DESCRIPTION

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/3091