### PR TITLE
WindowsPB: Fix parameters for updated vs2017 installer

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
@@ -21,7 +21,7 @@
   tags: MSVS_2017
 
 - name: Install Visual Studio Community 2017
-  win_shell: 'C:\temp\vs_community.exe --wait --add Microsoft.VisualStudio.Workload.NativeDesktop;includeRecommended;includeOptional --quiet --norestart'
+  win_shell: 'C:\temp\vs_community.exe --wait --add Microsoft.VisualStudio.Workload.NativeDesktop --includeRecommended --includeOptional --quiet --norestart'
   args:
     executable: cmd
   when: (not vs2017_installed.stat.exists)


### PR DESCRIPTION
The Visual Studio community installer has been updated, and the existing parameter format does not work. 

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
