### PR TITLE
unixPb: Install `hostname` in sles 15 dockerfile

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.sles15
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.sles15
@@ -31,7 +31,7 @@ RUN ssh-keygen -A
 
 CMD ["/usr/sbin/sshd", "-D"]
 
-RUN zypper update -y && zypper install -y git curl make gcc libXrender1 libXi6 libXtst6 fontconfig fakeroot xorg-x11-server gawk
+RUN zypper update -y && zypper install -y git curl make gcc libXrender1 libXi6 libXtst6 fontconfig fakeroot xorg-x11-server gawk hostname
 
 # Install SSL Test packages
 RUN zypper install -y gnutls mozilla-nss mozilla-nss-devel mozilla-nss-tools


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

The `hostname` command is needed a jdk_net test:
https://ci.adoptium.net/job/Grinder/8802/testReport/sun_net_www_protocol_https_HttpsURLConnection_PostThruProxyWithAuth/java/PostThruProxyWithAuth/

```
Server started at: [SSL: ServerSocket[addr=60d5d0846858/172.17.0.18,localport=40167]]
Proxy server created: ServerSocket[addr=60d5d0846858/172.17.0.18,localport=38103]
Proxy server listening at: ServerSocket[addr=60d5d0846858/172.17.0.18,localport=38103]
Command line: [hostname]
executeProcess() failed: java.io.IOException: Cannot run program "hostname": error=2, No such file or directory
Client side failed: Get hostname failed.
```
