### PR TITLE
unixPB: Stop forcing JDK19_BOOT_DIR to point at a JDK18

### DIFF
--- a/ansible/docker/Dockerfile.Alpine3
+++ b/ansible/docker/Dockerfile.Alpine3
@@ -25,6 +25,5 @@ ENV \
     JDK16_BOOT_DIR="/usr/lib/jvm/zulu16" \
     JDK17_BOOT_DIR="/usr/lib/jvm/jdk-17" \
     JDK18_BOOT_DIR="/usr/lib/jvm/zulu18" \
-    JDK19_BOOT_DIR="/usr/lib/jvm/zulu18" \
     JDKLATEST_BOOT_DIR="/usr/lib/jvm/zulu18" \
     JAVA_HOME="/usr/lib/jvm/jdk8"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

JDK20 for Alpine/aarch64 won't build becausje the JDK19_BOOT_DIR definition points to a zulu18 which is not suitable as a boot JDK for 20. Once this is in the build process will download a nightly JDK19 for the JDK20 build, and then we'll be able to use that for JDK21.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] VPC/QPC not applicable for this PR (No alpine)
