### PR TITLE
Vagrant: Add Windows Server 2022 option to VPC

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -9,7 +9,6 @@ retry_files_enabled = False
 roles_path          = roles
 squash_actions      = apk
 allow_world_readable_tmpfiles = True
-deprecation_warnings = False
 
 # Pass an empty path to ssh so it doesn't read config. We don't need it
 # since we have all information available.

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -10,6 +10,7 @@ roles_path          = roles
 squash_actions      = apk
 allow_world_readable_tmpfiles = True
 
+
 # Pass an empty path to ssh so it doesn't read config. We don't need it
 # since we have all information available.
 [ssh_connection]

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -9,7 +9,7 @@ retry_files_enabled = False
 roles_path          = roles
 squash_actions      = apk
 allow_world_readable_tmpfiles = True
-
+deprecation_warnings = False
 
 # Pass an empty path to ssh so it doesn't read config. We don't need it
 # since we have all information available.

--- a/ansible/pbTestScripts/vmDestroy.sh
+++ b/ansible/pbTestScripts/vmDestroy.sh
@@ -63,7 +63,9 @@ checkOS() {
 			osToDestroy="Sol10" ;;
 		"Windows2012" | "Win2012" | "W12" | "w12" )
                         osToDestroy="W2012";;
-                "all" )
+  	"Windows2022" | "Win2022" | "W22" | "w22" )
+	                       osToDestroy="W2022";;
+	              "all" )
                         osToDestroy="U16 U18 U20 U21 C6 C7 C8 D8 D10 FBSD12 Sol10 W2012" ;;
 		"")
 			echo "No OS detected. Did you miss the '-o' option?" ; usage; exit 1;;
@@ -85,7 +87,8 @@ listOS() {
 		- Debian10
 		- FreeBSD12
 		- Solaris10
-		- Win2012"
+		- Win2012
+		- Win2022"
 	echo
 }
 
@@ -111,8 +114,8 @@ if [[ "$force" == False ]]; then
 		echo "Cancelling ..."
 		exit 1;
 	fi
-fi	
-for OS in $osToDestroy 
+fi
+for OS in $osToDestroy
 do
 	destroyVMs $OS
 done

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
@@ -20,7 +20,7 @@
   when: (not vs2017_installed.stat.exists)
   tags: MSVS_2017
 
-- name: Run Visual Studio 2017 Installer From Download With Powershell
+- name: Run Visual Studio 2017 Installer From Download
   win_shell: |
       Start-Process -Wait -FilePath 'C:\temp\vs_community.exe' -ArgumentList '--wait --add Microsoft.VisualStudio.Workload.NativeDesktop --includeRecommended --includeOptional --quiet --norestart'
   args:

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
@@ -20,13 +20,14 @@
   when: (not vs2017_installed.stat.exists)
   tags: MSVS_2017
 
-- name: Install Visual Studio Community 2017
-  win_shell: 'C:\temp\vs_community.exe --wait --add Microsoft.VisualStudio.Workload.NativeDesktop;includeRecommended;includeOptional --quiet --norestart'
+- name: Run Visual Studio 2017 Installer From Download With Powershell
+  win_shell: |
+      Start-Process -Wait -FilePath 'C:\temp\vs_community.exe' -ArgumentList '--wait --add Microsoft.VisualStudio.Workload.NativeDesktop --includeRecommended --includeOptional --quiet --norestart'
   args:
-    executable: cmd
+    executable: powershell
   when: (not vs2017_installed.stat.exists)
   register: vs2017_error
-  failed_when: vs2017_error.rc != 1 and vs2017_error.rc != 0
+  failed_when: vs2017_error.rc != 0 and vs2017_error.rc != 1
   tags: MSVS_2017
 
 - name: Register Visual Studio Community 2017 DIA SDK shared libraries

--- a/ansible/vagrant/Vagrantfile.Win2022
+++ b/ansible/vagrant/Vagrantfile.Win2022
@@ -1,0 +1,53 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Runs Powershell as an administator and does the following:
+#  - Gets/executes an Ansible provided script that configures WinRM to allow Ansible to communicate over it.
+#  - Resizes the disk to ~100GB, in line with the 'disksize.size = 100GB' option in the config below
+
+$script = <<SCRIPT
+Start-Process powershell -Verb runAs
+
+
+wget https://raw.githubusercontent.com/ansible/ansible-documentation/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile .\\ConfigureRemotingForAnsible.ps1
+.\\ConfigureRemotingForAnsible.ps1 -CertValidityDays 9999
+.\\ConfigureRemotingForAnsible.ps1 -EnableCredSSP
+.\\ConfigureRemotingForAnsible.ps1 -ForceNewSSLCert
+.\\ConfigureRemotingForAnsible.ps1 -SkipNetworkProfileCheck
+
+# Retrieving disk's current size
+$currentDiskSize =(Get-Partition -DriveLetter c | select Size)
+$currentDiskSize =($currentDiskSize -replace "[^0-9]" , "")
+# The size the disk should be, in bytes (130GB)
+$diskSizeBoundary = 139586437120
+# Changing the disksize to max supported size (~130GB)
+if ([long]$currentDiskSize -lt $diskSizeBoundary) {
+        echo "Resizing disk to max size"
+        $size = (Get-PartitionSupportedSize -DriveLetter c); Resize-Partition -DriveLetter c -Size $size.SizeMax
+}else {
+        echo "Disk is already at max size"
+}
+
+Start-Process cmd -Verb runAs
+winrm set winrm/config/service '@{AllowUnencrypted="true"}'
+SCRIPT
+
+# 2 = version of configuration file for Vagrant 1.1+ leading up to 2.0.x
+Vagrant.configure("2") do |config|
+
+  config.vm.define :adoptopenjdkW2022 do |adoptopenjdkW2022|
+    adoptopenjdkW2022.vm.box = "gusztavvargadr/windows-server-2022-standard"
+    adoptopenjdkW2022.vm.hostname = "adoptopenjdkW2022"
+    adoptopenjdkW2022.vm.communicator = "winrm"
+    adoptopenjdkW2022.vm.synced_folder ".", "/vagrant"
+    adoptopenjdkW2022.vm.network :private_network, type: "dhcp"
+    adoptopenjdkW2022.vm.provision "shell", inline: $script, privileged: false
+    adoptopenjdkW2022.disksize.size = '130GB'
+  end
+  config.vm.provider "virtualbox" do |v|
+    v.gui = false
+    v.memory = 8192
+    v.cpus = 2
+    v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
+  end
+end


### PR DESCRIPTION
Fixes #3193 

Implements a VPC option for Windows Server 2022, this requires a new Vagrant Box to match the standard VPC vagrant file naming ( Vagrantfile.win2022 ) and in particular an improvement to the MSVS_2017 installation from download role to mirror the installs of MSVS_2019 & MSVS_2019, in using Powershell to handle the installation rather than the command shell.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)

