### PR TITLE
unixPB: Install jdk21 instead of 11 from dockerhost.yml

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/dockerhost.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/dockerhost.yml
@@ -30,7 +30,7 @@
     - role: Swap_File
     - role: Crontab
     - role: adoptopenjdk_install
-      jdk_version: 11
+      jdk_version: 21
     - role: Nagios_Plugins        # AdoptOpenJDK Infrastructure
       tags: [nagios_plugins, adoptopenjdk]
     - role: Nagios_Master_Config  # AdoptOpenJDK Infrastructure


### PR DESCRIPTION
Keep up to date :-)

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
