### PR TITLE
UnixPB: Update URL For Maven GPG Signature

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/maven/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/maven/tasks/main.yml
@@ -26,7 +26,7 @@
   tags: maven
 
 - name: GPG Signature verification
-  script: ../Supporting_Scripts/package_signature_verification.sh -f /tmp/apache-maven-3.6.3-bin.tar.gz -sl "https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip.asc" -k {{ key.apache_maven }}
+  script: ../Supporting_Scripts/package_signature_verification.sh -f /tmp/apache-maven-3.6.3-bin.tar.gz -sl "https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz.asc" -k {{ key.apache_maven }}
   when: maven_installed.rc != 0
   tags: maven
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/maven/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/maven/tasks/main.yml
@@ -26,7 +26,7 @@
   tags: maven
 
 - name: GPG Signature verification
-  script: ../Supporting_Scripts/package_signature_verification.sh -f /tmp/apache-maven-3.6.3-bin.tar.gz -sl "https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz.asc" -k {{ key.apache_maven }}
+  script: ../Supporting_Scripts/package_signature_verification.sh -f /tmp/apache-maven-3.6.3-bin.tar.gz -sl "https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip.asc" -k {{ key.apache_maven }}
   when: maven_installed.rc != 0
   tags: maven
 


### PR DESCRIPTION
Update URL to download Maven 3.6.3 GPG signature file.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
