### PR TITLE
inventory: Remove test-equinix-win2012r2-x64-1

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -135,9 +135,6 @@ hosts:
           ubuntu1804-ppc64le-2: {ip: 140.211.168.8, user: ubuntu}
           ubuntu2004-ppc64le-1: {ip: 140.211.168.235, user: ubuntu}
 
-      - equinix:
-          win2012r2-x64-1: {ip: 147.75.32.146, user: Admin}
-
       - equinix_esxi:
           ubuntu2204-x64-1: {ip: 145.40.115.44, description: Perf machine}
           ubuntu2204-x64-2: {ip: 145.40.115.46, description: Perf machine}


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

According to https://github.com/adoptium/infrastructure/issues/2879#issuecomment-1415818400 this machine is fit for removal. Its unreachable via awx. Unpingale and cannot rdp into.

Was/is there a plan to replace this machine?