### PR TITLE
unixPb: Switch back to default xcode before running Macos playbook

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
@@ -10,6 +10,10 @@
     msg: "The version of Ansible you are using needs to be greater than 2.11"
   when: ansible_version.full is version('2.11', '<=')
 
+- name: Switch back to command line tools xcode before proceeding
+  command: sudo xcode-select --switch /
+  tags: adoptopenjdk
+
 - name: Get macOS version
   shell: sw_vers -productVersion
   register: macos_version


### PR DESCRIPTION

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/3249#issue-1992773944

Brew update hits error if selected xcode is outdated 
```
Error: Your Xcode (11.7 => /Applications/Xcode-11.7.app/Xcode.app/Contents/Developer) is too outdated.\n
Please update to Xcode 13.2.1 (or delete it).\nXcode can be updated from the App Store.\n
\nError: Your Command Line Tools are too outdated.\nUpdate them from Software Update in System Preferences.\n
\nIf that doesn't show you any updates, run:\n
```