### PR TITLE
docker: Use secret for ROSIPW on RHEL7 build dockerfile

### DIFF
--- a/ansible/docker/Dockerfile.RHEL7
+++ b/ansible/docker/Dockerfile.RHEL7
@@ -1,10 +1,9 @@
 FROM registry.access.redhat.com/rhel7
-# This dockerfile should be built using:
-#  docker build --no-cache -t rhel7_build_image -f ansible/docker/Dockerfile.RHEL7 --build-arg ROSIUSER=******* --build-arg ROSIPW=******* --build-arg git_sha=******* `pwd`
+# This dockerfile should be built using this from the top level of the repository:
+#  ROSIPW=******* docker build --no-cache -t rhel7_build_image -f ansible/docker/Dockerfile.RHEL7 --build-arg ROSIUSER=******* --secret id=ROSIPW --build-arg git_sha="$(git rev-parse --short HEAD)" `pwd`
 ARG ROSIUSER
-ARG ROSIPW
 RUN sed -i 's/\(def in_container():\)/\1\n    return False/g' /usr/lib64/python*/*-packages/rhsm/config.py
-RUN subscription-manager register --username=${ROSIUSER} --password=${ROSIPW} --auto-attach
+RUN --mount=type=secret,id=ROSIPW,required=true subscription-manager register --username=${ROSIUSER} --password="$(cat /run/secrets/ROSIPW)" --auto-attach
 RUN subscription-manager repos --enable rhel-7-for-system-z-optional-rpms
 # ^^ Optional repo needed for Xvfb
 


### PR DESCRIPTION
Current process exposes the ROSI credential in the docker image. This switches the process to use a secret supplied in an environment variable as per https://docs.docker.com/build/building/secrets

Another option would be to use a secret file (e.g. `secret id=ROSPIW,src=$HOME/.rosipw`) but that runs a great risk of being accessed if cleanup does not occur properly.

Draft while testing is performed, but reviews welcome in the meantime

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [X] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
