### PR TITLE
UnixPB : Linter Fixes

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,4 +1,9 @@
 ---
+# .ansible-lint
+
+exclude_paths:
+  - ./ansible/playbooks/adoptopenjdk_variables.yml # See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1926
+
 skip_list:
   - '106'  # Role name {} does not match ``^[a-z][a-z0-9_]+$`` pattern
   - '204'  # Lines should be no longer than 160 chars
@@ -21,7 +26,3 @@ skip_list:
   - 'no-free-form' # Exclude As Requires Significant Changes ( 196 changes required )
   - 'fqcn[action]' # Exclude As Requires Significant Changes ( 249 changes required )
   - 'args[module]' # Exclude Experimental Rule Validation ( Prevents 4 experimental warnings )
-
-
-exclude_paths:
-  - ./ansible/playbooks/adoptopenjdk_variables.yml # See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1926

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,9 +1,6 @@
 ---
 # .ansible-lint
 
-exclude_paths:
-  - ./ansible/playbooks/adoptopenjdk_variables.yml # See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1926
-
 skip_list:
   - '106'  # Role name {} does not match ``^[a-z][a-z0-9_]+$`` pattern
   - '204'  # Lines should be no longer than 160 chars
@@ -26,3 +23,9 @@ skip_list:
   - 'no-free-form' # Exclude As Requires Significant Changes ( 196 changes required )
   - 'fqcn[action]' # Exclude As Requires Significant Changes ( 249 changes required )
   - 'args[module]' # Exclude Experimental Rule Validation ( Prevents 4 experimental warnings )
+
+kinds:
+    - vars: "./ansible/playbooks/adoptopenjdk_variables.yml"
+
+exclude_paths:
+  - ./ansible/playbooks/adoptopenjdk_variables.yml # See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1926

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -25,7 +25,7 @@ skip_list:
   - 'args[module]' # Exclude Experimental Rule Validation ( Prevents 4 experimental warnings )
 
 kinds:
-  - vars: "./ansible/playbooks/adoptopenjdk_variables.yml"
+  - vars: "ansible/playbooks/adoptopenjdk_variables.yml"
 
 exclude_paths:
-  - ./ansible/playbooks/adoptopenjdk_variables.yml # See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1926
+  - ansible/playbooks/adoptopenjdk_variables.yml # See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1926

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -25,7 +25,7 @@ skip_list:
   - 'args[module]' # Exclude Experimental Rule Validation ( Prevents 4 experimental warnings )
 
 kinds:
-    - vars: "./ansible/playbooks/adoptopenjdk_variables.yml"
+  - vars: "./ansible/playbooks/adoptopenjdk_variables.yml"
 
 exclude_paths:
   - ./ansible/playbooks/adoptopenjdk_variables.yml # See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1926

--- a/ansible/playbooks/.ansible-lint
+++ b/ansible/playbooks/.ansible-lint
@@ -1,6 +1,0 @@
----
-
-rules:
-  vars:
-    schema:vars
-    path: ./adoptopenjdk_variables.yml

--- a/ansible/playbooks/.ansible-lint
+++ b/ansible/playbooks/.ansible-lint
@@ -1,3 +1,5 @@
+---
+
 rules:
   vars:
     schema:vars

--- a/ansible/playbooks/.ansible-lint
+++ b/ansible/playbooks/.ansible-lint
@@ -1,0 +1,4 @@
+rules:
+  vars:
+    schema:vars
+    path: ./adoptopenjdk_variables.yml

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
@@ -279,7 +279,7 @@
         group: wheel
       become: yes
       become_user: root
-      become_method: sudo
+      become_method: ansible.builtin.sudo
 
 - name: Install latest JDK {{ jdk_version }} release if one not already installed (Solaris)
   when:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
@@ -279,7 +279,7 @@
         group: wheel
       become: yes
       become_user: root
-      become_method: ansible.builtin.sudo
+      become_method: sudo
 
 - name: Install latest JDK {{ jdk_version }} release if one not already installed (Solaris)
   when:


### PR DESCRIPTION
Update Ansible Lint rules to use vars type validation on adoptopenjdk_vars.yml rather than playbook schema validation.

Fixes #3104 

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
