### PR TITLE
Ubuntu 22.04 build dockerfile missing `gnupg`

### DIFF
--- a/ansible/docker/Dockerfile.Ubuntu2204
+++ b/ansible/docker/Dockerfile.Ubuntu2204
@@ -4,7 +4,7 @@ ARG user=jenkins
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
-RUN apt-get -y install git curl ansible
+RUN apt-get -y install git curl ansible gnupg
 
 COPY . /ansible
 


### PR DESCRIPTION

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR (This file is not tested in VPC
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
