### PR TITLE
unixPB: Add an optional role for performance tools

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/performance_tools/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/performance_tools/tasks/main.yml
@@ -1,0 +1,58 @@
+---
+###########################################
+### Installs gdb, perf, nmon & valgrind ###
+###   On Ubuntu, Rhel, CentOS & SLES    ###
+###########################################
+###            Optional Role            ###
+###########################################
+
+- name: Install gdb & valgrind
+  become: yes
+  package:
+    update_cache: yes
+    name: ['gdb', 'valgrind']
+    state: latest
+  when: ansible_distribution == "Ubuntu" or
+        ansible_distribution == "CentOS" or
+        ansible_distribution == "RedHat" or
+        ansible_distribution == "SLES"
+  tags: performance_tools
+
+- name: Install Perf (except Ubuntu)
+  become: yes
+  package:
+    update_cache: yes
+    name: perf
+    state: latest
+  when: ansible_distribution != "Ubuntu"
+  tags: performance_tools
+
+- name: Perf installation (Ubuntu)
+  become: yes
+  when: ansible_distribution == "Ubuntu"
+  tags: performance_tools
+  block:
+    - name: Get kernel info (Ubuntu) #for perf installation
+      shell: uname -r
+      register: uname
+
+    - name: Check perf for the specific kernel exists or not (Ubuntu)
+      shell: apt search linux-tools-`uname -r` 2>/dev/null #2?/dev/null remove apt cli warning
+      register: linux_tools
+
+    - name: Install perf (Ubuntu)
+      package:
+        update_cache: yes
+        name: ['linux-tools-common', 'linux-tools-generic', 'linux-tools-{{ uname.stdout }}']
+        state: latest
+      when: "'linux-tools-'~uname.stdout in linux_tools.stdout" # ~ -> concatenates string
+
+- name: Install nmon (except Rhel 7/CentOS 7 s390x) #nmon needs epel repo
+  become: yes
+  package:
+    update_cache: yes
+    name: nmon
+    state: latest
+  when: not (ansible_distribution_major_version == "7" and ansible_architecture == "s390x" and
+        (ansible_distribution == "RedHat" or ansible_distribution == "CentOS"))
+  tags: performance_tools


### PR DESCRIPTION
Fixes: https://github.com/adoptium/infrastructure/issues/3181

Adds an optional role for installing gdb, perf, nmon and valgrind on Ubuntu, CentOS, Rhel & SLES machines.

##### Checklist

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
