### PR TITLE
unixpb: Add Xcode11 installation tasks to Unix playbook

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -6,7 +6,7 @@
 # It can be defined as 'all' or a specific group which the host belongs to.
 # For example, it can be 'all' or 'x86' for when a host is in the group 'x86'.
 - name: Ansible Unix playbook
-  hosts: "{{ Groups | default('localhost:build:test:perf:jck:!*zos*:!*win*:!*aix*') }}"
+  hosts: all
   gather_facts: yes
   tasks:
     - name: Run Tasks

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -76,8 +76,7 @@
       when: ansible_distribution == "MacOSX"
     - role: Xcode11
       when: ansible_distribution == "MacOSX" and ansible_architecture == "arm64"
-      tags: xcode11
-      tags: [build_tools, xcode, adoptopenjdk]
+      tags: [xcode11, adoptopenjdk]
     - role: cmake                 # OpenJ9 / OpenJFX
       when: ansible_distribution != "Solaris" # Compile fails on Solaris
       tags: [build_tools, build_tools_openj9, build_tools_openjfx]

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -76,7 +76,7 @@
       when: ansible_distribution == "MacOSX"
     - role: Xcode11
       when: ansible_distribution == "MacOSX" and ansible_architecture == "arm64"
-      tags: [xcode11, adoptopenjdk]
+      tags: [xcode11]
     - role: cmake                 # OpenJ9 / OpenJFX
       when: ansible_distribution != "Solaris" # Compile fails on Solaris
       tags: [build_tools, build_tools_openj9, build_tools_openjfx]

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -74,6 +74,9 @@
       tags: [build_tools]
     - role: Xcode
       when: ansible_distribution == "MacOSX"
+    - role: Xcode11
+      when: ansible_distribution == "MacOSX" and ansible_architecture == "arm64"
+      tags: xcode11
       tags: [build_tools, xcode, adoptopenjdk]
     - role: cmake                 # OpenJ9 / OpenJFX
       when: ansible_distribution != "Solaris" # Compile fails on Solaris

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -6,7 +6,7 @@
 # It can be defined as 'all' or a specific group which the host belongs to.
 # For example, it can be 'all' or 'x86' for when a host is in the group 'x86'.
 - name: Ansible Unix playbook
-  hosts: all
+  hosts: "{{ Groups | default('localhost:build:test:perf:jck:!*zos*:!*win*:!*aix*') }}"
   gather_facts: yes
   tasks:
     - name: Run Tasks

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode11/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode11/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+# Xcode 11.7 is needed to build x64 JDK8
+# See https://github.com/adoptium/infrastructure/issues/2536#issuecomment-1708716478
+# Xcode11.7 package should be in Vendor_Files directory
+
+- name: Check if Xcode11.7 is installed
+  stat:
+    path: /Applications/Xcode.11.7.app/
+  register: xcode11_installed
+
+- name: Install Xcode11.7
+  when: not xcode11_installed.stat exists
+  block:
+    - name: Transfer Xcode11.7 over to remote machine
+      copy:
+        src: /Vendor_Files/mac/Xcode_11.7.xip
+        dest: /tmp/Xcode_11.7.xip
+
+    - name: Extract Xcode11.7
+      command: xip -x /tmp/Xcode_11.7.xip
+
+    - name: Move Xcode11.7 to /Applications directory
+      copy:
+        src: /tmp/Xcode.app
+        dest: /Applications/Xcode.11.7.app/
+        remote_src: true

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode11/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode11/tasks/main.yml
@@ -1,7 +1,8 @@
 ---
 # Xcode 11.7 is needed to build x64 JDK8 om Arm64 Mac
+# Xcode11.7 can be downloaded from https://developer.apple.com/download/all after authentication with apple ID and password
 # See https://github.com/adoptium/infrastructure/issues/2536#issuecomment-1708716478
-# The Xcode11.7 package should be present in /Vendor_Files/mac/Xcode_11.7.xip on the controller node
+# The Xcode11.7 package should be present in /Vendor_Files/mac/Xcode_11.7.xip on the controller node 
 
 - name: Check if Xcode11.7 is installed
   stat:
@@ -9,7 +10,7 @@
   register: xcode11_installed
 
 - name: Install Xcode11.7
-  when: not xcode11_installed.stat exists
+  when: xcode11_installed.stat.exists is false
   block:
     - name: Transfer Xcode11.7 over to remote machine
       copy:
@@ -17,7 +18,7 @@
         dest: /tmp/Xcode_11.7.xip
 
     - name: Extract Xcode11.7
-      command: xip -x /tmp/Xcode_11.7.xip
+      command: cd /tmp/ && xip -x /tmp/Xcode_11.7.xip
 
     - name: Move Xcode11.7 to /Applications directory
       copy:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode11/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode11/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: Check if Xcode11.7 is installed
   stat:
-    path: /Applications/Xcode.11.7.app/
+    path: /Applications/Xcode-11.7.app/
   register: xcode11_installed
 
 - name: Install Xcode11.7

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode11/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode11/tasks/main.yml
@@ -10,7 +10,7 @@
   register: xcode11_installed
 
 - name: Install Xcode11.7
-  when: xcode11_installed.stat.exists is false
+  when: not xcode11_installed.stat.exists
   block:
     - name: Transfer Xcode11.7 over to remote machine
       copy:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode11/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode11/tasks/main.yml
@@ -2,23 +2,37 @@
 # Xcode 11.7 is needed to build x64 JDK8 om Arm64 Mac
 # Xcode11.7 can be downloaded from https://developer.apple.com/download/all after authentication with apple ID and password
 # See https://github.com/adoptium/infrastructure/issues/2536#issuecomment-1708716478
-# The Xcode11.7 package should be present in /Vendor_Files/mac/Xcode_11.7.xip on the controller node
 
 - name: Check if Xcode11.7 is installed
   stat:
     path: /Applications/Xcode-11.7.app/
   register: xcode11_installed
 
+- name: Check if SAS variable is defined
+  set_fact:
+    apple_variables: yes
+  when: not xcode11_installed.stat.exists and XCode11.7_SAS_TOKEN is defined
+
+- name: Display Information when XCode11.7_SAS_TOKEN is not defined
+  debug:
+    msg: "XCode11.7_SAS_TOKEN is not defined. Xcode will need to be installed manually.
+          Skipping Xcode installation"
+  when: not xcode11_installed.stat.exists and apple_variables is not defined
+
 - name: Install Xcode11.7
-  when: not xcode11_installed.stat.exists
+  when: not xcode11_installed.stat.exists and apple_variables is defined
   block:
-    - name: Transfer Xcode11.7 over to remote machine
-      copy:
-        src: /Vendor_Files/mac/Xcode_11.7.xip
+    - name: Download XCode 11.7 from Azure blob storage
+      get_url:
+        url: "https://ansiblestorageadopt.blob.core.windows.net/xcode11-7/Xcode_11.7.xip?{{ XCode11.7_SAS_TOKEN }}"
         dest: /tmp/Xcode_11.7.xip
+        mode: 0755
 
     - name: Extract Xcode11.7
-      shell: cd /tmp/ && xip -x /tmp/Xcode_11.7.xip
+      shell: xip -x /tmp/Xcode_11.7.xip
+      args:
+        chdir: /tmp
+        creates: /tmp/Xcode.app
 
     - name: Move Xcode11.7 to /Applications directory
       copy:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode11/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode11/tasks/main.yml
@@ -2,7 +2,7 @@
 # Xcode 11.7 is needed to build x64 JDK8 om Arm64 Mac
 # Xcode11.7 can be downloaded from https://developer.apple.com/download/all after authentication with apple ID and password
 # See https://github.com/adoptium/infrastructure/issues/2536#issuecomment-1708716478
-# The Xcode11.7 package should be present in /Vendor_Files/mac/Xcode_11.7.xip on the controller node 
+# The Xcode11.7 package should be present in /Vendor_Files/mac/Xcode_11.7.xip on the controller node
 
 - name: Check if Xcode11.7 is installed
   stat:
@@ -23,5 +23,10 @@
     - name: Move Xcode11.7 to /Applications directory
       copy:
         src: /tmp/Xcode.app
-        dest: /Applications/Xcode.11.7.app/
+        dest: /Applications/Xcode-11.7.app/
         remote_src: true
+
+    - name: Clean up Xcode11.7.xip file
+      file:
+        path: /tmp/Xcode_11.7.xip
+        state: absent

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode11/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode11/tasks/main.yml
@@ -18,7 +18,7 @@
         dest: /tmp/Xcode_11.7.xip
 
     - name: Extract Xcode11.7
-      command: cd /tmp/ && xip -x /tmp/Xcode_11.7.xip
+      shell: cd /tmp/ && xip -x /tmp/Xcode_11.7.xip
 
     - name: Move Xcode11.7 to /Applications directory
       copy:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode11/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode11/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
-# Xcode 11.7 is needed to build x64 JDK8
+# Xcode 11.7 is needed to build x64 JDK8 om Arm64 Mac
 # See https://github.com/adoptium/infrastructure/issues/2536#issuecomment-1708716478
-# Xcode11.7 package should be in Vendor_Files directory
+# The Xcode11.7 package should be present in /Vendor_Files/mac/Xcode_11.7.xip on the controller node
 
 - name: Check if Xcode11.7 is installed
   stat:


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/2536

Xcode11.7 is required on m1 mac machines in order to cross compile x64 jdk8

Our usual method of installing xcode using `xcversion` is no longer supported https://github.com/xcpretty/xcode-install/blob/master/MIGRATION.md and is causing errors when I use it to install xcode11.7, see https://github.com/adoptium/infrastructure/issues/2536#issuecomment-1733623397

[xcodes](https://github.com/xcpretty/xcode-install/blob/master/MIGRATION.md) is another tool used to install different versions of xcode but I think it is dependent on Xcode13 which I believe requires macOS 11.3+ (our M1 machines are 11.0)




