### PR TITLE
UnixPB: Only install ssl test packages on x64 for Centos/RHEL

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -87,6 +87,8 @@ Additional_Build_Tools_CentOS_x86:
   - glibc.i686                    # a dependency required for executing a 32-bit C binary
   - glibc-devel.i686              # a dependency required for executing a 32-bit C binary
   - libstdc++.i686                # a dependency required for executing a 32-bit C binary
+  - libnss3.so
+  - libnssutil3.so
 
 Additional_Build_Tools_CentOS8_Stream:
   - libdwarf

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -30,8 +30,6 @@ Build_Tool_Packages:
   - gnutls-utils
   - java-1.8.0-openjdk-devel
   - libcurl-devel
-  - libnss3.so
-  - libnssutil3.so
   - libpng-devel
   - libXext-devel
   - libXi-devel                   # JDK12+ compilation
@@ -113,7 +111,5 @@ Test_Tool_Packages:
   - fakeroot
   - gnutls
   - gnutls-utils
-  - libnss3.so
-  - libnssutil3.so
   - nss-devel
   - nss-tools

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -76,6 +76,7 @@ Additional_Build_Tools_RHEL_x86:
   - glibc.i686                    # a dependency required for executing a 32-bit C binary
   - glibc-devel.i686              # a dependency required for executing a 32-bit C binary
   - libstdc++.i686                # a dependency required for executing a 32-bit C binary
+  - libnss3.so
 
 Additional_Build_Tools_RHEL_ppc64:
   - glibc.ppc                     # a dependency required for executing a 32-bit C binary

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -31,7 +31,6 @@ Build_Tool_Packages:
   - gmp-devel
   - libcurl-devel
   - libffi-devel
-  - libnss3.so
   - libpng-devel
   - libXext-devel
   - libXi-devel                   # JDK12+ compilation
@@ -114,6 +113,5 @@ Test_Tool_Packages:
   - mercurial
   - gnutls
   - gnutls-utils
-  - libnss3.so
   - nss-devel
   - nss-tools

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.cent8
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.cent8
@@ -6,7 +6,7 @@ RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|
 
 RUN dnf -y update && dnf install -y perl openssh-server unzip zip wget epel-release
 # Install OpenSSL Packages
-RUN dnf install -y gnutls gnutls-utils libnss3.so libnssutil3.so nss-devel nss-tools
+RUN dnf install -y gnutls gnutls-utils nss-devel nss-tools
 RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -P ""
 # Get latest jdk17 ga
 RUN wget -q 'https://api.adoptium.net/v3/binary/latest/17/ga/linux/x64/jdk/hotspot/normal/eclipse?project=jdk' -O /tmp/jdk17.tar.gz


### PR DESCRIPTION
Fixes #3224

Remove problematic SSL test related packages from distributions that are encountering issues on ARM / PPC64LE on RHEL, CentOS & UBI 8.


##### Checklist

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)

