### PR TITLE
Github: Disable push on merge & update document.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
         tags: adoptopenjdk/centos6_build_image:latest
         cache-from: type=registry,ref=adoptopenjdk/centos6_build_image:latest
         cache-to: type=inline
-        push: true
+        push: false
       if: github.ref == 'refs/heads/master'
 
   build-and-push-alpine3:

--- a/FAQ.md
+++ b/FAQ.md
@@ -31,6 +31,8 @@ Most Ansible changes are tested automatically with a series of CI jobs:
 | Windows (2019 and 2022) | [build_wsl.yml](./.github/workflows/build_wsl.yml) | Uses Windows Subsystem for Linux to run ansible |
 | Solaris 10 | [build_vagrant.yml](./.github/workflows/build_vagrant.yml) | Uses Vagrant to run a Solaris image inside a macOS host |
 
+Please note that the Centos 6 & Alpine 3 build jobs, build a docker image but DO NOT PUSH to dockerhub. The job has a seperate configuration section to push to dockerhub when a PR is merged, however that function is disabled, and has been superceded by the Jenkins docker image updater job. The code has been left in place for two reasons, the first to allow the ability to re-enable quickly, and also to test the authentication job for the dockerhub credentials. These credentials are stored in GitHub and are managed by the EF infrastructure team.
+
 ## Running the ansible scripts on local machines
 
 The full documentation for running locally is at [ansible/README.md].
@@ -328,7 +330,7 @@ or [aqavit](https://projects.eclipse.org/projects/adoptium.aqavit) projects.
 
 ## Patching
 
-At Adoptium we use scheduled jobs within [AWX](https://awx2.adoptopenjdk.net/#/home) to execute our platform playbooks onto our machines. 
+At Adoptium we use scheduled jobs within [AWX](https://awx2.adoptopenjdk.net/#/home) to execute our platform playbooks onto our machines.
 The Unix, Windows, MacOS and AIX playbooks are executed weekly onto our [machines](https://github.com/adoptium/infrastructure/blob/master/ansible/inventory.yml) to keep them patched and up to date.
 
 For more information see https://github.com/adoptium/infrastructure/wiki/Ansible-AWX#schedules


### PR DESCRIPTION
Fixes #3298 

Disable the Github Action to push a Centos 6 docker image on merge to Github. This is already disabled for Alpine 3.

This functionality has been relocated to the Jenkins multiplatform docker build job.

However for future reference , the code has been left in place to make re-enablement quicker/simpler should it be required, and it will also test the docker hub credentials being used. 

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [X] VPC/QPC not applicable for this PR

