### PR TITLE
WindowsPB: Prevent Installation Of Firefox & Bump Installation version of Thunderbird

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -50,7 +50,6 @@
     - CodesignCert
     - 7-Zip                       # Mostly extracting other prereqs :-)
     - cygwin
-#    - Firefox                    # Redundant No Longer Required
     - Strawberry_Perl             # Testing
 #    - Freemarker                  # OpenJ9"
     - GIT

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -50,7 +50,7 @@
     - CodesignCert
     - 7-Zip                       # Mostly extracting other prereqs :-)
     - cygwin
-    - Firefox
+#    - Firefox                    # Redundant No Longer Required
     - Strawberry_Perl             # Testing
 #    - Freemarker                  # OpenJ9"
     - GIT
@@ -90,7 +90,7 @@
       tags: [jenkins, adoptopenjdk]
       when: jenkins_secret is defined  # Only run if jenkins_secret is defined
     - role: Thunderbird
-      tags: [Thunderbird, jck, adoptopenjdk]
+      tags: jck
     - role: logs
       position: "End"
       tags: always

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -88,8 +88,6 @@
     - role: Jenkins_Service_Installation # Automate installing the jenkins service
       tags: [jenkins, adoptopenjdk]
       when: jenkins_secret is defined  # Only run if jenkins_secret is defined
-    - role: Thunderbird
-      tags: jck
     - role: logs
       position: "End"
       tags: always

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Thunderbird/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Thunderbird/tasks/main.yml
@@ -15,9 +15,9 @@
 
 - name: Download Thunderbird
   win_get_url:
-    url: https://ftp.mozilla.org/pub/thunderbird/releases/78.11.0/win64/en-GB/Thunderbird%20Setup%2078.11.0.exe
+    url: https://ftp.mozilla.org/pub/thunderbird/releases/115.4.1/win64/en-GB/Thunderbird%20Setup%20115.4.1.exe
     dest: 'C:\temp\thunderbird.exe'
-    checksum: 58479f60339aadef41210f522d380dc13fe2611690e2942e141fd5361393c7da
+    checksum: 7e68974880164058142491714e3e1c1fb92cef657d84244e2e37ee5c0c1cc909
     checksum_algorithm: sha256
   when: (not thunderbird_download.stat.exists) and (not thunderbird_installed.stat.exists)
 


### PR DESCRIPTION
Fixes #3239 

Remove installation of firefox from the windows playbook due to security concerns, and restrict installation of Thunderbird to JCK machines. In addition bump the version of thunderbird to the current version ( 115.4 ), which currently has no known security issues.


##### Checklist

<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
