### PR TITLE
unixPB: Fix errors in Common role to support Centos 9 Stream

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
@@ -35,6 +35,12 @@
     - ansible_distribution_major_version == "8"
   tags: patch_update
 
+- name: Enable CodeReady Builder repo for CentOS9 Stream
+  shell: dnf config-manager --set-enabled crb
+  when:
+    - ansible_distribution_major_version == "9"
+  tags: patch_update
+
 - name: Clean dnf cache
   shell: dnf clean all && rm -rf /var/cache/dnf
   when:
@@ -62,17 +68,18 @@
   when: ansible_distribution_major_version == "7"
   tags: build_tools
 
-- name: Install additional build tools for CentOS 8
+- name: Install additional build tools for CentOS 8/9 Stream
   package: "name={{ item }} state=latest"
-  with_items: "{{ Additional_Build_Tools_CentOS8 }}"
-  when: ansible_distribution_major_version == "8"
+  with_items: "{{ Additional_Build_Tools_CentOS8_CentOS9Stream }}"
+  when: ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9"
   tags: build_tools
 
-- name: Install additional build tools for NOT CentOS8
+- name: Install additional build tools for NOT CentOS8/9
   package: "name={{ item }} state=latest"
-  with_items: "{{ Additional_Build_Tools_NOT_CentOS8 }}"
+  with_items: "{{ Additional_Build_Tools_NOT_CentOS8_CentOS9Stream }}"
   when:
     - ansible_distribution_major_version != "8"
+    - ansible_distribution_major_version != "9"
   tags: build_tools
 
 - name: Install Libdwarf.h for CentOS8 Stream
@@ -129,6 +136,7 @@
   when:
     - ansible_architecture == "x86_64"
     - ansible_distribution_major_version != "8"
+    - ansible_distribution_major_version != "9"
   tags: build_tools
 
 - name: Sed change the baseurl for CentOS SCL (CentOS6)

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -70,7 +70,7 @@ Additional_Build_Tools_CentOS7:
   - libstdc++-static
   - ccache
 
-Additional_Build_Tools_CentOS8:
+Additional_Build_Tools_CentOS8_CentOS9Stream:
   - glibc-locale-source
   - glibc-langpack-ja             # required for creating Japanese locales
   - glibc-langpack-ko             # required for creating Korean locales
@@ -79,7 +79,7 @@ Additional_Build_Tools_CentOS8:
   - cmake
   - ccache
 
-Additional_Build_Tools_NOT_CentOS8:
+Additional_Build_Tools_NOT_CentOS8_CentOS9Stream:
   - lbzip2
   - java-1.7.0-openjdk-devel
   - ntp


### PR DESCRIPTION
Fixes: https://github.com/adoptium/infrastructure/issues/3276

Add Common role support for CentOS 9 Stream

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access): https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/1813/
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
