### PR TITLE
Vagrant: Increase boot timeout for windows machines

### DIFF
--- a/ansible/vagrant/Vagrantfile.Win2012
+++ b/ansible/vagrant/Vagrantfile.Win2012
@@ -51,4 +51,5 @@ Vagrant.configure("2") do |config|
     v.memory = 5120
     v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
   end
+  config.vm.boot_timeout = 600
 end

--- a/ansible/vagrant/Vagrantfile.Win2022
+++ b/ansible/vagrant/Vagrantfile.Win2022
@@ -50,4 +50,5 @@ Vagrant.configure("2") do |config|
     v.cpus = 2
     v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
   end
+  config.vm.boot_timeout = 600
 end


### PR DESCRIPTION
The windows boxes available for the Vagrant Playbook check often fail to boot due to vagrants default timeout.

This PR increases the default.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)

