### PR TITLE
unixPb: Remove task to uninstall libpng

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
@@ -180,15 +180,6 @@
   when: not pdfwriter.stat.exists
   tags: jck_tools
 
-- name: Uninstall libpng
-  become: yes
-  become_user: "{{ ansible_user }}"
-  homebrew:
-    name: libpng
-    state: absent
-    path: "{{ homebrew_path }}"
-  tags: adoptopenjdk
-
 # As per https://github.com/eclipse/openj9/issues/3790
 - name: Creating /etc/sysctl.conf for kernel tunings
   file:


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Now that https://github.com/adoptium/temurin-build/issues/3509 is solved and https://github.com/adoptium/temurin-build/pull/3523 was merged we can remove the task which uninstalls libpng from our mac machines as the build will now know to not pick up libpng 