### PR TITLE
inventory: Correct the OS for dockerhost skytap machine

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -99,7 +99,7 @@ hosts:
           ubuntu2204-s390x-1: {ip: 148.100.74.237, user: linux1}
 
       - skytap:
-          ubuntu2204-ppc64le-1: {ip: 20.61.136.212, description: 32CPU, 400G}
+          ubuntu2004-ppc64le-1: {ip: 20.61.136.212, description: 32CPU, 400G}
 
   - test:
 


### PR DESCRIPTION

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

```
root@dockerhost-skytap-ubuntu2004-ppc64le-1:~# cat /etc/os-release 
NAME="Ubuntu"
VERSION="20.04.6 LTS (Focal Fossa)"
```
Incorrectly named 2204 when its OS is 2004
