### PR TITLE
unixPb: Update Centos7 image with patch & texinfo to enabled building of devkit

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -45,7 +45,7 @@ Build_Tool_Packages:
   - numactl-devel                 # OpenJ9
   - openssh-clients               # IBM: cloning over SSH
   - openssl-devel
-  - patch
+  - patch                         # For DevKit creation that runs "patch"
   - perl-DBI
   - perl-devel
   - perl-Digest-SHA
@@ -56,7 +56,7 @@ Build_Tool_Packages:
   - pigz
   - strace                        # For SBOM dependency analysis
   - systemtap-sdt-devel
-  - texinfo
+  - texinfo                       # For DevKit creation (binutils build)
   - unzip
   - wget
   - which

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -45,6 +45,7 @@ Build_Tool_Packages:
   - numactl-devel                 # OpenJ9
   - openssh-clients               # IBM: cloning over SSH
   - openssl-devel
+  - patch
   - perl-DBI
   - perl-devel
   - perl-Digest-SHA
@@ -55,6 +56,7 @@ Build_Tool_Packages:
   - pigz
   - strace                        # For SBOM dependency analysis
   - systemtap-sdt-devel
+  - texinfo
   - unzip
   - wget
   - which

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -44,11 +44,13 @@ Build_Tool_Packages:
   - nss-devel
   - nss-tools
   - openssl-devel
+  - patch                         # For DevKit creation that runs "patch"
   - perl-devel
   - perl-IPC-Cmd                  # required for openssl v3 compiles
   - pkgconfig
   - strace                        # For SBOM dependency analysis
   - systemtap-sdt-devel
+  - texinfo                       # For DevKit creation (binutils build)
   - unzip
   - wget
   - xz


### PR DESCRIPTION
Fixes https://github.com/adoptium/infrastructure/issues/3289

DevKit creation needs:
- "patch" as DevKit patches certain downloads
- "texinfo" as DevKit build of binutils needs this to build

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
