### PR TITLE
UnixPB: Update Debian URLs

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
@@ -25,13 +25,13 @@
 
 - name: Add AdoptOpenJDK GPG key
   apt_key:
-    url: https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public
+    url: https://packages.adoptium.net/artifactory/api/gpg/key/public
     state: present
   tags: patch_update
 
 - name: Add the adoptopenjdk repository to apt for JDK8
   apt_repository:
-    repo: "deb https://adoptopenjdk.jfrog.io/adoptopenjdk/deb {{ ansible_distribution_release }} main"
+    repo: "deb https://packages.adoptium.net/artifactory/deb {{ ansible_distribution_release }} main"
     update_cache: no
   when:
     - (ansible_architecture != "riscv64")

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
@@ -29,7 +29,7 @@
     state: present
   tags: patch_update
 
-- name: Add the adoptopenjdk repository to apt for JDK8
+- name: Add the Eclipse Temurin repository to apt for JDK8
   apt_repository:
     repo: "deb https://packages.adoptium.net/artifactory/deb {{ ansible_distribution_release }} main"
     update_cache: no

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
@@ -23,7 +23,7 @@
     state: present
   tags: patch_update
 
-- name: Add AdoptOpenJDK GPG key
+- name: Add Eclipse Temurin GPG key
   apt_key:
     url: https://packages.adoptium.net/artifactory/api/gpg/key/public
     state: present

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Debian.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Debian.yml
@@ -68,7 +68,7 @@ Additional_Packages_Debian8:
   - libgstreamer0.10-dev                # OpenJFX prereq
   - libgstreamer-plugins-base0.10-dev   # OpenJFX prereq
   - openjdk-7-jdk
-  - adoptopenjdk-8-hotspot
+  - temurin-8-jdk
   - libmpfr4
   - libmpfr4-dbg
 


### PR DESCRIPTION
Fixes #3173 

Update URLs for GPG and repository to adoptium.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
