### PR TITLE
inventory: remove test-azure-win2012r2-x64-1 and -3

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -109,8 +109,6 @@ hosts:
           ubuntu1804-armv8-2: {ip: 114.119.175.125}
 
       - azure:
-          win2012r2-x64-1: {ip: 13.68.134.204, user: adoptopenjdk}
-          win2012r2-x64-3: {ip: 13.68.219.237, user: adoptopenjdk}
           win2016-x64-1: {ip: 52.149.211.210, user: adoptopenjdk}
           win2019-x64-1: {ip: 20.185.182.137, user: adoptopenjdk}
           win2022-x64-1: {ip: 51.132.234.42, user: adoptopenjdk}


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Ref https://github.com/adoptium/infrastructure/issues/3238#issuecomment-1853516549

test-azure-win2012r2-x64-1 and -3 have been replaced with test-azure-win2022-x64-1 and -2

Will remove their jenkins entries once this gets merged