### PR TITLE
ITWPlaybook: Improve Xcode Installation in ITW playbook.

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_ITW_Playbook/roles/Common/scripts/install-xcode.sh
+++ b/ansible/playbooks/AdoptOpenJDK_ITW_Playbook/roles/Common/scripts/install-xcode.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
+os_maj_vers=$(sw_vers -productVersion | awk -F "." '{print $1}')
 osx_vers=$(sw_vers -productVersion | awk -F "." '{print $2}')
 cmd_line_tools_temp_file="/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress"
 
+echo 1 = $os_maj_vers
+echo 2 = $osx_vers
+
 # Installing the latest Xcode command line tools on 10.9.x or higher
 
-if [[ "$osx_vers" -ge 9 ]]; then
+if [[ "$os_maj_vers" -ge 10 ]] && [[ "$osx_vers" -ge 9 ]]; then
   touch "$cmd_line_tools_temp_file";
   PROD=$(softwareupdate -l |
     grep "\*.*Command Line" |
@@ -20,25 +24,34 @@ fi
 # instead from public download URLs, which can be found in the dvtdownloadableindex:
 # https://devimages.apple.com.edgekey.net/downloads/xcode/simulators/index-3905972D-B609-49CE-8D06-51ADC78E07BC.dvtdownloadableindex
 
-if [[ "$osx_vers" -eq 7 ]] || [[ "$osx_vers" -eq 8 ]]; then
+if [[ "$os_maj_vers" -eq 10 ]] && [[ "$osx_vers" -eq 7 ]] || [[ "$osx_vers" -eq 8 ]]; then
 
 	if [[ "$osx_vers" -eq 7 ]]; then
 		DMGURL=http://devimages.apple.com/downloads/xcode/command_line_tools_for_xcode_os_x_lion_april_2013.dmg
+    DMGSHA="20a3e1965c685c6c079ffe89b168c3975c9a106c4b33b89aeac93c8ffa4e0523"
 	fi
 
 	if [[ "$osx_vers" -eq 8 ]]; then
 		 DMGURL=http://devimages.apple.com/downloads/xcode/command_line_tools_for_osx_mountain_lion_april_2014.dmg
+     DMGSHA="2ce8cb402efe7a1fe104759d9f32bed3c9b5e9f9db591f047702ae5dc7f3d1ac"
 	fi
 
 		TOOLS=cltools.dmg
 		curl "$DMGURL" -o "$TOOLS"
-		TMPMOUNT=`/usr/bin/mktemp -d /tmp/clitools.XXXX`
-		hdiutil attach "$TOOLS" -mountpoint "$TMPMOUNT" -nobrowse
-		# The "-allowUntrusted" flag has been added to the installer
-		# command to accomodate for now-expired certificates used
-		# to sign the downloaded command line tools.
-		installer -allowUntrusted -pkg "$(find $TMPMOUNT -name '*.mpkg')" -target /
-		hdiutil detach "$TMPMOUNT"
-		rm -rf "$TMPMOUNT"
-		rm "$TOOLS"
+    DLSUM=`shasum -a 256 "$TOOLS"|cut -d" " -f1`
+
+    if [[ "$DLSUM" == "$DMGSHA" ]]; then
+        TMPMOUNT=`/usr/bin/mktemp -d /tmp/clitools.XXXX`
+    		hdiutil attach "$TOOLS" -mountpoint "$TMPMOUNT" -nobrowse
+    		# The "-allowUntrusted" flag has been added to the installer
+    		# command to accomodate for now-expired certificates used
+    		# to sign the downloaded command line tools.
+    		installer -allowUntrusted -pkg "$(find $TMPMOUNT -name '*.mpkg')" -target /
+    		hdiutil detach "$TMPMOUNT"
+    		rm -rf "$TMPMOUNT"
+    		rm "$TOOLS"
+    else
+      echo "Error - Checksums Do Not Match"
+      exit 1
+    fi
 fi

--- a/ansible/playbooks/AdoptOpenJDK_ITW_Playbook/roles/Common/scripts/install-xcode.sh
+++ b/ansible/playbooks/AdoptOpenJDK_ITW_Playbook/roles/Common/scripts/install-xcode.sh
@@ -24,34 +24,33 @@ fi
 # instead from public download URLs, which can be found in the dvtdownloadableindex:
 # https://devimages.apple.com.edgekey.net/downloads/xcode/simulators/index-3905972D-B609-49CE-8D06-51ADC78E07BC.dvtdownloadableindex
 
-if [[ "$os_maj_vers" -eq 10 ]] && [[ "$osx_vers" -eq 7 ]] || [[ "$osx_vers" -eq 8 ]]; then
-
-	if [[ "$osx_vers" -eq 7 ]]; then
-		DMGURL=http://devimages.apple.com/downloads/xcode/command_line_tools_for_xcode_os_x_lion_april_2013.dmg
+if ([[ "$os_maj_vers" -eq 10 ]] && [[ "$osx_vers" -eq 7 ]]) || ([[ "$os_maj_vers" -eq 10 ]] && [[ "$osx_vers" -eq 8 ]]);
+  if [[ "$osx_vers" -eq 7 ]]; then
+    DMGURL=http://devimages.apple.com/downloads/xcode/command_line_tools_for_xcode_os_x_lion_april_2013.dmg
     DMGSHA="20a3e1965c685c6c079ffe89b168c3975c9a106c4b33b89aeac93c8ffa4e0523"
-	fi
+  fi
 
-	if [[ "$osx_vers" -eq 8 ]]; then
-		 DMGURL=http://devimages.apple.com/downloads/xcode/command_line_tools_for_osx_mountain_lion_april_2014.dmg
-     DMGSHA="2ce8cb402efe7a1fe104759d9f32bed3c9b5e9f9db591f047702ae5dc7f3d1ac"
-	fi
+  if [[ "$osx_vers" -eq 8 ]]; then
+    DMGURL=http://devimages.apple.com/downloads/xcode/command_line_tools_for_osx_mountain_lion_april_2014.dmg
+    DMGSHA="2ce8cb402efe7a1fe104759d9f32bed3c9b5e9f9db591f047702ae5dc7f3d1ac"
+  fi
 
-		TOOLS=cltools.dmg
-		curl "$DMGURL" -o "$TOOLS"
-    DLSUM=`shasum -a 256 "$TOOLS"|cut -d" " -f1`
+  TOOLS=cltools.dmg
+  curl "$DMGURL" -o "$TOOLS"
+  DLSUM=`shasum -a 256 "$TOOLS"|cut -d" " -f1`
 
-    if [[ "$DLSUM" == "$DMGSHA" ]]; then
-        TMPMOUNT=`/usr/bin/mktemp -d /tmp/clitools.XXXX`
-    		hdiutil attach "$TOOLS" -mountpoint "$TMPMOUNT" -nobrowse
-    		# The "-allowUntrusted" flag has been added to the installer
-    		# command to accomodate for now-expired certificates used
-    		# to sign the downloaded command line tools.
-    		installer -allowUntrusted -pkg "$(find $TMPMOUNT -name '*.mpkg')" -target /
-    		hdiutil detach "$TMPMOUNT"
-    		rm -rf "$TMPMOUNT"
-    		rm "$TOOLS"
-    else
-      echo "Error - Checksums Do Not Match"
-      exit 1
-    fi
+  if [[ "$DLSUM" == "$DMGSHA" ]]; then
+    TMPMOUNT=`/usr/bin/mktemp -d /tmp/clitools.XXXX`
+    hdiutil attach "$TOOLS" -mountpoint "$TMPMOUNT" -nobrowse
+    # The "-allowUntrusted" flag has been added to the installer
+    # command to accomodate for now-expired certificates used
+    # to sign the downloaded command line tools.
+    installer -allowUntrusted -pkg "$(find $TMPMOUNT -name '*.mpkg')" -target /
+    hdiutil detach "$TMPMOUNT"
+    rm -rf "$TMPMOUNT"
+    rm "$TOOLS"
+  else
+    echo "Error - Checksums Do Not Match"
+    exit 1
+  fi
 fi

--- a/ansible/playbooks/AdoptOpenJDK_ITW_Playbook/roles/Common/scripts/install-xcode.sh
+++ b/ansible/playbooks/AdoptOpenJDK_ITW_Playbook/roles/Common/scripts/install-xcode.sh
@@ -8,7 +8,7 @@ echo 2 = $osx_vers
 
 # Installing the latest Xcode command line tools on 10.9.x or higher
 
-if [[ "$os_maj_vers" -ge 10 ]] && [[ "$osx_vers" -ge 9 ]]; then
+if [[ "$os_maj_vers" -eq 10 ]] && [[ "$osx_vers" -ge 9 ]]; then
   touch "$cmd_line_tools_temp_file";
   PROD=$(softwareupdate -l |
     grep "\*.*Command Line" |


### PR DESCRIPTION
Fixes #3281 

HTTPS download is not available for the 2 files from Apple.

SHA256 checksum tests added, and scope of script restricted to MacOS10.

This script is not run automatically as part of the playbook.

##### Checklist

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR

