### PR TITLE
unixPB: Solaris remove duplicate jvm check and correct jvm search path 

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Solaris.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Solaris.yml
@@ -370,12 +370,7 @@
   tags: build_tools
 
 - name: Check if Liberica 11 is already installed in the target location
-  stat: path=/usr/lib/jvm/bell-jdk-11/bin/java
-  register: liberica11_installed
-  tags: build_tools
-
-- name: Check if Liberica 11 is already installed in the target location
-  stat: path=/usr/lib/jvm/bell-jdk-11/bin/java
+  stat: path=/usr/lib/jvm/jdk-11/bin/java
   register: liberica11_installed
   tags: build_tools
 


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

The playbook creates the symlink `/usr/lib/jvm/jdk-11` [after installing java](https://github.com/adoptium/infrastructure/blob/fc7d6fe556def56471531f94fa880af77b32a04d/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Solaris.yml#L445), but searches `/usr/lib/jvm/bell-jdk-11` to check if the jvm is already installed. Corrected this to `/usr/lib/jvm/jdk-11`

Removed duplicate code