### PR TITLE
inventory: remove deleted mac minis from inventory

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -54,9 +54,6 @@ hosts:
 
       - macstadium:
           macos1014-x64-1: {ip: 208.83.1.170, user: Administrator, description: G3B i7-4C/16G/250G}
-          macos1014-x64-2: {ip: 207.254.28.76, user: Administrator, description: G3C i7-4C/16G/500G}
-          macos11-arm64-1: {ip: 207.254.31.15, user: Administrator, description: G5G M1/8C/16G/1T}
-          macos11-arm64-2: {ip: 207.254.31.16, user: Administrator, description: G5G M1/8C/16G/1T}
 
       - marist:
           rhel79-s390x-1: {ip: 148.100.75.212, user: linux1}
@@ -149,11 +146,6 @@ hosts:
 
       - macstadium:
           macos1014-x64-1: {ip: 207.254.29.43, user: administrator, description: G3B i7/4C/16G/250G}
-          macos1014-x64-2: {ip: 207.254.29.44, user: administrator, description: G3B i7/4C/16G/250G}
-          macos1014-x64-3: {ip: 207.254.28.237, user: administrator, description: G3B i7/4C/16G/250G}
-          macos1014-x64-4: {ip: 207.254.71.202, user: Administrator, description: G4B i7-6C/32G/512G}
-          macos1015-x64-1: {ip: 207.254.28.171, user: administrator, description: G3B i7/4C/16G/250G}
-          macos11-arm64-1: {ip: 199.7.163.51, user: Administrator, description: G5A M1/8C/8G/256G}
           macos11-arm64-2: {ip: 199.7.163.52, user: Administrator, description: G5A M1/8C/8G/256G}
 
       - marist:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
