### PR TITLE
windowsPb: Skip NSClient install on arm64

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NSClient/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NSClient/tasks/main.yml
@@ -35,7 +35,7 @@
     creates_path: 'c:\nsclient\nscp.exe'
     state: present
     arguments: /l* C:\temp\nscp.log /quiet INSTALLLOCATION=c:\nsclient CONF_CAN_CHANGE=1 MONITORING_TOOL=none ALLOWED_HOSTS=127.0.0.1,{{ Nagios_Master_IP }} ADD_DEFAULTS=1 CONF_CHECKS=1 CONF_NSCLIENT=1 /quiet
-  when: (not nsclient_installed.stat.exists)
+  when: (not nsclient_installed.stat.exists) and (ansible_architecture == "32-bit" or ansible_architecture == "64-bit")
   tags: NSClient
 
 - name: Enable External Script Options For NSClient
@@ -47,7 +47,7 @@
     - CheckNSCP
     - CheckDisk
     - CheckSystem
-  when: (not nsclient_installed.stat.exists)
+  when: (not nsclient_installed.stat.exists) and (ansible_architecture == "32-bit" or ansible_architecture == "64-bit")
   register: result
   failed_when: (result.rc == 0) or (result.rc == -1)
   tags: NSClient
@@ -56,6 +56,7 @@
   win_service:
     name: nscp
     state: restarted
+  when: (not nsclient_installed.stat.exists) and (ansible_architecture == "32-bit" or ansible_architecture == "64-bit")
   tags: NSClient
 
 - name: Cleanup NSClient
@@ -63,4 +64,5 @@
     path: C:\temp\nscp.msi
     state: absent
   failed_when: false
+  when: (not nsclient_installed.stat.exists) and (ansible_architecture == "32-bit" or ansible_architecture == "64-bit")
   tags: NSClient


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/3132

Theres no client for arm64 windows. The role should be skipped until we find a suitable client