### PR TITLE
UnixPB: Change default JDK for alpine arm64

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Alpine.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Alpine.yml
@@ -14,6 +14,11 @@
   register: usr_lib_jvm_exists
   tags: build_tools
 
+- name: Checking for default-jvm
+  stat: path=/usr/lib/jvm/default-jvm
+  register: usr_lib_default_jvm_exists
+  tags: build_tools
+
 - name: Creating /usr/lib/jvm if not found
   file:
     path: /usr/lib/jvm
@@ -140,14 +145,14 @@
 
     - name: Install java 11 from Alpine repositories
       package: "name=openjdk11 state=installed"
-      when: not adoptopenjdk11_installed.stat.exists
+      when: ansible_architecture != "aarch64" and not adoptopenjdk11_installed.stat.exists
 
     - name: Create symlink to point at openjdk11
       file:
         src: /usr/lib/jvm/java-11-openjdk
         dest: /usr/lib/jvm/jdk-11
         state: link
-      when: not adoptopenjdk11_installed.stat.exists
+      when: ansible_architecture != "aarch64" and not adoptopenjdk11_installed.stat.exists
 
     - name: Check if zulu-16 is already installed in the target location
       stat: path=/usr/lib/jvm/zulu16
@@ -200,6 +205,19 @@
         state: link
       when:
         - not adoptopenjdk17_installed.stat.exists
+
+    - name: Remove Default JVM For Alpine AARCH64
+      file:
+        path: /usr/lib/jvm/default-jvm
+        state: absent
+      when: ansible_architecture == "aarch64" and usr_lib_default_jvm_exists.stat.exists
+
+    - name: Arm64 Change Default JVM Link to JDK17
+      file:
+        src: '{{ adoptopenjdk17_dir.stdout }}'
+        dest: /usr/lib/jvm/default-jvm
+        state: link
+      when: ansible_architecture == "aarch64"
 
     - name: Check if zulu-18 is already installed in the target location
       stat: path=/usr/lib/jvm/zulu18


### PR DESCRIPTION
Fixes #3245 

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR

Alpine is not supported in VPC.
