### PR TITLE
inventory: add dockerhost-skytap-ubuntu2204-x64-1

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -100,6 +100,7 @@ hosts:
 
       - skytap:
           ubuntu2004-ppc64le-1: {ip: 20.61.136.212, description: 32CPU, 400G}
+          ubuntu2204-x64-1: {ip: 20.61.136.254, description: 24 core Intel X5650}
 
   - test:
 


### PR DESCRIPTION
Draft until bastillion/nagios updated

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
