### PR TITLE
winPB: Install 32bit NSClient On ARM64 Windows Machines

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NSClient/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NSClient/tasks/main.yml
@@ -26,7 +26,7 @@
     force: no
     checksum: ca6a67fb01c1468f2b510fd2f9eb0750887db3fb49a0302732c1421c85c6627c
     checksum_algorithm: sha256
-  when: (not nsclient_installed.stat.exists) and (ansible_architecture == "32-bit")
+  when: (not nsclient_installed.stat.exists) and (ansible_architecture == "32-bit" or ansible_architecture == "ARM 64-bit Processor")
   tags: NSClient
 
 - name: Install NSClient
@@ -35,7 +35,7 @@
     creates_path: 'c:\nsclient\nscp.exe'
     state: present
     arguments: /l* C:\temp\nscp.log /quiet INSTALLLOCATION=c:\nsclient CONF_CAN_CHANGE=1 MONITORING_TOOL=none ALLOWED_HOSTS=127.0.0.1,{{ Nagios_Master_IP }} ADD_DEFAULTS=1 CONF_CHECKS=1 CONF_NSCLIENT=1 /quiet
-  when: (not nsclient_installed.stat.exists) and (ansible_architecture == "32-bit" or ansible_architecture == "64-bit")
+  when: (not nsclient_installed.stat.exists) and (ansible_architecture == "32-bit" or ansible_architecture == "64-bit" or ansible_architecture == "ARM 64-bit Processor")
   tags: NSClient
 
 - name: Enable External Script Options For NSClient
@@ -47,7 +47,7 @@
     - CheckNSCP
     - CheckDisk
     - CheckSystem
-  when: (not nsclient_installed.stat.exists) and (ansible_architecture == "32-bit" or ansible_architecture == "64-bit")
+  when: (not nsclient_installed.stat.exists) and (ansible_architecture == "32-bit" or ansible_architecture == "64-bit" or ansible_architecture == "ARM 64-bit Processor")
   register: result
   failed_when: (result.rc == 0) or (result.rc == -1)
   tags: NSClient
@@ -56,7 +56,7 @@
   win_service:
     name: nscp
     state: restarted
-  when: (not nsclient_installed.stat.exists) and (ansible_architecture == "32-bit" or ansible_architecture == "64-bit")
+  when: (not nsclient_installed.stat.exists) and (ansible_architecture == "32-bit" or ansible_architecture == "64-bit" or ansible_architecture == "ARM 64-bit Processor")
   tags: NSClient
 
 - name: Cleanup NSClient
@@ -64,5 +64,5 @@
     path: C:\temp\nscp.msi
     state: absent
   failed_when: false
-  when: (not nsclient_installed.stat.exists) and (ansible_architecture == "32-bit" or ansible_architecture == "64-bit")
+  when: (not nsclient_installed.stat.exists) and (ansible_architecture == "32-bit" or ansible_architecture == "64-bit" or ansible_architecture == "ARM 64-bit Processor")
   tags: NSClient


### PR DESCRIPTION
Fixes #3132 

Install the Windows 32 bit NSClient on Windows aarch64 hosts. This has been tested on test-azure-win11-aarch64-1 & test-azure-win11-aarch64-2, and both are now monitored by nagios.

##### Checklist


- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
