### PR TITLE
Docs: Add information on regular deployment of playbooks via AWX

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -320,7 +320,7 @@ or [aqavit](https://projects.eclipse.org/projects/adoptium.aqavit) projects.
 ## Patching
 
 At Adoptium we use scheduled jobs within [AWX](https://awx2.adoptopenjdk.net/#/home) to execute our platform playbooks onto our machines. 
-The Unix, Windows, MacOS and AIX playbooks are executed weekly to keep our [machines](https://github.com/adoptium/infrastructure/blob/master/ansible/inventory.yml) patched and up to date.
+The Unix, Windows, MacOS and AIX playbooks are executed weekly onto our [machines](https://github.com/adoptium/infrastructure/blob/master/ansible/inventory.yml) to keep them patched and up to date.
 
 For more information see https://github.com/adoptium/infrastructure/wiki/Ansible-AWX#schedules
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -317,6 +317,12 @@ Most of the relevant ones are under the
 [temurin](https://projects.eclipse.org/projects/adoptium.temurin/who)
 or [aqavit](https://projects.eclipse.org/projects/adoptium.aqavit) projects.
 
+## Patching
+
+At Adoptium we use scheduled jobs within [AWX](https://awx2.adoptopenjdk.net/#/home) to execute our platform playbooks onto our machines. 
+The Unix, Windows, MacOS and AIX playbooks are executed weekly to keep our machines patched and up to date.
+
+For more information see https://github.com/adoptium/infrastructure/wiki/Ansible-AWX#schedules
 
 ## Adding new systems
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -320,7 +320,7 @@ or [aqavit](https://projects.eclipse.org/projects/adoptium.aqavit) projects.
 ## Patching
 
 At Adoptium we use scheduled jobs within [AWX](https://awx2.adoptopenjdk.net/#/home) to execute our platform playbooks onto our machines. 
-The Unix, Windows, MacOS and AIX playbooks are executed weekly to keep our machines patched and up to date.
+The Unix, Windows, MacOS and AIX playbooks are executed weekly to keep our [machines](https://github.com/adoptium/infrastructure/blob/master/ansible/inventory.yml) patched and up to date.
 
 For more information see https://github.com/adoptium/infrastructure/wiki/Ansible-AWX#schedules
 


### PR DESCRIPTION

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [x] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/3220