### PR TITLE
github: Fix Centos6 build image push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,21 +20,6 @@ permissions:
   contents: read
 
 jobs:
-  debug-pr-status:
-    name: Input check
-    runs-on: ubuntu-latest
-    steps:
-    
-      - name: Checking your input
-        run: |
-          echo "github.event.pull_request.merged           : $MERGED_RAW"
-          echo "github.event.pull_request.merged == 'true' : $MERGED_TRUE_STR"
-          echo "github.event.pull_request.merged  == true  : $MERGED_TRUE_BOOL"
-        env:
-          MERGED_RAW: ${{ github.event.pull_request.merged }}
-          MERGED_TRUE_STR: ${{ github.event.pull_request.merged == 'true' }}
-          MERGED_TRUE_BOOL: ${{ github.event.pull_request.merged == true }}
-          
   build-and-push-centos6:
     name: Centos6
     runs-on: ubuntu-latest
@@ -50,7 +35,8 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-      if: github.event.pull_request.merged
+      if: github.ref == 'refs/heads/master'
+
 
     - name: Docker Build CentOS6 Image Test
       uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0
@@ -72,7 +58,7 @@ jobs:
         cache-from: type=registry,ref=adoptopenjdk/centos6_build_image:latest
         cache-to: type=inline
         push: true
-      if: github.event.pull_request.merged
+      if: github.ref == 'refs/heads/master'
 
   build-and-push-alpine3:
     name: Alpine3


### PR DESCRIPTION
This is intended to fix https://github.com/adoptium/infrastructure/issues/3211

With the debug from the previous PR https://github.com/adoptium/infrastructure/pull/3272 I was able to determine that the GHA status for PR merged is not set as either string or boolean.

github.event.pull_request.merged == 'true' : false
github.event.pull_request.merged  == true  : false

This change removes the PR and instead checks for the branch name, it should run the docker login and push steps only when running on the master branch.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes]
- [X] VPC/QPC not applicable for this PR

