### PR TITLE
unixPB: Update maven URL to apache archive

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/maven/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/maven/tasks/main.yml
@@ -14,14 +14,14 @@
 
 - name: Download Apache Maven v3.6.3
   get_url:
-   url: https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz
+   url: https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz
    dest: /tmp/
    checksum: sha512:c35a1803a6e70a126e80b2b3ae33eed961f83ed74d18fcd16909b2d44d7dada3203f1ffe726c17ef8dcca2dcaa9fca676987befeadc9b9f759967a8cb77181c0
   when: maven_installed.rc != 0 and ansible_distribution != "Solaris"
   tags: maven
 
 - name: Download Apache Maven v3.6.3 (Solaris)
-  command: wget https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz -O /tmp/apache-maven-3.6.3-bin.tar.gz
+  command: wget https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz -O /tmp/apache-maven-3.6.3-bin.tar.gz
   when: maven_installed.rc != 0 and ansible_distribution == "Solaris"
   tags: maven
 


### PR DESCRIPTION
Update URL for maven 3.6.3
Fixes #3097 

VPC check : https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=CentOS8,label=vagrant/1672/console

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)

