### PR TITLE
unixPb: run the updatepackage.sh script via dockerhost playbook

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/scripts/updatepackages.sh
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/scripts/updatepackages.sh
@@ -1,16 +1,22 @@
- #!/bin/bash
+#!/bin/bash
+set -u
 
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 containerIds=$(docker ps -q)
 
+commonPackages=
+fedoraPackages=
+debianPackages=
+alpinePackages=
+
 for container in $containerIds
 do
     OS=$(docker exec -it $container sh -c "cat /etc/os-release" | head -n 1)
-    if [[ $OS =~ "CentOS" || $OS =~ "Fedora" || $OS=~ "Red Hat Enterprise Linux" ]]; then
+    if [[ "$OS" == *"CentOS"* ]] || [[ "$OS" == *"Fedora"* ]] || [[ "$OS" == *"Red Hat Enterprise Linux"* ]]; then
         installCommand="yum -y update"
-    elif [[ $OS =~ "Ubuntu" || $OS =~ "Debian" ]]; then
+    elif [[ "$OS" == *"Ubuntu"* ]] || [[ "$OS" == *"Debian"* ]]; then
         installCommand="apt-get update && apt-get -y upgrade"
-    elif [[ $OS =~ "Alpine" ]]; then
+    elif [[ "$OS" == *"Alpine"* ]]; then
         installCommand="apk update && apk upgrade"
     else 
         echo "Unrecognised OS, skipping package update"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/scripts/updatepackages.sh
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/scripts/updatepackages.sh
@@ -4,25 +4,26 @@ set -u
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 containerIds=$(docker ps -q)
 
-commonPackages=
-fedoraPackages=
-debianPackages=
-alpinePackages=
+commonPackages="gnupg fakeroot"
+fedoraPackages="procps-ng hostname shared-mime-info"
+debianPackages=""
+alpinePackages=""
 
 for container in $containerIds
 do
     OS=$(docker exec -it $container sh -c "cat /etc/os-release" | head -n 1)
     if [[ "$OS" == *"CentOS"* ]] || [[ "$OS" == *"Fedora"* ]] || [[ "$OS" == *"Red Hat Enterprise Linux"* ]]; then
-        installCommand="yum -y update"
+        installCommand="yum -y update && yum -y install $commonPackages $fedoraPackages"
     elif [[ "$OS" == *"Ubuntu"* ]] || [[ "$OS" == *"Debian"* ]]; then
-        installCommand="apt-get update && apt-get -y upgrade"
+        installCommand="apt-get update && apt-get -y upgrade && apt-get -y install $commonPackages $debianPackages"
     elif [[ "$OS" == *"Alpine"* ]]; then
-        installCommand="apk update && apk upgrade"
+        installCommand="apk update && apk upgrade && apk --update add $commonPackages $alpinePackages"
     else 
         echo "Unrecognised OS, skipping package update"
         continue
     fi
     echo "Updating packages for container $container"
+    echo "Running $installCommand"
     docker exec -it $container sh -c "$installCommand"
     echo "=============================================="
 done

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/tasks/main.yml
@@ -249,4 +249,6 @@
   script: scripts/updatepackages.sh
   args:
     executable: bash
-  tags: updateContainers
+  tags:
+    - updateContainers
+    - never

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/tasks/main.yml
@@ -245,10 +245,8 @@
     regexp: kernel_core_pattern
     line: kernel.core_pattern=core.%p
 
-- name: Copy updatepackages.sh script to remote cron.daily directory
-  copy:
-    src: scripts/updatepackages.sh
-    dest: /etc/cron.daily/updatepackages.sh
-    owner: root
-    group: root
-    mode: +x
+- name: Run updatePackage.sh script
+  script: scripts/updatepackages.sh
+  args:
+    executable: bash
+  tags: updateContainers


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/2962

Ive added a job in AWX to run the updatepackage.sh script regularly (will initiate it when this gets merged). This is better than it being in a cron job since AWX will pull updates to the script. It will run tasks in the `dockerhost.yml` playbook tagged with `updateContainers` which only corresponds to the task I have added in this pr. The `never` tag ensures that the task will only run when specified (by use of the `updateContainers` tag) and not as part of the entire playbook. 

This is still a draft because though this script updates the containers, it does not install new packages if needed, so I need to think of a clean way to do that. 

My last resort is to add strings in the `updatepackages.sh` script which contain any new package that needs to be installed on the containers (sort of how we do in the [Common](https://github.com/adoptium/infrastructure/tree/master/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars) role but as bash strings) but im certain theres a better way to do this.

Any thoughts @sxa @steelhead31 
