### PR TITLE
github: Replace action checkout version with SHA in build_qemu

### DIFF
--- a/.github/workflows/build_qemu.yml
+++ b/.github/workflows/build_qemu.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@01aecccf739ca6ff86c0539fbc67a7a5007bbc81 # v2.1.0
 
       - name: Run on architecture
-        uses: uraimo/run-on-arch-action@v2.4.0
+        uses: uraimo/run-on-arch-action@b101fffede73ba1ed3cc0ca4425cbf61e2672e6e # v2.4.0
         with:
           arch: ${{ matrix.arch }}
           distro: ${{ matrix.distro }}

--- a/.github/workflows/build_qemu.yml
+++ b/.github/workflows/build_qemu.yml
@@ -36,7 +36,7 @@ jobs:
           #   distro: jessie
 
     steps:
-      - uses: actions/checkout@v2.1.0
+      - uses: actions/checkout@01aecccf739ca6ff86c0539fbc67a7a5007bbc81 # v2.1.0
 
       - name: Run on architecture
         uses: uraimo/run-on-arch-action@v2.4.0


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

