### PR TITLE
unixPB: Fix sles 12 build tools package name

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/SLES.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/SLES.yml
@@ -64,7 +64,7 @@ Additional_Build_Tools_SLES12:
   - perl-CPAN-Meta
 
 Additional_Build_Tools_SLES12_SP5:
-  - curl-devel    ## Required To Install Git From Source
+  - libcurl-devel    ## Required To Install Git From Source
 
 Additional_Build_Tools_SLES12_NOT_SP5:
   - git-core


### PR DESCRIPTION
Fixes #3191.
Package name updated to `libcurl-devel` from `curl-devel`.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
