### PR TITLE
inventory: Add windows test server & wazuh SIEM server

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -15,6 +15,7 @@ hosts:
 
       - azure:
           ubuntu2004-x64-1: {ip: 40.121.206.1, user: webmaster, description: jckservices.adoptium.net}
+          ubuntu2204-x64-1: {ip: 172.187.163.163, user: adoptopenjdk, description: infra-wazuh-server}
 
       - digitalocean:
           ubuntu2004-x64-1: {ip: 178.62.115.224, description: bastillion.adoptopenjdk.net}
@@ -114,6 +115,7 @@ hosts:
           win2016-x64-1: {ip: 52.149.211.210, user: adoptopenjdk}
           win2019-x64-1: {ip: 20.185.182.137, user: adoptopenjdk}
           win2022-x64-1: {ip: 51.132.234.42, user: adoptopenjdk}
+          win2022-x64-2: {ip: 20.26.116.218, user: adoptopenjdk}
           win11-aarch64-1: {ip: 20.4.31.184, user: adoptopenjdk}
           win11-aarch64-2: {ip: 108.143.205.79, user: adoptopenjdk}
 


### PR DESCRIPTION
Add the new windows test server ( issue #3238 ) and Wazuh server ( #3047 ) to the ansible inventory.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR
- [X] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
