### PR TITLE
github: Fix Centos6 build image push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,9 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-      if: github.ref == 'refs/heads/master'
+      if: github.event.pull_request.merged == true
 
-    - name: Docker Build & Push Centos6 Image to Docker Hub
+    - name: Docker Build CentOS6 Image Test
       uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0
       with:
         file: ./ansible/docker/Dockerfile.CentOS6
@@ -45,7 +45,20 @@ jobs:
         tags: adoptopenjdk/centos6_build_image:latest
         cache-from: type=registry,ref=adoptopenjdk/centos6_build_image:latest
         cache-to: type=inline
-        push: ${{ github.ref == 'refs/heads/master' }}
+        push: false
+      if: github.ref != 'refs/heads/master'
+
+    - name: Docker Build & Push Centos6 Image to Docker Hub On Merge
+      uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0
+      with:
+        file: ./ansible/docker/Dockerfile.CentOS6
+        build-args: git_sha=${{ github.sha }}
+        tags: adoptopenjdk/centos6_build_image:latest
+        cache-from: type=registry,ref=adoptopenjdk/centos6_build_image:latest
+        cache-to: type=inline
+        push: true
+      if: github.event.pull_request.merged == true
+
 
   build-and-push-alpine3:
     name: Alpine3


### PR DESCRIPTION
Fixes #3211 

Amend the value of the docker push tag in the action to a boolean rather than a reference. Similar to the alpine image push which does work.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR

