### PR TITLE
UnixPB: Fix Linter For Xcode 11 task

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode11/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode11/tasks/main.yml
@@ -19,15 +19,17 @@
           Skipping Xcode installation"
   when: not xcode11_installed.stat.exists and apple_variables is not defined
 
+- name: Download XCode 11.7 from Azure blob storage
+  get_url:
+    url: "https://ansiblestorageadopt.blob.core.windows.net/xcode11-7/Xcode_11.7.xip?{{ XCode11.7_SAS_TOKEN }}"
+    dest: /tmp/Xcode_11.7.xip
+    mode: 0755
+  when: not xcode11_installed.stat.exists and apple_variables is defined
+    
 - name: Install Xcode11.7
   when: not xcode11_installed.stat.exists and apple_variables is defined
   block:
-    - name: Download XCode 11.7 from Azure blob storage
-      get_url:
-        url: "https://ansiblestorageadopt.blob.core.windows.net/xcode11-7/Xcode_11.7.xip?{{ XCode11.7_SAS_TOKEN }}"
-        dest: /tmp/Xcode_11.7.xip
-        mode: 0755
-
+  
     - name: Extract Xcode11.7
       shell: xip -x /tmp/Xcode_11.7.xip
       args:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode11/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode11/tasks/main.yml
@@ -29,7 +29,7 @@
 - name: Install Xcode11.7
   when: not xcode11_installed.stat.exists and apple_variables is defined
   block:
-  
+
     - name: Extract Xcode11.7
       shell: xip -x /tmp/Xcode_11.7.xip
       args:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode11/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode11/tasks/main.yml
@@ -25,7 +25,7 @@
     dest: /tmp/Xcode_11.7.xip
     mode: 0755
   when: not xcode11_installed.stat.exists and apple_variables is defined
-    
+
 - name: Install Xcode11.7
   when: not xcode11_installed.stat.exists and apple_variables is defined
   block:


### PR DESCRIPTION
Fixes #3258 

As per this linter bug when: not xcode11_installed.stat.exists and apple_variables is defined

Certain tasks when cascaded several levels lose context, and cannot be linted successfully. Seperating out the problem tasks ( in this case the get_url task ) from the block, and then leaving all non problematic tasks in the block, allows the linter to behave correctly.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR

