### PR TITLE
Github: Update Docker Login Credentials To Use Token

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        password: ${{ secrets.DOCKER_TOKEN }}
       if: github.ref == 'refs/heads/master'
 
 
@@ -57,7 +57,7 @@ jobs:
         tags: adoptopenjdk/centos6_build_image:latest
         cache-from: type=registry,ref=adoptopenjdk/centos6_build_image:latest
         cache-to: type=inline
-        push: true
+        push: false
       if: github.ref == 'refs/heads/master'
 
   build-and-push-alpine3:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_TOKEN }}
-      if: github.ref != 'refs/heads/master'
+      if: github.ref == 'refs/heads/master'
 
 
     - name: Docker Build CentOS6 Image Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_TOKEN }}
-      if: github.ref == 'refs/heads/master'
+      if: github.ref != 'refs/heads/master'
 
 
     - name: Docker Build CentOS6 Image Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
         tags: adoptopenjdk/centos6_build_image:latest
         cache-from: type=registry,ref=adoptopenjdk/centos6_build_image:latest
         cache-to: type=inline
-        push: false
+        push: true
       if: github.ref == 'refs/heads/master'
 
   build-and-push-alpine3:


### PR DESCRIPTION
Fixes #3211 

Update docker credentials to use PAT, but disable push on merge, due to replacement with docker multiarch jenkins job. Code left to enable easy re-enablement if required.

The docker push on merge has also been disabled, due to the relocation of the centos6 docker push to the jenkins job as per this PR: https://github.com/adoptium/infrastructure/pull/3296

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR