### PR TITLE
WindowsPB: Update checksum for downloaded vs2022

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2022/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2022/tasks/main.yml
@@ -104,7 +104,7 @@
 - name: Download Visual Studio Community 2022
   win_get_url:
     url: 'https://aka.ms/vs/17/release/vs_Community.exe'
-    checksum: ef3e389f222335676581eddbe7ddec01147969c1d42e19b9dade815c3c0f04b1
+    checksum: 78e702c22b7e9ff9a560257a817a0d5dffe72358c7073bc436664d2397eee8d4
     checksum_algorithm: sha256
     dest: 'C:\temp\vs_community22.exe'
     force: no


### PR DESCRIPTION
The checksum for the downloaded version of windows VS2022 requires an update, due to a change to the remote installation bootstrapper file. This is currently causing the github actions to fail.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
