### PR TITLE
windowsPb: Add check for 7zip installation

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/7-Zip/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/7-Zip/tasks/main.yml
@@ -4,19 +4,27 @@
 ########
 # Added for extracting MinGW-W64
 
-- name: Download 7-Zip (required to unpack MinGW-W64)
-  win_get_url:
-    url: https://www.7-zip.org/a/7z2201-x64.exe
-    dest: 'C:\temp\7z.exe'
-    force: no
-    checksum: b055fee85472921575071464a97a79540e489c1c3a14b9bdfbdbab60e17f36e4
-    checksum_algorithm: sha256
+- name: Check if 7-Zip is installed
+  win_stat:
+    path: 'C:\7-Zip\7z.exe'
+  register: zip_installed
   tags: 7zip
 
-- name: Install 7-Zip
-  win_package:
-    path: 'C:\temp\7z.exe'
-    creates_path: 'C:\7-Zip\7z.exe'
-    state: present
-    arguments: /S /D="C:\7-Zip"
+- name: Download and install 7-Zip
+  when: not zip_installed.stat.exists
   tags: 7zip
+  block:
+    - name: Download 7-Zip (required to unpack MinGW-W64)
+      win_get_url:
+        url: https://www.7-zip.org/a/7z2201-x64.exe
+        dest: 'C:\temp\7z.exe'
+        force: no
+        checksum: b055fee85472921575071464a97a79540e489c1c3a14b9bdfbdbab60e17f36e4
+        checksum_algorithm: sha256
+
+    - name: Install 7-Zip
+      win_package:
+        path: 'C:\temp\7z.exe'
+        creates_path: 'C:\7-Zip\7z.exe'
+        state: present
+        arguments: /S /D="C:\7-Zip"


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/3123#issue-1791954714

build-ibmcloud-win2012r2-x64-2 is experiencing DNS problems which causes an error when downloading 7Zip
```
7-Zip : Download 7-Zip
FAILED! => {"changed": false, "dest": "C:\\temp\\7z.exe", "elapsed": 0.0670207, "msg": "Error when requesting 'Last-Modified'
 date from 'https://www.7-zip.org/a/7z2201-x64.exe'. The remote name could not be resolved: 'www.7-zip.org'", "status_code": 
null, "url": "https://www.7-zip.org/a/7z2201-x64.exe"
```
While I fix that, it makes sense to add a task which checks if 7zip is already installed before downloading and installing it