### PR TITLE
github: Clarify machine access removal process

### DIFF
--- a/.github/ISSUE_TEMPLATE/machineaccess.md
+++ b/.github/ISSUE_TEMPLATE/machineaccess.md
@@ -6,6 +6,10 @@ labels: 'Temp Infra Access'
 assignees: 'sxa'
 
 ---
+**NOTE: THIS ISSUE SHOULD NOT BE CLOSED BY THE ORIGINATOR IF ACCESS IS GRANTED**.
+When the access is no longer needed please add a comment and a member
+of the infrastructure team will revoke it and close the issue.
+
 Required access level (Delete as appropriate). Note that you should only
 request the minimum level that is required to solve your problem
 


### PR DESCRIPTION
Add reference to assist users to know that they should not close the issue when access is required as per [the described process](https://github.com/adoptium/infrastructure/blob/master/FAQ.md#temporary-access-to-a-machine).

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [x] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
