### PR TITLE
github: Fix Github action failing solaris 10 playbook check.

### DIFF
--- a/.github/workflows/build_vagrant.yml
+++ b/.github/workflows/build_vagrant.yml
@@ -8,6 +8,11 @@ on:
     branches:
     - master
 
+# Cancel existing runs if user makes another push.
+concurrency:
+  group: "${{ github.ref }}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 
@@ -51,6 +56,7 @@ jobs:
         rm -f id_rsa.pub id_rsa
         # Copy the machine's ssh key for the VMs to use, after removing prior files
         ssh-keygen -q -f $PWD/id_rsa -t rsa -N ''
+        vagrant plugin install vagrant-vbguest
         vagrant up
         vagrantPORT=$(vagrant port | grep host | awk '{ print $4 }')
         rm -f playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx
@@ -63,4 +69,4 @@ jobs:
     - name: Run Ansible Playbook
       run: |
         cd ansible
-        ansible-playbook -i playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx -u vagrant -b --skip-tags adoptopenjdk,cups playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+        ansible-playbook -i playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx --ssh-common-args='-o StrictHostKeyChecking=no -o HostKeyAlgorithms=ssh-rsa' -u vagrant -b --skip-tags adoptopenjdk,cups playbooks/AdoptOpenJDK_Unix_Playbook/main.yml

--- a/ansible/vagrant/Vagrantfile.Solaris10
+++ b/ansible/vagrant/Vagrantfile.Solaris10
@@ -2,7 +2,8 @@
 # vi: set ft=ruby :
 
 $script = <<SCRIPT
-sudo /opt/csw/bin/pkgutil -y -i python
+# Install Python 2.7
+sudo /opt/csw/bin/pkgutil -y -i python27
 # Put the host machine's IP into the authorised_keys file on the VM
 if [ -r /vagrant/id_rsa.pub ]; then
         mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys


### PR DESCRIPTION
The github solaris playbook test is failing due to a number of issues, resolved in this PR...

Firstly the version of vagrant on the MacOS12 runner, requires the installation of the vagrant virtual box extensions.

Secondly due to upgrades in the default installation of Ansible, a later version of python is required, so the vagrantfile for Solaris 10 has been updated to install Python 2.7

In addition, the rsa cipher needed to be added to the ansible playbook line.

Fixes #3204 


##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)