### PR TITLE
windowsPb: skip msvs2019 install tasks when necessary

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
@@ -23,6 +23,7 @@
   win_stat:
     path: 'C:\TEMP\VS2019_Layout.zip'
   register: vs2019_layout_ready
+  when: (not vs2019_installed.stat.exists)
   tags: adoptopenjdk
 
 # Exit Play If No VS2019 Layout & AdoptOpenJDK = true
@@ -30,7 +31,7 @@
 - name: Exit With Error When No Layout Within AdoptOpenJDK
   fail:
     msg: "The VS2019 Layout File Appears To Be Missing From Vendor_Files"
-  when: (not vs2019_layout_ready.stat.exists)
+  when: (not vs2019_layout_ready.stat.exists) and (not vs2019_installed.stat.exists)
   tags: adoptopenjdk
 
 # Install VS2019 From Layout For AdoptOpenJDK
@@ -38,7 +39,7 @@
   win_unzip:
     src: C:\TEMP\VS2019_Layout.zip
     dest: C:\TEMP
-  when: (vs2019_layout_ready.stat.exists)
+  when: (vs2019_layout_ready.stat.exists) and (not vs2019_installed.stat.exists)
   tags: adoptopenjdk
 
 - name: Run Visual Studio 2019 Installer From Layout
@@ -55,6 +56,7 @@
   with_items:
     - 'C:\TEMP\VS2019_Layout.zip'
     - 'C:\temp\VSLayout2019'
+  when: (not vs2019_installed.stat.exists)
   tags: adoptopenjdk
 
 ## Check If VS2019 Has Been Installed From Layout Even If Not AdoptOpenJDK

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
@@ -23,7 +23,6 @@
   win_stat:
     path: 'C:\TEMP\VS2019_Layout.zip'
   register: vs2019_layout_ready
-  when: (not vs2019_installed.stat.exists)
   tags: adoptopenjdk
 
 # Exit Play If No VS2019 Layout & AdoptOpenJDK = true


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Missed these changes in the https://github.com/adoptium/infrastructure/pull/3103. Skips these install tasks when it detects that the compiler is already installed