### PR TITLE
github: Remove Ubuntu 21.04

### DIFF
--- a/.github/workflows/check_dockerstatic.yml
+++ b/.github/workflows/check_dockerstatic.yml
@@ -92,8 +92,6 @@ jobs:
            dockerfile: "Dockerfile.u1804"
          - os: ubuntu20.04
            dockerfile: "Dockerfile.u2004"
-         - os: ubuntu21.04
-           dockerfile: "Dockerfile.u2104"
     steps:
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
     - name: Test Dockerfile on ${{ matrix.os }}


### PR DESCRIPTION
Fixes #3386 

Remove out of support Ubuntu version from GHA 

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR
