### PR TITLE
github: Update The URL for the ansible Powershell Script

### DIFF
--- a/.github/workflows/build_wsl.yml
+++ b/.github/workflows/build_wsl.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         Set-LocalUser -Name "runneradmin" -Password (ConvertTo-SecureString -AsPlainText "Ansible_password123!" -Force)
         New-NetFirewallRule -DisplayName "ALLOW TCP PORT 5986" -Direction inbound -Profile Any -Action Allow -LocalPort 5986 -Protocol TCP
-        Invoke-WebRequest https://github.com/ansible/ansible-documentation/tree/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile .\ConfigureRemotingForAnsible.ps1
+        Invoke-WebRequest https://raw.githubusercontent.com/ansible/ansible-documentation/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile .\ConfigureRemotingForAnsible.ps1
         .\ConfigureRemotingForAnsible.ps1 -CertValidityDays 9999
         .\ConfigureRemotingForAnsible.ps1 -EnableCredSSP
         .\ConfigureRemotingForAnsible.ps1 -ForceNewSSLCert

--- a/.github/workflows/build_wsl.yml
+++ b/.github/workflows/build_wsl.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         Set-LocalUser -Name "runneradmin" -Password (ConvertTo-SecureString -AsPlainText "Ansible_password123!" -Force)
         New-NetFirewallRule -DisplayName "ALLOW TCP PORT 5986" -Direction inbound -Profile Any -Action Allow -LocalPort 5986 -Protocol TCP
-        Invoke-WebRequest https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile .\ConfigureRemotingForAnsible.ps1
+        Invoke-WebRequest https://github.com/ansible/ansible-documentation/tree/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile .\ConfigureRemotingForAnsible.ps1
         .\ConfigureRemotingForAnsible.ps1 -CertValidityDays 9999
         .\ConfigureRemotingForAnsible.ps1 -EnableCredSSP
         .\ConfigureRemotingForAnsible.ps1 -ForceNewSSLCert

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -12,7 +12,7 @@
 # Ensure you have opened Internet Explorer and completed the setup (other wise wget will not work)
 # Run powershell as the Administrator
 # If setting up a win2012r2 machine, run '[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12' See: https://github.com/adoptium/infrastructure/issues/1858
-# wget https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile .\ConfigureRemotingForAnsible.ps1
+# wget https://github.com/ansible/ansible-documentation/tree/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile .\ConfigureRemotingForAnsible.ps1
 # .\ConfigureRemotingForAnsible.ps1 -CertValidityDays 9999
 # .\ConfigureRemotingForAnsible.ps1 -EnableCredSSP
 # .\ConfigureRemotingForAnsible.ps1 -ForceNewSSLCert

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -12,7 +12,7 @@
 # Ensure you have opened Internet Explorer and completed the setup (other wise wget will not work)
 # Run powershell as the Administrator
 # If setting up a win2012r2 machine, run '[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12' See: https://github.com/adoptium/infrastructure/issues/1858
-# wget https://github.com/ansible/ansible-documentation/tree/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile .\ConfigureRemotingForAnsible.ps1
+# wget https://raw.githubusercontent.com/ansible/ansible-documentation/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile .\ConfigureRemotingForAnsible.ps1
 # .\ConfigureRemotingForAnsible.ps1 -CertValidityDays 9999
 # .\ConfigureRemotingForAnsible.ps1 -EnableCredSSP
 # .\ConfigureRemotingForAnsible.ps1 -ForceNewSSLCert

--- a/ansible/vagrant/Vagrantfile.Win2012
+++ b/ansible/vagrant/Vagrantfile.Win2012
@@ -11,7 +11,7 @@ Start-Process powershell -Verb runAs
 # Windows 2012r2 needs to be forced to use TLS1.2, see: https://github.com/adoptium/infrastructure/issues/1858
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-wget https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile .\\ConfigureRemotingForAnsible.ps1
+wget https://github.com/ansible/ansible-documentation/tree/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile .\\ConfigureRemotingForAnsible.ps1
 .\\ConfigureRemotingForAnsible.ps1 -CertValidityDays 9999
 .\\ConfigureRemotingForAnsible.ps1 -EnableCredSSP
 .\\ConfigureRemotingForAnsible.ps1 -ForceNewSSLCert

--- a/ansible/vagrant/Vagrantfile.Win2012
+++ b/ansible/vagrant/Vagrantfile.Win2012
@@ -11,7 +11,7 @@ Start-Process powershell -Verb runAs
 # Windows 2012r2 needs to be forced to use TLS1.2, see: https://github.com/adoptium/infrastructure/issues/1858
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-wget https://github.com/ansible/ansible-documentation/tree/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile .\\ConfigureRemotingForAnsible.ps1
+wget https://raw.githubusercontent.com/ansible/ansible-documentation/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile .\\ConfigureRemotingForAnsible.ps1
 .\\ConfigureRemotingForAnsible.ps1 -CertValidityDays 9999
 .\\ConfigureRemotingForAnsible.ps1 -EnableCredSSP
 .\\ConfigureRemotingForAnsible.ps1 -ForceNewSSLCert

--- a/ansible/vagrant/Vagrantfile.Windows2022.Core
+++ b/ansible/vagrant/Vagrantfile.Windows2022.Core
@@ -9,7 +9,7 @@ $script = <<SCRIPT
 Start-Process powershell -Verb runAs
 
 
-wget https://github.com/ansible/ansible-documentation/tree/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile .\\ConfigureRemotingForAnsible.ps1
+wget https://raw.githubusercontent.com/ansible/ansible-documentation/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile .\\ConfigureRemotingForAnsible.ps1
 .\\ConfigureRemotingForAnsible.ps1 -CertValidityDays 9999
 .\\ConfigureRemotingForAnsible.ps1 -EnableCredSSP
 .\\ConfigureRemotingForAnsible.ps1 -ForceNewSSLCert

--- a/ansible/vagrant/Vagrantfile.Windows2022.Core
+++ b/ansible/vagrant/Vagrantfile.Windows2022.Core
@@ -9,7 +9,7 @@ $script = <<SCRIPT
 Start-Process powershell -Verb runAs
 
 
-wget https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile .\\ConfigureRemotingForAnsible.ps1
+wget https://github.com/ansible/ansible-documentation/tree/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile .\\ConfigureRemotingForAnsible.ps1
 .\\ConfigureRemotingForAnsible.ps1 -CertValidityDays 9999
 .\\ConfigureRemotingForAnsible.ps1 -EnableCredSSP
 .\\ConfigureRemotingForAnsible.ps1 -ForceNewSSLCert


### PR DESCRIPTION
Fixes #3155 

As per this issue : https://github.com/ansible/ansible/issues/81240

The URL for this script 

https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1

Has changed to

https://raw.githubusercontent.com/ansible/ansible-documentation/devel/examples/scripts/ConfigureRemotingForAnsible.ps1

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR
