### PR TITLE
UnixPB: Fix Docker Installation On Debian. 

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
@@ -51,9 +51,9 @@
       package:
         name:
           - docker.io
-        state: latest   # TODO: Package installs should not use latest
+        state: present
         use: auto       # automatic select package manager to use yum, apt and so on
-      when: ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int >= 20) or ansible_distribution == "Debian")
+      when: (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int >= 20)
 
     - name: Install for SLES15 # zypper does not support in package module
       include_tasks: sles.yml


### PR DESCRIPTION
Fixes #3268 

Prevent installation of docker.io, as docker-ce has already been installed. Update docker.io installation to install the current version, rather than latest.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)

