### PR TITLE
windowsPb: Add adoptopenjdk tags to MSVS_2019 role

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -72,7 +72,7 @@
     - role: MSVS_2017             # OpenJ9
       when: ansible_architecture == "64-bit"
     - role: MSVS_2019                   # OpenJ9
-      tags: [MSVS_2019, adoptopenjdk]
+      tags: MSVS_2019
     - NVidia_Cuda_Toolkit         # OpenJ9
     - NTP_TIME
     - Clang_64bit                 # OpenJ9

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -71,7 +71,8 @@
       when: ansible_architecture == "64-bit"
     - role: MSVS_2017             # OpenJ9
       when: ansible_architecture == "64-bit"
-    - MSVS_2019                   # OpenJ9
+    - role: MSVS_2019                   # OpenJ9
+      tags: [MSVS_2019, adoptopenjdk]
     - NVidia_Cuda_Toolkit         # OpenJ9
     - NTP_TIME
     - Clang_64bit                 # OpenJ9

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
@@ -49,8 +49,15 @@
   when: (vs2019_layout_ready.stat.exists) and (not vs2019_installed.stat.exists)
   tags: adoptopenjdk
 
-## Check If VS2019 Has Been Installed From Layout Even If Not AdoptOpenJDK
+- name: Remove Visual Studio 2019 Layout Files
+  win_file:
+    path: "{{ items }}"
+  with_items:
+    - 'C:\TEMP\VS2019_Layout.zip'
+    - 'C:\temp\VSLayout2019'
+  tags: adoptopenjdk
 
+## Check If VS2019 Has Been Installed From Layout Even If Not AdoptOpenJDK
 - name: Test if VS 2019 is installed
   win_stat:
     path: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community'

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
@@ -3,14 +3,14 @@
 # Visual Studio Community 2019 #
 ################################
 
-- name: Register AdoptOpenJDK Var
-  ansible.builtin.set_fact:
-    AdoptYes: false
+# - name: Register AdoptOpenJDK Var
+#   ansible.builtin.set_fact:
+#     AdoptYes: false
 
-- name: Set AdoptOpenJDK Var If Running With AdoptOpenJDK Tag
-  ansible.builtin.set_fact:
-    AdoptYes: true
-  tags: adoptopenjdk
+# - name: Set AdoptOpenJDK Var If Running With AdoptOpenJDK Tag
+#   ansible.builtin.set_fact:
+#     AdoptYes: true
+#   tags: adoptopenjdk
 
 - name: Test if VS 2019 is installed
   win_stat:
@@ -25,6 +25,7 @@
     remote_src: no
   when: (not vs2019_installed.stat.exists) or ( AdoptYes|bool == true)
   failed_when: false
+  tags: MSVS_2019
 
 # Check For The Transferred File & Exit If AdoptOpenJDK Run
 - name: Check If Layout Has Transferred
@@ -38,7 +39,7 @@
 - name: Exit With Error When No Layout Within AdoptOpenJDK
   fail:
     msg: "The VS2019 Layout File Appears To Be Missing From Vendor_Files"
-  when: (not vs2019_layout_ready.stat.exists) and ( AdoptYes|bool == true)
+  when: (not vs2019_layout_ready.stat.exists) # and ( AdoptYes|bool == true)
   tags: MSVS_2019
 
 # Install VS2019 From Layout For AdoptOpenJDK
@@ -74,7 +75,7 @@
     checksum_algorithm: sha256
     dest: 'C:\temp\vs_community19.exe'
     force: no
-  when: (not vs2019_installed.stat.exists) and ( AdoptYes|bool == false)
+  when: (not vs2019_installed.stat.exists) # and ( AdoptYes|bool == false)
   tags: MSVS_2019
 
 - name: Run Visual Studio 2019 Installer From Download
@@ -82,7 +83,7 @@
       Start-Process -Wait -FilePath 'C:\temp\vs_community19.exe' -ArgumentList '--wait --add Microsoft.VisualStudio.Workload.NativeDesktop --includeRecommended --includeOptional --quiet --norestart'
   args:
     executable: powershell
-  when: (not vs2019_installed.stat.exists) and ( AdoptYes|bool == false)
+  when: (not vs2019_installed.stat.exists) # and ( AdoptYes|bool == false)
   register: vs2019_error
   failed_when: vs2019_error.rc != 0 and vs2019_error.rc != 3010
   tags: MSVS_2019
@@ -91,7 +92,7 @@
   win_shell: Start-Process -FilePath 'C:\temp\vs_community19.exe' -Wait -NoNewWindow -ArgumentList
     'modify --installPath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community" --quiet
     --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.ATL.ARM64 --add Microsoft.VisualStudio.Component.VC.MFC.ARM64'
-  when: (not vs2019_installed.stat.exists) and ( AdoptYes|bool == false)
+  when: (not vs2019_installed.stat.exists) # and ( AdoptYes|bool == false)
   tags: MSVS_2019
 
 - name: Register Visual Studio Community 2019 DIA SDK shared libraries

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
@@ -3,44 +3,35 @@
 # Visual Studio Community 2019 #
 ################################
 
-# - name: Register AdoptOpenJDK Var
-#   ansible.builtin.set_fact:
-#     AdoptYes: false
-
-# - name: Set AdoptOpenJDK Var If Running With AdoptOpenJDK Tag
-#   ansible.builtin.set_fact:
-#     AdoptYes: true
-#   tags: adoptopenjdk
-
 - name: Test if VS 2019 is installed
   win_stat:
     path: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community'
   register: vs2019_installed
-  tags: MSVS_2019
+  tags: adoptopenjdk
 
 - name: Transfer VS2019 Layout File
   win_copy:
     src: /Vendor_Files/windows/VS2019_layout.16.11.32106.67.zip
     dest: C:\TEMP\VS2019_Layout.zip
     remote_src: no
-  when: (not vs2019_installed.stat.exists) or ( AdoptYes|bool == true)
+  when: (not vs2019_installed.stat.exists)
   failed_when: false
-  tags: MSVS_2019
+  tags: adoptopenjdk
 
 # Check For The Transferred File & Exit If AdoptOpenJDK Run
 - name: Check If Layout Has Transferred
   win_stat:
     path: 'C:\TEMP\VS2019_Layout.zip'
   register: vs2019_layout_ready
-  tags: MSVS_2019
+  tags: adoptopenjdk
 
 # Exit Play If No VS2019 Layout & AdoptOpenJDK = true
 # This Is Defined Behaviour - This Shouldnt Occur But If It Does, Its Captured Here
 - name: Exit With Error When No Layout Within AdoptOpenJDK
   fail:
     msg: "The VS2019 Layout File Appears To Be Missing From Vendor_Files"
-  when: (not vs2019_layout_ready.stat.exists) # and ( AdoptYes|bool == true)
-  tags: MSVS_2019
+  when: (not vs2019_layout_ready.stat.exists)
+  tags: adoptopenjdk
 
 # Install VS2019 From Layout For AdoptOpenJDK
 - name: Unzip VS2019 Layout
@@ -48,7 +39,7 @@
     src: C:\TEMP\VS2019_Layout.zip
     dest: C:\TEMP
   when: (vs2019_layout_ready.stat.exists)
-  tags: MSVS_2019
+  tags: adoptopenjdk
 
 - name: Run Visual Studio 2019 Installer From Layout
   win_shell: |
@@ -56,7 +47,7 @@
   args:
     executable: powershell
   when: (vs2019_layout_ready.stat.exists) and (not vs2019_installed.stat.exists)
-  tags: MSVS_2019
+  tags: adoptopenjdk
 
 ## Check If VS2019 Has Been Installed From Layout Even If Not AdoptOpenJDK
 
@@ -64,7 +55,6 @@
   win_stat:
     path: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community'
   register: vs2019_installed
-  tags: MSVS_2019
 
 # Download & Install VS2019 When No Layout & Not AdoptOpenJDK
 # This is the target that you're redirected to when you go to https://aka.ms/vs/16/release/vs_community.exe
@@ -75,25 +65,22 @@
     checksum_algorithm: sha256
     dest: 'C:\temp\vs_community19.exe'
     force: no
-  when: (not vs2019_installed.stat.exists) # and ( AdoptYes|bool == false)
-  tags: MSVS_2019
+  when: (not vs2019_installed.stat.exists)
 
 - name: Run Visual Studio 2019 Installer From Download
   win_shell: |
       Start-Process -Wait -FilePath 'C:\temp\vs_community19.exe' -ArgumentList '--wait --add Microsoft.VisualStudio.Workload.NativeDesktop --includeRecommended --includeOptional --quiet --norestart'
   args:
     executable: powershell
-  when: (not vs2019_installed.stat.exists) # and ( AdoptYes|bool == false)
+  when: (not vs2019_installed.stat.exists)
   register: vs2019_error
   failed_when: vs2019_error.rc != 0 and vs2019_error.rc != 3010
-  tags: MSVS_2019
 
 - name: Install ARM64 components
   win_shell: Start-Process -FilePath 'C:\temp\vs_community19.exe' -Wait -NoNewWindow -ArgumentList
     'modify --installPath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community" --quiet
     --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.ATL.ARM64 --add Microsoft.VisualStudio.Component.VC.MFC.ARM64'
-  when: (not vs2019_installed.stat.exists) # and ( AdoptYes|bool == false)
-  tags: MSVS_2019
+  when: (not vs2019_installed.stat.exists)
 
 - name: Register Visual Studio Community 2019 DIA SDK shared libraries
   win_command: 'regsvr32 /s "{{ item }}"'
@@ -101,7 +88,6 @@
     - C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\DIA SDK\bin\msdia140.dll
     - C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\DIA SDK\bin\amd64\msdia140.dll
   when: (not vs2019_installed.stat.exists)
-  tags: MSVS_2019
 
 - name: Reboot machine after Visual Studio installation
   win_reboot:
@@ -109,5 +95,4 @@
     shutdown_timeout: 1800
   when: (not vs2019_installed.stat.exists)
   tags:
-    - MSVS_2019
     - reboot


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Instead of checking to see if the adoptopenjdk tags are being used and then running adopt specific tasks, the playbook should run such tasks by default and skip them only if `--skip-tags adoptopenjdk` is used. 