### PR TITLE
unixPB: Install rng-tools to fix low entropy

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -141,3 +141,4 @@
     - role: logs
       position: "End"
       tags: always
+    - rngd

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/rngd/tasks/fedora.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/rngd/tasks/fedora.yml
@@ -1,0 +1,20 @@
+---
+- name: Install the rng-tools package (Fedora)
+  package: 
+    name: rng-tools
+    state: latest
+
+- name: Update the rngd.service file (Fedora)
+  ini_file: 
+    path: /usr/lib/systemd/system/rngd.service
+    section: service
+    option: ExecStart
+    value: "/sbin/rngd -f -r /dev/urandom -o /dev/random"
+    backup: yes
+
+- name: Start and enable "rngd" service (Fedora)
+  service: 
+    name: rngd
+    state: started
+    enabled: yes
+    

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/rngd/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/rngd/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+################
+#  rng daemon  #
+################
+- name: Install rng-tools and start service
+  tags: rngd
+  block:
+    - name: Install rng-tools and start rng-tools.service (Ubuntu)
+      include_tasks: ubuntu.yml
+      when:
+        - ansible_distribution == "Ubuntu" and ansible_distribution_major_version < "21"
+
+    - name: Install rng-tools and start rngd (Fedora)
+      include_tasks: fedora.yml
+      when:
+        - (ansible_distribution == "RedHat" and ansible_distribution_major_version <= "8") or 
+          (ansible_distribution == "CentOS" and ansible_distribution_major_version <= "8")
+
+    - name: Install rng-tools and start rng-tools.service (SLES)
+      include_tasks: sles.yml
+      when:
+        - ansible_distribution == "SLES" and ansible_distribution_major_version <= "12"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/rngd/tasks/sles.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/rngd/tasks/sles.yml
@@ -1,0 +1,20 @@
+---
+- name: Install the rng-tools package (SLES)
+  package: 
+    name: rng-tools
+    state: latest
+
+- name: Update the rng-tools.service file (SLES)
+  ini_file: 
+    path: /usr/lib/systemd/system/rng-tools.service
+    section: service
+    option: ExecStart
+    value: "usr/sbin/rngd -f -r /dev/urandom -o /dev/random"
+    backup: yes
+
+- name: Start and enable "rng-tools" service (SLES)
+  service: 
+    name: rng-tools
+    state: started
+    enabled: yes
+    

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/rngd/tasks/ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/rngd/tasks/ubuntu.yml
@@ -1,0 +1,20 @@
+---
+- name: Install the rng-tools package (Ubuntu)
+  package: 
+    name: rng-tools
+    state: latest
+
+- name: Update the rng-tools defaults file (Ubuntu)
+  lineinfile:
+    dest: '/etc/default/rng-tools'
+    regexp: '^HRNGDEVICE=/dev/urandom'
+    mode: '0644'
+    insertafter: '^#HRNGDEVICE=/dev/null'
+    line: 'HRNGDEVICE=/dev/urandom'
+
+- name: Start and enable "rngd" service (Ubuntu)
+  systemd:
+      name: rng-tools.service
+      state: started
+      enabled: yes
+    


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->
Cryptography tests are failing as not enough random information is being generated on older distributions, causing tests to timeout.
So installing and enabling rng-tools and its services fix the issues. 

##### Fixes
 - https://github.com/adoptium/aqa-tests/pull/4474
 - https://github.com/eclipse-openj9/openj9/issues/16720

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
