### PR TITLE
windowsPb: add timeout variables to variables file

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/group_vars/all/adoptopenjdk_variables.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/group_vars/all/adoptopenjdk_variables.yml
@@ -8,6 +8,10 @@ Nagios_Plugins: Disabled
 ##### This needs to be set before running ######
 #ansible_password: CHANGE_ME
 
+# If Experiencing timeout errors, set the two variables below. (See https://github.com/adoptium/infrastructure/tree/master/ansible#how-do-i-run-the-playbooks-on-a-remote-windows-host)
+# ansible_winrm_operation_timeout_sec: 600
+# ansible_winrm_read_timeout_sec: 630
+
 ### Default JDK ###
 bootjdk: hotspot
 heapsize: normal


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/tree/master/ansible#how-do-i-run-the-playbooks-on-a-remote-windows-host

Saves a user (me recently) from having to go that link and copy and paste the variables 
