### PR TITLE
inventory: Add specs for macstadium systems for reference

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -51,10 +51,10 @@ hosts:
           solaris10-x64-1: {ip: 145.40.115.43}
 
       - macstadium:
-          macos1014-x64-1: {ip: 208.83.1.170, user: Administrator}
-          macos1014-x64-2: {ip: 207.254.28.76, user: Administrator}
-          macos11-arm64-1: {ip: 207.254.31.15, user: Administrator}
-          macos11-arm64-2: {ip: 207.254.31.16, user: Administrator}
+          macos1014-x64-1: {ip: 208.83.1.170, user: Administrator, description: G3B i7-4C/16G/250G}
+          macos1014-x64-2: {ip: 207.254.28.76, user: Administrator, description: G3C i7-4C/16G/500G}
+          macos11-arm64-1: {ip: 207.254.31.15, user: Administrator, description: G5G M1/8C/16G/1T}
+          macos11-arm64-2: {ip: 207.254.31.16, user: Administrator, description: G5G M1/8C/16G/1T}
 
       - marist:
           rhel79-s390x-1: {ip: 148.100.75.212, user: linux1}
@@ -145,13 +145,13 @@ hosts:
           macos1201-x64-2: {ip: 216.39.74.140, user: admin, description: DXT440}
 
       - macstadium:
-          macos1014-x64-1: {ip: 207.254.29.43, user: administrator}
-          macos1014-x64-2: {ip: 207.254.29.44, user: administrator}
-          macos1014-x64-3: {ip: 207.254.28.237, user: administrator}
-          macos1014-x64-4: {ip: 207.254.71.202, user: Administrator}
-          macos1015-x64-1: {ip: 207.254.28.171, user: administrator}
-          macos11-arm64-1: {ip: 199.7.163.51, user: Administrator}
-          macos11-arm64-2: {ip: 199.7.163.52, user: Administrator}
+          macos1014-x64-1: {ip: 207.254.29.43, user: administrator, description: G3B i7/4C/16G/250G}
+          macos1014-x64-2: {ip: 207.254.29.44, user: administrator, description: G3B i7/4C/16G/250G}
+          macos1014-x64-3: {ip: 207.254.28.237, user: administrator, description: G3B i7/4C/16G/250G}
+          macos1014-x64-4: {ip: 207.254.71.202, user: Administrator, description: G4B i7-6C/32G/512G}
+          macos1015-x64-1: {ip: 207.254.28.171, user: administrator, description: G3B i7/4C/16G/250G}
+          macos11-arm64-1: {ip: 199.7.163.51, user: Administrator, description: G5A M1/8C/8G/256G}
+          macos11-arm64-2: {ip: 199.7.163.52, user: Administrator, description: G5A M1/8C/8G/256G}
 
       - marist:
           rhel7-s390x-2: {ip: 148.100.74.92}


### PR DESCRIPTION
Updates to record the specs of the macstadium machines pending a review of what we're using at this provider. 
Noting that the larger `test-macstadium-macos1014-x64-4` was listed as a `build-` prefixed machine in the macstadium UI but I've now renamed it, although it does not seem to have been contactable for a while.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
