### PR TITLE
Nagios: Fix Check Container Spaces Plugin

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/additional_plugins/check_container_spaces.sh
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/additional_plugins/check_container_spaces.sh
@@ -20,15 +20,19 @@ do
 	#echo "ID = "$containerID
 	workspaceSpace=$(docker exec $containerID sh -c "if [ -d /home/jenkins/workspace ] ; then du -s /home/jenkins/workspace | awk '{print $3}' ; else echo 0 ; fi" 2> /dev/null)
 	workSpace=`echo $workspaceSpace|cut -d" " -f1`
+	## Allow For Container With No Workspace
+	if [ -z $workSpace ]; then
+                workSpace=0
+        fi
 
 	## Create Lists Of Errors And Warnings
-	if [ $workSpace -gt $ErrorThreshold ]
+	if (( $workSpace > $ErrorThreshold ))
 	then
 		## Add Container Name To ErrorList
 		ErrorList="$ErrorList,$containerName,$containerID"
 		# echo "Errors In "$ErrorList
 	else
-		if [ $workSpace -gt $WarnThreshold ] && [ $workSpace -lt $ErrorThreshold ]
+		if (( $workSpace > $WarnThreshold )) && (( $workSpace < $ErrorThreshold ))
 		then
 			WarnList="$WarnList,$containerName,$containerID"
 			#echo "Warnings In "$WarnList


### PR DESCRIPTION
Update the Nagios "Check Docker Container Spaces Plugin" to allow for null values being returned where the workspace directory does not exist, and also update the threshold comparisons to use numeric comparisons rather than string.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR

Script has been deployed and tested locally using vagrant and virtual machines, and also on dockerhost-marist-ubuntu2204-s390x-
