### PR TITLE
UnixPB: Ensure CC environment variable is always set for NASM compilation

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/nasm/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/nasm/tasks/main.yml
@@ -87,6 +87,8 @@
 
 - name: Running ./configure & make for nasm ( Not Ubuntu 22+ )
   shell: cd /tmp/nasm-2.13.03 && CC={{ CC }} && ./configure -prefix=/usr/local && make install
+  environment:
+          CC: "{{ CC }}"
   when:
     - (ansible_distribution != "Ubuntu" or ansible_distribution == "Ubuntu" and ansible_distribution_major_version < "22") and (nasm_installed.rc is defined) and ((nasm_installed.rc != 0 ) or (nasm_installed.rc == 0 and nasm.stdout is version_compare('2.13.03', operator='ne')) )
   tags: nasm


### PR DESCRIPTION
Ensure the CC environment variable is always set regardless of O/S

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)

