### PR TITLE
Download cross-build jdk17u and jdk21u from CI

### DIFF
--- a/ansible/docker/Dockerfile.Ubuntu2004-riscv64
+++ b/ansible/docker/Dockerfile.Ubuntu2004-riscv64
@@ -21,6 +21,7 @@ RUN useradd -c "Jenkins user" -d /home/${user} -u 1000 -g 1000 -m ${user}
 
 ENV \
     JDK11_BOOT_DIR="/usr/lib/jvm/java-11-openjdk-riscv64" \
-    JDK17_BOOT_DIR="/usr/lib/jvm/java-17-openjdk-riscv64" \
+    JDK17_BOOT_DIR="/usr/lib/jvm/jdk-17" \
     JDK19_BOOT_DIR="/usr/lib/jvm/jdk-19" \
+    JDK21_BOOT_DIR="/usr/lib/jvm/jdk-21" \
     JAVA_HOME="/usr/lib/jvm/java-11-openjdk-riscv64"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -109,11 +109,10 @@
         - ansible_distribution != "Solaris"
         - ansible_architecture != "riscv64"
       tags: build_tools
-    - role: adoptopenjdk_install  # Current LTS
+    - role: adoptopenjdk_install  # Previous LTS
       jdk_version: 17
       when:
         - ansible_distribution != "Solaris"
-        - ansible_architecture != "riscv64"
       tags: build_tools
     - role: adoptopenjdk_install  # JDK19 Build Bootstrap
       jdk_version: 18
@@ -127,6 +126,11 @@
       when:
         - ansible_distribution != "Alpine"
         - ansible_distribution != "Solaris"
+      tags: build_tools
+    - role: adoptopenjdk_install  # Current LTS
+      jdk_version: 21
+      when:
+        - ansible_architecture == "riscv64"
       tags: build_tools
     - role: Nagios_Plugins        # AdoptOpenJDK Infrastructure
       tags: [nagios_plugins, adoptopenjdk]

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
@@ -187,6 +187,7 @@
         url: https://api.adoptium.net/v3/binary/version/jdk-21.0.1+12.1-ea-beta/linux/riscv64/jdk/hotspot/normal/adoptium
         dest: /tmp/jdk21.tar.gz
         mode: 0440
+        checksum: sha256:45baa6571849e4a93b76156a96a4eb83c0398f410d4542b8039a4e097c7c2161
       retries: 3
       delay: 5
       register: adoptopenjdk_download
@@ -247,6 +248,7 @@
         url: https://ci.adoptium.net/userContent/riscv/jdk17u-riscv64-17.0.9+9-ea-cross-20231221.tar.gz
         dest: /tmp/jdk17.tar.gz
         mode: 0440
+        checksum: sha256:7b84db96e69f075dbea49164f866d7296b1f2f7a45961978155505d4fd07b0e4
       retries: 3
       delay: 5
       register: adoptopenjdk_download

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
@@ -134,7 +134,7 @@
     - ansible_distribution != "MacOSX"
     - not ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and ansible_distribution_major_version == "6")
     - ansible_os_family != "Solaris"
-    - not (ansible_architecture == "riscv64" and jdk_version == 19) # Linux-riscv64 for JDK 19 is special cased
+    - not (ansible_architecture == "riscv64" and (jdk_version == 21 or jdk_version == 19 or jdk_version == 17)) # Linux-riscv64 for JDK 17, 19, 21 are special cased
     - adoptopenjdk_installed.rc != 0
   tags: adoptopenjdk_install
     # Api does not return release information for JDK10
@@ -173,6 +173,36 @@
         path: /tmp/jdk{{ jdk_version }}.tar.gz
         state: absent
 
+# JDK 21 on Linux-riscv64 is a special-case because JDK 21 is the first version that supports
+# RISC-V. There is also no JDK 21 or 20 available on Ubuntu 20.04 that we can use as boot JDK.
+- name: Install JDK {{ jdk_version }} on Linux-riscv64
+  when:
+    - ansible_architecture == "riscv64" and jdk_version == 21
+    - adoptopenjdk_installed.rc != 0
+  tags: adoptopenjdk_install
+    # Api does not return release information for JDK10
+  block:
+    - name: Download jdk{{ jdk_version }} release (Linux-riscv64)
+      get_url:
+        url: https://api.adoptium.net/v3/binary/version/jdk-21.0.1+12.1-ea-beta/linux/riscv64/jdk/hotspot/normal/adoptium
+        dest: /tmp/jdk21.tar.gz
+        mode: 0440
+      retries: 3
+      delay: 5
+      register: adoptopenjdk_download
+      until: adoptopenjdk_download is not failed
+
+    - name: Install latest jdk{{ jdk_version }} release if one not already installed (Linux-riscv64)
+      unarchive:
+        src: /tmp/jdk21.tar.gz
+        dest: /usr/lib/jvm
+        remote_src: yes
+
+    - name: Remove jdk21.tar.gz (Linux-riscv64)
+      file:
+        path: /tmp/jdk21.tar.gz
+        state: absent
+
 # JDK 19 on Linux-riscv64 is a special-case because JDK 19 is the first version that supports
 # RISC-V. There is also no JDK 19 or 20 available on Ubuntu 20.04 that we can use as boot JDK.
 - name: Install JDK {{ jdk_version }} on Linux-riscv64
@@ -201,6 +231,36 @@
     - name: Remove jdk19.tar.gz (Linux-riscv64)
       file:
         path: /tmp/jdk19.tar.gz
+        state: absent
+
+# JDK 17 on Linux-riscv64 is a special-case because the Ubuntu openjdk-17-jdk package doesn't seem
+# to work on VF2.
+- name: Install JDK {{ jdk_version }} on Linux-riscv64
+  when:
+    - ansible_architecture == "riscv64" and jdk_version == 17
+    - adoptopenjdk_installed.rc != 0
+  tags: adoptopenjdk_install
+    # Api does not return release information for JDK10
+  block:
+    - name: Download jdk{{ jdk_version }} release (Linux-riscv64)
+      get_url:
+        url: https://ci.adoptium.net/userContent/riscv/jdk17u-riscv64-17.0.9+9-ea-cross-20231221.tar.gz
+        dest: /tmp/jdk17.tar.gz
+        mode: 0440
+      retries: 3
+      delay: 5
+      register: adoptopenjdk_download
+      until: adoptopenjdk_download is not failed
+
+    - name: Install latest jdk{{ jdk_version }} release if one not already installed (Linux-riscv64)
+      unarchive:
+        src: /tmp/jdk17.tar.gz
+        dest: /usr/lib/jvm
+        remote_src: yes
+
+    - name: Remove jdk17.tar.gz (Linux-riscv64)
+      file:
+        path: /tmp/jdk17.tar.gz
         state: absent
 
 # # CentOS6 needs it's own task so it can use a different python interpreter.


### PR DESCRIPTION
We don't want to rely on openjdk-17-jdk from Ubuntu 20.04 repositories, it crashes when running on VF2.

Relates to https://github.com/adoptium/temurin-build/issues/3591

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
