### PR TITLE
WindowsPB: Update checksum for vs2022 download

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2022/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2022/tasks/main.yml
@@ -94,7 +94,7 @@
 - name: Download Visual Studio Community 2022
   win_get_url:
     url: 'https://aka.ms/vs/17/release/vs_Community.exe'
-    checksum: 78e702c22b7e9ff9a560257a817a0d5dffe72358c7073bc436664d2397eee8d4
+    checksum: 34a171cb2c54abb13e184a48338f5ca6867e2663f608e7d2408cfbcd2309f0a1
     checksum_algorithm: sha256
     dest: 'C:\temp\vs_community22.exe'
     force: no


### PR DESCRIPTION
Update checksum for VS2022 installer download

Fixes #3255 


- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)

