### PR TITLE
unixPB: Add Docker support for SLES 12

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
@@ -55,46 +55,46 @@
         use: auto       # automatic select package manager to use yum, apt and so on
       when: (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int >= 20)
 
-    - name: Install for SLES15 # zypper does not support in package module
+    - name: Install for SLES # zypper does not support in package module
       include_tasks: sles.yml
       when:
-        - ansible_distribution == "SLES" and ansible_distribution_major_version == "15"
+        - ansible_distribution == "SLES"
 
     ################
     # Post Install #
     ################
-    - name: Add Jenkins user to the docker group for Ubuntu, Debian, SLES12, CentOS7  and RHEL7
+    - name: Add Jenkins user to the docker group for Ubuntu, Debian, SLES, CentOS7  and RHEL7
       user:
         name: "{{ Jenkins_Username }}"
         groups: docker
         append: yes
         state: present
       when:
-        - (ansible_distribution == "Ubuntu" or ansible_distribution == "Debian") or (ansible_distribution == "SLES" and ansible_distribution_major_version == "15") or ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS" ) and ansible_distribution_major_version == "7")
+        - (ansible_distribution == "Ubuntu" or ansible_distribution == "Debian") or (ansible_distribution == "SLES") or ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS" ) and ansible_distribution_major_version == "7")
         - ansible_architecture != "riscv64"
       tags:
         - jenkins
 
-    - name: Add Nagios user to the docker group for Ubuntu, Debian, SLES12, CentOS7  and RHEL7
+    - name: Add Nagios user to the docker group for Ubuntu, Debian, SLES, CentOS7  and RHEL7
       user:
         name: nagios
         groups: docker
         append: yes
         state: present
       when:
-        - (ansible_distribution == "Ubuntu" or ansible_distribution == "Debian") or (ansible_distribution == "SLES" and ansible_distribution_major_version == "15") or ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS" ) and ansible_distribution_major_version == "7")
+        - (ansible_distribution == "Ubuntu" or ansible_distribution == "Debian") or (ansible_distribution == "SLES") or ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS" ) and ansible_distribution_major_version == "7")
         - ansible_architecture != "riscv64"
         - Nagios_Plugins == "Enabled"
       tags:
         - docker
 
-- name: Enable and Start Docker Service for Ubuntu, Debian, SLES12, CentOS7  and RHEL7
+- name: Enable and Start Docker Service for Ubuntu, Debian, SLES, CentOS7  and RHEL7
   service:
     name: docker
     state: started
     enabled: yes
   when:
-    - (ansible_distribution == "Ubuntu" or ansible_distribution == "Debian") or (ansible_distribution == "SLES" and ansible_distribution_major_version == "15") or ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS" ) and ansible_distribution_major_version == "7")
+    - (ansible_distribution == "Ubuntu" or ansible_distribution == "Debian") or (ansible_distribution == "SLES") or ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS" ) and ansible_distribution_major_version == "7")
     - ansible_architecture != "riscv64"
   tags:
     - docker

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/sles.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/sles.yml
@@ -2,14 +2,16 @@
 - name: Add Docker Repo for SLES15
   command: zypper ar https://download.docker.com/linux/sles/docker-ce.repo
   when:
+    - ansible_distribution_major_version == "15"
     - ansible_architecture == "x86_64" or ansible_architecture == "s390x"
 
-- name: Add security repo for container-selinux
-  community.general.zypper_repository:
+- name: Add security repo for container-selinux for SLES 15
+  zypper_repository:
     repo: https://download.opensuse.org/repositories/security:SELinux/SLE_15_SP3/security:SELinux.repo
     state: present
     auto_import_keys: yes
   when:
+    - ansible_distribution_major_version == "15"
     - ansible_architecture == "x86_64" or ansible_architecture == "s390x"
 
 - name: Install Docker on SLES15
@@ -22,7 +24,18 @@
     - docker-ce-cli
     - containerd.io
   when:
+    - ansible_distribution_major_version == "15"
     - ansible_architecture == "x86_64" or ansible_architecture == "s390x"
   tags:
     # TODO: Package installs should not use latest
     - skip_ansible_lint
+
+- name: Install docker in SLES 12
+  package:
+    update_cache: yes
+    name: ['containerd', 'runc', 'docker']
+    state: latest
+  when:
+    - ansible_distribution == "SLES"
+    - ansible_distribution_major_version == "12"
+    - ansible_architecture != "aarch64"  #no docker support for sles 12 aarch64


### PR DESCRIPTION
Extends docker support to SLES 12.
Fixes: https://github.com/adoptium/infrastructure/issues/3326

All the relevant packages mentioned in the PB are available as part of `Containers Module 12` repo. eg: https://scc.suse.com/packages/25502818

note: docker not supported in sles 12 aarch64
##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
