### PR TITLE
Doc: Update docker static patching policy

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -315,7 +315,7 @@ cases they may be used as `dockerBuild` hosts too.
 
 Instructions on how to create a static docker container can be found [here](https://github.com/adoptium/infrastructure/tree/master/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/README.md)
 
-### Dockerhost Patching System
+### Dockerhost Patching
 
 At the moment we have the [updatepackages.sh](https://github.com/adoptium/infrastructure/blob/master/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/scripts/updatepackages.sh) script which runs weekly on all of our Dockerhost systems to ensure that the Static Docker containers are patched and up to date. The script is also used to install new test [prerequisite](https://github.com/adoptium/aqa-tests/blob/master/doc/Prerequisites.md#prerequisites) packages onto the containers.
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -315,12 +315,14 @@ cases they may be used as `dockerBuild` hosts too.
 
 Instructions on how to create a static docker container can be found [here](https://github.com/adoptium/infrastructure/tree/master/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/README.md)
 
+### Dockerhost Patching System
+
+At the moment we have the [updatepackages.sh](https://github.com/adoptium/infrastructure/blob/master/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/scripts/updatepackages.sh) script which runs weekly on all of our Dockerhost systems to ensure that the Static Docker containers are patched and up to date. The script is also used to install new test [prerequisite](https://github.com/adoptium/aqa-tests/blob/master/doc/Prerequisites.md#prerequisites) packages onto the containers.
+
 ### DockerHost TODO
 
-1. Set up patching cycle
-2. Identify ways to redeploy when needed to pick up updates
-3. Allow dockerhost.yml playbook to adjust core file settings
-4. Add mechanism to deploy differently based on host machine size
+1. Allow dockerhost.yml playbook to adjust core file settings
+2. Add mechanism to deploy differently based on host machine size
 
 ## Temporary access to a machine
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -317,7 +317,7 @@ Instructions on how to create a static docker container can be found [here](http
 
 ### Dockerhost Patching
 
-At the moment we have the [updatepackages.sh](https://github.com/adoptium/infrastructure/blob/master/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/scripts/updatepackages.sh) script which runs weekly on all of our Dockerhost systems to ensure that the Static Docker containers are patched and up to date. The script is also used to install new test [prerequisite](https://github.com/adoptium/aqa-tests/blob/master/doc/Prerequisites.md#prerequisites) packages onto the containers.
+At the moment we have the [updatepackages.sh](https://github.com/adoptium/infrastructure/blob/master/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/scripts/updatepackages.sh) script which runs weekly on all of our Dockerhost systems via a scheduled job on our AWX server to ensure that the Static Docker containers are patched and up to date. The script is also used to install new test [prerequisite](https://github.com/adoptium/aqa-tests/blob/master/doc/Prerequisites.md#prerequisites) packages onto the containers.
 
 ### DockerHost TODO
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -317,7 +317,7 @@ Instructions on how to create a static docker container can be found [here](http
 
 ### Dockerhost Patching
 
-At the moment we have the [updatepackages.sh](https://github.com/adoptium/infrastructure/blob/master/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/scripts/updatepackages.sh) script which runs weekly on all of our Dockerhost systems via a scheduled job on our AWX server to ensure that the Static Docker containers are patched and up to date. The script is also used to install new test [prerequisite](https://github.com/adoptium/aqa-tests/blob/master/doc/Prerequisites.md#prerequisites) packages onto the containers.
+At the moment we have the [updatepackages.sh](https://github.com/adoptium/infrastructure/blob/master/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/scripts/updatepackages.sh) script which runs weekly on all of our Dockerhost systems via a [scheduled job on our AWX server](https://awx2.adoptopenjdk.net/#/templates/job_template/34?template_search=page_size:20;order_by:name;type:workflow_job_template,job_template) to ensure that the Static Docker containers are patched and up to date. The script is also used to install new test [prerequisite](https://github.com/adoptium/aqa-tests/blob/master/doc/Prerequisites.md#prerequisites) packages onto the containers.
 
 ### DockerHost TODO
 


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/2962

Update to the dockerstatic docs now that https://github.com/adoptium/infrastructure/pull/3152 is merged
