### PR TITLE
windowsPb: Fix the Rust install location

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Rust/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Rust/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Test if Rust is already installed
   win_stat:
-    path: 'C:\Program Files\Rust stable MSVC 1.33\bin\rustc.exe'
+    path: 'C:\rust\bin\rustc.exe'
   register: rust_installed
   tags: Rust
 


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Ref https://github.com/adoptium/infrastructure/issues/3123#issue-1791954714
Rust gets installed into C:\rust\bin\rustc.exe while the task to check if it is already installed looks elsewhere