### PR TITLE
docker: link libffi library and install gawk in SLES15 dockerfile

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.sles15
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.sles15
@@ -31,7 +31,10 @@ RUN ssh-keygen -A
 
 CMD ["/usr/sbin/sshd", "-D"]
 
-RUN zypper update -y && zypper install -y git curl make gcc libXrender1 libXi6 libXtst6 fontconfig fakeroot xorg-x11-server
+RUN zypper update -y && zypper install -y git curl make gcc libXrender1 libXi6 libXtst6 fontconfig fakeroot xorg-x11-server gawk
+
+# Link libffi library (See https://github.com/adoptium/infrastructure/issues/3026#issuecomment-1589277527)
+RUN ln -s /usr/lib64/libffi.so.7 /usr/lib64/libffi.so.6
 
 EXPOSE 22
 # Start with docker run -p 22XX:22 UUID


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Ref https://github.com/adoptium/infrastructure/issues/3026#issuecomment-1589277527

Solves library error on SLES15

```
19:51:21  =JAVA VERSION OUTPUT BEGIN=
19:51:21  Error: dl failure on line 894
19:51:21  Error: failed /long_path_goes_here/libjvm.so, because libffi.so.6: cannot open shared object file: No such file or directory
```
