### PR TITLE
github: Fix Centos6 build image push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Docker
 
 on:
   pull_request:
+    types: [opened, closed]
     paths:
     - .github/workflows/build.yml
     - ansible/playbooks/AdoptOpenJDK_Unix_Playbook/**
@@ -9,6 +10,7 @@ on:
     branches:
     - master
   push:
+    types: [opened, closed]
     paths:
     - .github/workflows/build.yml
     - ansible/playbooks/AdoptOpenJDK_Unix_Playbook/**
@@ -20,6 +22,20 @@ permissions:
   contents: read
 
 jobs:
+  debug-pr-status:
+  name: Input check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checking your input
+        run: |
+          echo "github.event.pull_request.merged           : $MERGED_RAW"
+          echo "github.event.pull_request.merged == 'true' : $MERGED_TRUE_STR"
+          echo "github.event.pull_request.merged  == true  : $MERGED_TRUE_BOOL"
+        env:
+          MERGED_RAW: ${{ github.event.pull_request.merged }}
+          MERGED_TRUE_STR: ${{ github.event.pull_request.merged == 'true' }}
+          MERGED_TRUE_BOOL: ${{ github.event.pull_request.merged == true }}
+          
   build-and-push-centos6:
     name: Centos6
     runs-on: ubuntu-latest
@@ -35,7 +51,7 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-      if: github.event.pull_request.merged == true
+      if: github.event.pull_request.merged
 
     - name: Docker Build CentOS6 Image Test
       uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0
@@ -57,8 +73,7 @@ jobs:
         cache-from: type=registry,ref=adoptopenjdk/centos6_build_image:latest
         cache-to: type=inline
         push: true
-      if: github.event.pull_request.merged == true
-
+      if: github.event.pull_request.merged
 
   build-and-push-alpine3:
     name: Alpine3


### PR DESCRIPTION
Fixes https://github.com/adoptium/infrastructure/issues/3211

Amend the value of the docker push tag in the action to a boolean rather than a reference. Similar to the alpine image push which does work.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR

