### PR TITLE
Vagrant: Increase Windows Timeout in Vagrant files

### DIFF
--- a/ansible/pbTestScripts/vmDestroy.sh
+++ b/ansible/pbTestScripts/vmDestroy.sh
@@ -47,6 +47,8 @@ checkOS() {
                         osToDestroy="U20";;
                 "Ubuntu2104" | "U21" | "u21" )
                         osToDestroy="U21";;
+								"Ubuntu2204" | "U22" | "u22" )
+				                        osToDestroy="U22";;
                 "CentOS6" | "centos6" | "C6" | "c6" )
                         osToDestroy="C6" ;;
                 "CentOS7" | "centos7" | "C7" | "c7" )
@@ -66,7 +68,7 @@ checkOS() {
   	"Windows2022" | "Win2022" | "W22" | "w22" )
 	                       osToDestroy="W2022";;
 	              "all" )
-                        osToDestroy="U16 U18 U20 U21 C6 C7 C8 D8 D10 FBSD12 Sol10 W2012" ;;
+                        osToDestroy="U16 U18 U20 U21 U22 6 C7 C8 D8 D10 FBSD12 Sol10 W2012 W2022" ;;
 		"")
 			echo "No OS detected. Did you miss the '-o' option?" ; usage; exit 1;;
 		*) echo "$OS is not a currently supported OS" ; listOS; exit 1;
@@ -80,6 +82,7 @@ listOS() {
 		- Ubuntu1804
 		- Ubuntu2004
 		- Ubuntu2104
+		- Ubuntu2204
 		- CentOS6
 		- CentOS7
 		- CentOS8

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/nasm/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/nasm/tasks/main.yml
@@ -36,10 +36,25 @@
   stat: path=/usr/local/gcc/bin/gcc-7.5
   register: gcc7
   tags: nasm
+
 - name: Setting CC to gcc-7.5 binary found
   set_fact:
     CC: "/usr/local/gcc/bin/gcc-7.5"
   when: gcc7.stat.exists and CC is not defined
+  tags: nasm
+
+## For Ubuntu 22+ Set GCC to gcc_11
+
+- name: Checking for gcc-11 binary installation
+  stat: path=/usr/bin/gcc-11
+  register: gcc11
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int >= 22
+  tags: nasm
+
+- name: Setting CC to gcc-11 binary found
+  set_fact:
+    CC: "/usr/bin/gcc-11"
+  when: gcc11.stat.exists and ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int >= 22
   tags: nasm
 
 - name: Print 'CC' variable
@@ -83,6 +98,27 @@
     copy: False
   when:
     - (nasm_installed.rc is defined) and ((nasm_installed.rc != 0 ) or (nasm_installed.rc == 0 and nasm.stdout is version_compare('2.13.03', operator='ne')) )
+  tags: nasm
+
+## Patch NASM Source On Ubuntu 22.04 due to bug with compiling with gcc 8+
+## See With https://src.fedoraproject.org/rpms/nasm/raw/0cc3eb244bd971df81a7f02bc12c5ec259e1a5d6/f/0001-Remove-invalid-pure_func-qualifiers.patch
+
+- name: Patch NASM 13.03 Source
+  lineinfile:
+    path: /tmp/nasm-2.13.03/include/nasmlib.h
+    regexp: '^void pure_func seg_init\(void\);.*$'
+    line: 'void seg_init(void);'
+  when:
+    - (nasm_installed.rc is defined) and ((nasm_installed.rc != 0 ) or (nasm_installed.rc == 0 and nasm.stdout is version_compare('2.13.03', operator='ne')) ) and (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int >= 22)
+  tags: nasm
+
+- name: Patch NASM 13.03 Source
+  lineinfile:
+    path: /tmp/nasm-2.13.03/include/nasmlib.h
+    regexp: '^int32_t pure_func seg_alloc\(void\);.*$'
+    line: 'int32_t seg_alloc(void);'
+  when:
+    - (nasm_installed.rc is defined) and ((nasm_installed.rc != 0 ) or (nasm_installed.rc == 0 and nasm.stdout is version_compare('2.13.03', operator='ne')) ) and (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int >= 22)
   tags: nasm
 
 - name: Running ./configure & make for nasm

--- a/ansible/vagrant/Vagrantfile.Ubuntu2204
+++ b/ansible/vagrant/Vagrantfile.Ubuntu2204
@@ -20,7 +20,8 @@ Vagrant.configure("2") do |config|
   end
   config.vm.provider "virtualbox" do |v|
     v.gui = false
-    v.memory = 2560
+    v.memory = 4096
+    v.cpus = 2
     v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
   end
 end

--- a/ansible/vagrant/Vagrantfile.Ubuntu2204
+++ b/ansible/vagrant/Vagrantfile.Ubuntu2204
@@ -1,0 +1,26 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+$script = <<SCRIPT
+# Put the host machine's IP into the authorised_keys file on the VM
+if [ -r /vagrant/id_rsa.pub ]; then
+        mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys
+fi
+SCRIPT
+
+# 2 = version of configuration file for Vagrant 1.1+ leading up to 2.0.x
+Vagrant.configure("2") do |config|
+
+  config.vm.define :adoptopenjdkU22 do |adoptopenjdkU22|
+    adoptopenjdkU22.vm.box = "bento/ubuntu-22.04"
+    adoptopenjdkU22.vm.synced_folder ".", "/vagrant"
+    adoptopenjdkU22.vm.hostname = "adoptopenjdkU22"
+    adoptopenjdkU22.vm.network :private_network, type: "dhcp"
+    adoptopenjdkU22.vm.provision "shell", inline: $script, privileged: false
+  end
+  config.vm.provider "virtualbox" do |v|
+    v.gui = false
+    v.memory = 2560
+    v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
+  end
+end

--- a/ansible/vagrant/Vagrantfile.Win2012
+++ b/ansible/vagrant/Vagrantfile.Win2012
@@ -51,4 +51,5 @@ Vagrant.configure("2") do |config|
     v.memory = 5120
     v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
   end
+  config.vm.boot_timeout = 600
 end

--- a/ansible/vagrant/Vagrantfile.Win2022
+++ b/ansible/vagrant/Vagrantfile.Win2022
@@ -50,4 +50,5 @@ Vagrant.configure("2") do |config|
     v.cpus = 2
     v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
   end
+  config.vm.boot_timeout = 600
 end


### PR DESCRIPTION
Increase the timeout value for Windows 2012 & Windows 2022 boxes to allow the boxes to boot.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)

