### PR TITLE
windowsPb: Add missing when condition to MSVS_2019 install 

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
@@ -23,6 +23,7 @@
   win_stat:
     path: 'C:\TEMP\VS2019_Layout.zip'
   register: vs2019_layout_ready
+  when: (not vs2019_installed.stat.exists)
   tags: adoptopenjdk
 
 - name: Get SHA256 checksum of the file
@@ -38,6 +39,7 @@
         exit 1
     }
   register: checksum_result
+  when: (not vs2019_installed.stat.exists)
   changed_when: false
   tags: adoptopenjdk
 


### PR DESCRIPTION

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

The playbook will attempt to get a sha checksum of a file that is not present (because msvs2019 is already installed) causing the playbook to fail

`"stderr": "Resolve-Path : Cannot find path 'C:\\TEMP\\VS2019_Layout.zip' because it does \r\nnot exist.`
