### PR TITLE
inventory: Add Windows 2022 Server Test Machine

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -112,6 +112,7 @@ hosts:
           win2012r2-x64-3: {ip: 13.68.219.237, user: adoptopenjdk}
           win2016-x64-1: {ip: 52.149.211.210, user: adoptopenjdk}
           win2019-x64-1: {ip: 20.185.182.137, user: adoptopenjdk}
+          win2022-x64-1: {ip: 51.132.234.42, user: adoptopenjdk}
           win11-aarch64-1: {ip: 20.4.31.184, user: adoptopenjdk}
           win11-aarch64-2: {ip: 108.143.205.79, user: adoptopenjdk}
 


### PR DESCRIPTION
Add Windows 2022 Server Test Machine, due to replace test-azure-win2012r2-x64-1

Fixes #3163 

Added to Jenkins: https://ci.adoptium.net/computer/test-azure-win2022-x64-1/
Added to Nagios: https://nagios.adoptopenjdk.net/nagios/cgi-bin/extinfo.cgi?type=1&host=test-azure-win2022-x64-1
Added To Wazuh: [Agent 014](https://20.26.114.19/app/wazuh#/agents?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-1y,to:now))&_a=(columns:!(_source),filters:!(('$state':(isImplicit:!t,store:appState),meta:(alias:!n,disabled:!f,index:'wazuh-alerts-*',key:manager.name,negate:!f,params:(query:infra-wazuh-server),removable:!f,type:phrase),query:(match:(manager.name:(query:infra-wazuh-server,type:phrase)))),('$state':(isImplicit:!t,store:appState),meta:(alias:!n,disabled:!f,index:'wazuh-alerts-*',key:agent.id,negate:!f,params:(query:'014'),removable:!f,type:phrase),query:(match:(agent.id:(query:'014',type:phrase))))),index:'wazuh-alerts-*',interval:auto,query:(language:kuery,query:''),sort:!()))
Grinder test runs in progress:
System Sanity: https://ci.adoptium.net/view/Test_grinder/job/Grinder/7674/ ✔️
Functional Sanity: https://ci.adoptium.net/view/Test_grinder/job/Grinder/7675/ ✔️
Perf Sanity: https://ci.adoptium.net/view/Test_grinder/job/Grinder/7676/ ✔️

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR
- [X] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
