### PR TITLE
inventory: Update IPs For Restored Azure Win 2012 Machines

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -39,8 +39,8 @@ hosts:
           ubuntu1804-armv8-2: {ip: 159.138.100.163}
 
       - azure:
-          win2012r2-x64-1: {ip: 51.132.23.101, user: adoptopenjdk}
-          win2012r2-x64-2: {ip: 51.132.22.249, user: adoptopenjdk}
+          win2012r2-x64-1: {ip: 20.108.178.21, user: adoptopenjdk}
+          win2012r2-x64-2: {ip: 20.108.176.36, user: adoptopenjdk}
           win2022-x64-1: {ip: 172.187.129.163, user: adoptopenjdk}
           win2022-x64-2: {ip: 172.187.176.15, user: adoptopenjdk}
 


### PR DESCRIPTION
Following the return of 2 Windows 2012 build machines to service, they have new public IP Addresses that require updating in the inventory.

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR
- [X] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
