### PR TITLE
NagiosPB : Add Jenkins host template and configuration to Config Server playbook.

### DIFF
--- a/ansible/playbooks/nagios/roles/Nagios_Config/defaults/main.yml
+++ b/ansible/playbooks/nagios/roles/Nagios_Config/defaults/main.yml
@@ -15,7 +15,7 @@ Input_Path: /tmp/ansible_inventory.yml
 Nagios_Base_Path: /usr/local/nagios
 
 # Ansible Inventory Host Group Types To Monitor -- Maps To Nagios Service Groups
-Nagios_Service_Types: 'build test dockerhost'
+Nagios_Service_Types: 'build test dockerhost infrastructure'
 
 # Should Ansible Replace Existing Configuration File
 Overwrite_Mode: True

--- a/ansible/playbooks/nagios/roles/Nagios_Config/files/Nagios_Server_Config.py
+++ b/ansible/playbooks/nagios/roles/Nagios_Config/files/Nagios_Server_Config.py
@@ -23,11 +23,21 @@ templates = {'build_win': 'build-windows-template.j2',
 special_templates = {'test-equinix_esxi-solaris10-x64-1': 'test-solaris-noport-template.j2',
             'test-siteox-solaris10u11-sparcv9-1': 'test-solaris-port-template.j2',
             'build-equinix_esxi-solaris10-x64-1': 'test-solaris-noport-template.j2',
-            'build-siteox-solaris10u11-sparcv9-1': 'test-solaris-port-template.j2'}
+            'build-siteox-solaris10u11-sparcv9-1': 'test-solaris-port-template.j2',
+            'infrastructure-hetzner-ubuntu2004-x64-1': 'jenkins-template.j2'
+            }
 
 ## Define Any Hosts That Should Be Excluded
 
 excluded_hosts = {'build-spearhead-freebsd12-x64-1',
                   'test-inspira-solaris10u11-sparcv9-1',
                   'build-inspira-solaris10u11-sparcv9-1',
-                  'build-inspira-solaris10u11-sparcv9-2'}
+                  'build-inspira-solaris10u11-sparcv9-2',
+                  'infrastructure-aws-ubuntu1804-x64-1',
+                  'infrastructure-azure-ubuntu2004-x64-1',
+                  'infrastructure-digitalocean-ubuntu2004-x64-1',
+                  'infrastructure-equinix-ubuntu1604-x64-1',
+                  'infrastructure-equinix-ubuntu2004-x64-1',
+                  'infrastructure-hetzner-ubuntu1604-x64-1',
+                  'infrastructure-ibmcloud-vagrant-x64-1'
+                  }

--- a/ansible/playbooks/nagios/roles/Nagios_Config/files/templates/jenkins-template.j2
+++ b/ansible/playbooks/nagios/roles/Nagios_Config/files/templates/jenkins-template.j2
@@ -1,0 +1,94 @@
+define host {
+        use                             linux-server
+        host_name                       {{ host_name }}
+        alias                           Add by Ansible
+        address                         {{ host_ip_address }}
+        check_command                   check_ssh!-4 -t 60
+        max_check_attempts              5
+        check_period                    24x7
+        notification_interval           720
+        notification_period             24x7
+        icon_image                      Ubuntu.png
+        icon_image_alt                  Ubuntu
+        statusmap_image                 Ubuntu.gd2
+}
+
+define service{
+        use                             generic-service
+	host_name                       {{ host_name }}
+        service_description             Current Load
+        check_command                   check_by_ssh!/usr/local/nagios/libexec/check_load -w 15,10,5 -c 30,24,20
+        notifications_enabled   0
+        check_interval                  30
+        action_url      /nagiosgraph/cgi-bin/show.cgi?host=$HOSTNAME$&service=$SERVICEDESC$' onMouseOver='showGraphPopup(this)' onMouseOut='hideGraphPopup()' rel='/nagiosgraph/cgi-bin/showgraph.cgi?host=$HOSTNAME$&service=$SERVICEDESC$&period=hour&rrdopts=-w+450
+}
+
+define service{
+        use                             generic-service
+        host_name                       {{ host_name }}
+        service_description             Disk Space Root Partition
+        check_command                   check_by_ssh!/usr/local/nagios/libexec/check_disk -w 20% -c 10% -p /
+        check_period                    once-a-day-at-8
+        action_url      /nagiosgraph/cgi-bin/show.cgi?host=$HOSTNAME$&service=$SERVICEDESC$' onMouseOver='showGraphPopup(this)' onMouseOut='hideGraphPopup()' rel='/nagiosgraph/cgi-bin/showgraph.cgi?host=$HOSTNAME$&service=$SERVICEDESC$&period=hour&rrdopts=-w+450
+}
+
+define service{
+        use                             generic-service
+        host_name                       {{ host_name }}
+        service_description             Disk Space Backup Server Partition
+        check_command                   check_by_ssh!/usr/local/nagios/libexec/check_disk -w 20% -c 10% -p /mnt/backup-server
+        check_period                    once-a-day-at-8
+        action_url      /nagiosgraph/cgi-bin/show.cgi?host=$HOSTNAME$&service=$SERVICEDESC$' onMouseOver='showGraphPopup(this)' onMouseOut='hideGraphPopup()' rel='/nagiosgraph/cgi-bin/showgraph.cgi?host=$HOSTNAME$&service=$SERVICEDESC$&period=hour&rrdopts=-w+450
+}
+
+define service{
+        use                             generic-service
+        host_name                       {{ host_name }}
+        service_description             Disk Space Jenkins Jobs Partition
+        check_command                   check_by_ssh!/usr/local/nagios/libexec/check_disk -w 20% -c 10% -p /home/jenkins/.jenkins/jobs
+        check_period                    once-a-day-at-8
+        action_url      /nagiosgraph/cgi-bin/show.cgi?host=$HOSTNAME$&service=$SERVICEDESC$' onMouseOver='showGraphPopup(this)' onMouseOut='hideGraphPopup()' rel='/nagiosgraph/cgi-bin/showgraph.cgi?host=$HOSTNAME$&service=$SERVICEDESC$&period=hour&rrdopts=-w+450
+}
+
+define service{
+        use                             generic-service
+        host_name                       {{ host_name }}
+        service_description             Disk Space Jenkins Workspace Partition
+        check_command                   check_by_ssh!/usr/local/nagios/libexec/check_disk -w 20% -c 10% -p /home/jenkins/.jenkins/workspace
+        check_period                    once-a-day-at-8
+        action_url      /nagiosgraph/cgi-bin/show.cgi?host=$HOSTNAME$&service=$SERVICEDESC$' onMouseOver='showGraphPopup(this)' onMouseOut='hideGraphPopup()' rel='/nagiosgraph/cgi-bin/showgraph.cgi?host=$HOSTNAME$&service=$SERVICEDESC$&period=hour&rrdopts=-w+450
+}
+
+define service{
+        use                             local-service
+        host_name                       {{ host_name }}
+        service_description             PING
+        check_period                    once-a-day-at-8
+        check_command                   check_ping!200.0,20%!500.0,60%
+	servicegroups			infrastructure_Servers
+}
+
+define service{
+        use                             generic-service
+        host_name                       {{ host_name }}
+        service_description             RAM
+        check_command                   check_by_ssh!/usr/local/nagios/libexec/check_mem -f -C -w 15 -c 5
+        action_url      /nagiosgraph/cgi-bin/show.cgi?host=nagios$&service=$' onMouseOver='showGraphPopup(this)' onMouseOut='hideGraphPopup()' rel='/nagiosgraph/cgi-bin/showgraph.cgi?host=nagios$&service=$&period=hour&rrdopts=-w+450
+        }
+
+define service{
+        use                             generic-service
+        host_name                       {{ host_name }}
+	check_period			once-a-day-at-8
+        service_description             Updates Required - apt
+        check_command			check_by_ssh!/usr/lib/nagios/plugins/check_apt
+	notifications_enabled   0
+        }
+
+define service{
+        use                             generic-service
+        host_name                       {{ host_name }}
+        service_description             Check Network Time System
+        check_command                   check_by_ssh!/usr/lib/nagios/plugins/check_ubuntu_ntp_timesync
+        check_interval                  15
+}

--- a/ansible/playbooks/nagios/roles/Nagios_Config/files/templates/jenkins-template.j2
+++ b/ansible/playbooks/nagios/roles/Nagios_Config/files/templates/jenkins-template.j2
@@ -18,7 +18,7 @@ define service{
 	host_name                       {{ host_name }}
         service_description             Current Load
         check_command                   check_by_ssh!/usr/local/nagios/libexec/check_load -w 15,10,5 -c 30,24,20
-        notifications_enabled   0
+        notifications_enabled           0
         check_interval                  30
         action_url      /nagiosgraph/cgi-bin/show.cgi?host=$HOSTNAME$&service=$SERVICEDESC$' onMouseOver='showGraphPopup(this)' onMouseOut='hideGraphPopup()' rel='/nagiosgraph/cgi-bin/showgraph.cgi?host=$HOSTNAME$&service=$SERVICEDESC$&period=hour&rrdopts=-w+450
 }

--- a/ansible/playbooks/nagios/roles/Nagios_Config/files/templates/jenkins-template.j2
+++ b/ansible/playbooks/nagios/roles/Nagios_Config/files/templates/jenkins-template.j2
@@ -82,7 +82,7 @@ define service{
 	check_period			once-a-day-at-8
         service_description             Updates Required - apt
         check_command			check_by_ssh!/usr/lib/nagios/plugins/check_apt
-	notifications_enabled   0
+	notifications_enabled           0
         }
 
 define service{


### PR DESCRIPTION
Fixes Issue #3107 
Update the Nagios configuration playbook to use the dedicated template for the Jenkins server, so that the automation can produce a relevant config file.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR

Playbook has been run successfully through both VM & vagrant Nagios servers.
