### PR TITLE
docker: New dockernode.yml playbook to automate deployment of docker static containers

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/dockernode.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/dockernode.yml
@@ -6,7 +6,7 @@
 - name: dockernode playbook
   hosts: all
   gather_facts: yes
-  
+
   roles:
     - role: Debug
       tags: debug

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/dockernode.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/dockernode.yml
@@ -2,6 +2,8 @@
 ###############################
 # Adoptium - Ansible Playbook #
 ###############################
+# This playbook is used to deploy static docker containers onto dockerhost machines
+# https://github.com/adoptium/infrastructure/issues/3370
 
 - name: Dockernode playbook
   hosts: all

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/dockernode.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/dockernode.yml
@@ -1,0 +1,13 @@
+---
+###############################
+# Adoptium - Ansible Playbook #
+###############################
+
+- name: dockernode playbook
+  hosts: localhost
+  gather_facts: yes
+  
+  roles:
+    - Debug
+    - role: deploy_container
+      tags: deploy

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/dockernode.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/dockernode.yml
@@ -3,7 +3,7 @@
 # Adoptium - Ansible Playbook #
 ###############################
 
-- name: dockernode playbook
+- name: Dockernode playbook
   hosts: all
   gather_facts: yes
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/dockernode.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/dockernode.yml
@@ -10,5 +10,7 @@
   roles:
     - role: Debug
       tags: debug
+    - role: Get_Vendor_Files
+      tags: deploy
     - role: deploy_container
       tags: deploy

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/dockernode.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/dockernode.yml
@@ -4,10 +4,11 @@
 ###############################
 
 - name: dockernode playbook
-  hosts: localhost
+  hosts: all
   gather_facts: yes
   
   roles:
-    - Debug
+    - role: Debug
+      tags: debug
     - role: deploy_container
       tags: deploy

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alp319
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alp319
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.19
 
 RUN apk --update add bash shadow openssh-server openssh-client unzip zip wget git curl make gcc perl xvfb \
         libxrender libxi libxtst procps musl-dev perl-doc alsa-lib libx11 msttcorefonts-installer fontconfig libxext freetype zlib fakeroot gnupg
@@ -11,13 +11,13 @@ RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -P ""
 ## Ensure Fonts Are Updated (Issue https://github.com/adoptium/infrastructure/issues/3039)
 RUN update-ms-fonts
 
-# Get latest jdk17 ga
-RUN wget -q 'https://api.adoptium.net/v3/binary/latest/17/ga/alpine-linux/x64/jdk/hotspot/normal/eclipse?project=jdk' -O /tmp/jdk17.tar.gz
+# Get latest jdk21 ga
+RUN wget -q 'https://api.adoptium.net/v3/binary/latest/21/ga/alpine-linux/x64/jdk/hotspot/normal/eclipse?project=jdk' -O /tmp/jdk21.tar.gz
 RUN gpg --keyserver keyserver.ubuntu.com --recv-keys 3B04D753C9050D9A5D343F39843C48A565F8F04B
-# Get sig file for latest jdk17 ga
-RUN wget -q `curl -s 'https://api.adoptium.net/v3/assets/feature_releases/17/ga?architecture=x64&heap_size=normal&image_type=jdk&jvm_impl=hotspot&os=alpine-linux&page=0&page_size=1&project=jdk&vendor=eclipse' | grep signature_link | awk '{split($0,a,"\""); print a[4]}'` -O /tmp/jdk17.sig
-RUN gpg --verify /tmp/jdk17.sig /tmp/jdk17.tar.gz
-RUN mkdir -p /usr/lib/jvm/jdk17 && tar -xpzf /tmp/jdk17.tar.gz -C /usr/lib/jvm/jdk17 --strip-components=1
+# Get sig file for latest jdk21 ga
+RUN wget -q `curl -s 'https://api.adoptium.net/v3/assets/feature_releases/21/ga?architecture=x64&heap_size=normal&image_type=jdk&jvm_impl=hotspot&os=alpine-linux&page=0&page_size=1&project=jdk&vendor=eclipse' | grep signature_link | awk '{split($0,a,"\""); print a[4]}'` -O /tmp/jdk21.sig
+RUN gpg --verify /tmp/jdk21.sig /tmp/jdk21.tar.gz
+RUN mkdir -p /usr/lib/jvm/jdk21 && tar -xpzf /tmp/jdk21.tar.gz -C /usr/lib/jvm/jdk21 --strip-components=1
 
 # Install ant and ant-contrib.
 RUN wget -O /tmp/ant.zip 'https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.9-bin.zip'
@@ -39,7 +39,7 @@ RUN chown -R jenkins:jenkins /home/jenkins/.ssh
 RUN chmod -R "g=,o=" /home/jenkins/.ssh
 
 # Remove temporary files.
-RUN rm -rf /tmp/jdk17.tar.gz /tmp/ant* /tmp/ant-contrib* /tmp/jdk17.sig
+RUN rm -rf /tmp/jdk21.tar.gz /tmp/ant* /tmp/ant-contrib* /tmp/jdk21.sig
 
 # Start container with docker run -p 2222:22 UUID.
 CMD ["/usr/sbin/sshd","-D"]

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.deb12
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.deb12
@@ -1,15 +1,21 @@
-FROM fedora:35
+FROM debian:12
+# Install Base Requirements
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+RUN apt-get update && apt-get install -y perl openssh-server unzip zip wget apt-utils gnupg curl
+# Install Packages For OpenSSL pbTestScripts
+RUN apt-get install -y gnutls-bin libnss3 libnss3-dev libnss3-tools pkg-config
+RUN echo "y" | ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -P ""
+RUN apt-get update
 
-RUN yum -y update && yum install -y perl openssh-server unzip zip wget
-RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -P ""
 # Get latest jdk17 ga
 RUN wget -q 'https://api.adoptium.net/v3/binary/latest/17/ga/linux/x64/jdk/hotspot/normal/eclipse?project=jdk' -O /tmp/jdk17.tar.gz
 RUN gpg --keyserver keyserver.ubuntu.com --recv-keys 3B04D753C9050D9A5D343F39843C48A565F8F04B
 # Get sig file for latest jdk17 ga
 RUN wget -q `curl -s 'https://api.adoptium.net/v3/assets/feature_releases/17/ga?architecture=x64&heap_size=normal&image_type=jdk&jvm_impl=hotspot&os=linux&page=0&page_size=1&project=jdk&vendor=eclipse' | grep signature_link | awk '{split($0,a,"\""); print a[4]}'` -O /tmp/jdk17.sig
 RUN gpg --verify /tmp/jdk17.sig /tmp/jdk17.tar.gz
+
 RUN mkdir -p /usr/lib/jvm/jdk17 && tar -xpzf /tmp/jdk17.tar.gz -C /usr/lib/jvm/jdk17 --strip-components=1
-# Install ant 1.10.12
+# Install ant via WGET
 RUN wget -q -O /tmp/ant.zip 'https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.12-bin.zip'
 RUN wget -q -O /tmp/ant-contrib.tgz  https://sourceforge.net/projects/ant-contrib/files/ant-contrib/ant-contrib-1.0b2/ant-contrib-1.0b2-bin.tar.gz
 RUN echo "7e6fbcc3563df4bd87c883ad86a161a71da2774e0ed71a1b3aad82cbff1a7656ed9a0acb5ce40652129376dfd79f1ef74ec3369c1067d412a63062fea62ceccd  /tmp/ant.zip" > /tmp/ant.sha512
@@ -18,7 +24,7 @@ RUN sha512sum --check --strict /tmp/ant.sha512
 RUN ln -s /usr/local/apache-ant-1.10.12/bin/ant /usr/bin/ant
 RUN unzip -q -d /usr/local /tmp/ant.zip
 RUN tar xpfz /tmp/ant-contrib.tgz -C /usr/local/apache-ant-1.10.12/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
-# Clear up space
+# Housekeep Downloaded Archives
 RUN rm /tmp/jdk17.tar.gz /tmp/ant.zip /tmp/ant-contrib.tgz /tmp/jdk17.sig
 # Set up jenkins user
 RUN useradd -m -d /home/jenkins jenkins
@@ -27,10 +33,9 @@ RUN echo "Jenkins_User_SSHKey" > /home/jenkins/.ssh/authorized_keys
 RUN chown -R jenkins /home/jenkins/.ssh
 RUN chmod -R og-rwx /home/jenkins/.ssh
 # RUN service ssh start
+RUN mkdir /var/run/sshd
 CMD ["/usr/sbin/sshd","-D"]
-RUN yum install -y git curl make gcc xorg-x11-server-Xvfb libXrender libXi libXtst procps glibc-langpack-en fontconfig which hostname fakeroot shared-mime-info
-# Install Packages For openssl
-RUN yum -y update && yum install -y openssl gnutls gnutls-utils libnss3.so nss-devel nss-tools
+RUN apt-get install git make gcc xvfb libxrender-dev libxi-dev libxtst-dev fontconfig fakeroot -y
 # ENTRYPOINT /usr/lib/jvm/jdk17/bin/java
-EXPOSE 22
-# Start with docker run -p 2222:22 UUID
+EXPOSE 21
+# Start with docker run -p 2211:22 UUID

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.f39
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.f39
@@ -1,21 +1,15 @@
-FROM debian:bullseye
-# Install Base Requirements
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
-RUN apt-get update && apt-get install -y perl openssh-server unzip zip wget apt-utils gnupg curl
-# Install Packages For OpenSSL pbTestScripts
-RUN apt-get install -y gnutls-bin libnss3 libnss3-dev libnss3-tools pkg-config
-RUN echo "y" | ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -P ""
-RUN apt-get update
+FROM fedora:39
 
+RUN yum -y update && yum install -y perl openssh-server unzip zip wget
+RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -P ""
 # Get latest jdk17 ga
 RUN wget -q 'https://api.adoptium.net/v3/binary/latest/17/ga/linux/x64/jdk/hotspot/normal/eclipse?project=jdk' -O /tmp/jdk17.tar.gz
 RUN gpg --keyserver keyserver.ubuntu.com --recv-keys 3B04D753C9050D9A5D343F39843C48A565F8F04B
 # Get sig file for latest jdk17 ga
 RUN wget -q `curl -s 'https://api.adoptium.net/v3/assets/feature_releases/17/ga?architecture=x64&heap_size=normal&image_type=jdk&jvm_impl=hotspot&os=linux&page=0&page_size=1&project=jdk&vendor=eclipse' | grep signature_link | awk '{split($0,a,"\""); print a[4]}'` -O /tmp/jdk17.sig
 RUN gpg --verify /tmp/jdk17.sig /tmp/jdk17.tar.gz
-
 RUN mkdir -p /usr/lib/jvm/jdk17 && tar -xpzf /tmp/jdk17.tar.gz -C /usr/lib/jvm/jdk17 --strip-components=1
-# Install ant via WGET
+# Install ant 1.10.12
 RUN wget -q -O /tmp/ant.zip 'https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.12-bin.zip'
 RUN wget -q -O /tmp/ant-contrib.tgz  https://sourceforge.net/projects/ant-contrib/files/ant-contrib/ant-contrib-1.0b2/ant-contrib-1.0b2-bin.tar.gz
 RUN echo "7e6fbcc3563df4bd87c883ad86a161a71da2774e0ed71a1b3aad82cbff1a7656ed9a0acb5ce40652129376dfd79f1ef74ec3369c1067d412a63062fea62ceccd  /tmp/ant.zip" > /tmp/ant.sha512
@@ -24,7 +18,7 @@ RUN sha512sum --check --strict /tmp/ant.sha512
 RUN ln -s /usr/local/apache-ant-1.10.12/bin/ant /usr/bin/ant
 RUN unzip -q -d /usr/local /tmp/ant.zip
 RUN tar xpfz /tmp/ant-contrib.tgz -C /usr/local/apache-ant-1.10.12/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
-# Housekeep Downloaded Archives
+# Clear up space
 RUN rm /tmp/jdk17.tar.gz /tmp/ant.zip /tmp/ant-contrib.tgz /tmp/jdk17.sig
 # Set up jenkins user
 RUN useradd -m -d /home/jenkins jenkins
@@ -33,9 +27,10 @@ RUN echo "Jenkins_User_SSHKey" > /home/jenkins/.ssh/authorized_keys
 RUN chown -R jenkins /home/jenkins/.ssh
 RUN chmod -R og-rwx /home/jenkins/.ssh
 # RUN service ssh start
-RUN mkdir /var/run/sshd
 CMD ["/usr/sbin/sshd","-D"]
-RUN apt-get install git make gcc xvfb libxrender-dev libxi-dev libxtst-dev fontconfig fakeroot -y
+RUN yum install -y git curl make gcc xorg-x11-server-Xvfb libXrender libXi libXtst procps glibc-langpack-en fontconfig which hostname fakeroot shared-mime-info
+# Install Packages For openssl
+RUN yum -y update && yum install -y openssl gnutls gnutls-utils nss-devel nss-tools
 # ENTRYPOINT /usr/lib/jvm/jdk17/bin/java
-EXPOSE 21
-# Start with docker run -p 2211:22 UUID
+EXPOSE 22
+# Start with docker run -p 2222:22 UUID

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.u2310
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.u2310
@@ -1,0 +1,44 @@
+FROM ubuntu:23.10
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -qq -y perl openssh-server unzip zip gnupg curl
+
+# Get latest jdk17 ga
+RUN wget -q 'https://api.adoptium.net/v3/binary/latest/17/ga/linux/x64/jdk/hotspot/normal/eclipse?project=jdk' -O /tmp/jdk17.tar.gz
+RUN gpg --keyserver keyserver.ubuntu.com --recv-keys 3B04D753C9050D9A5D343F39843C48A565F8F04B
+# Get sig file for latest jdk17 ga
+RUN wget -q `curl -s 'https://api.adoptium.net/v3/assets/feature_releases/17/ga?architecture=x64&heap_size=normal&image_type=jdk&jvm_impl=hotspot&os=linux&page=0&page_size=1&project=jdk&vendor=eclipse' | grep signature_link | awk '{split($0,a,"\""); print a[4]}'` -O /tmp/jdk17.sig
+RUN gpg --verify /tmp/jdk17.sig /tmp/jdk17.tar.gz
+RUN mkdir -p /usr/lib/jvm/jdk17 && tar -xpzf /tmp/jdk17.tar.gz -C /usr/lib/jvm/jdk17 --strip-components=1
+
+# Install ant
+RUN wget -q -O /tmp/ant.zip 'https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.zip'
+RUN wget -q -O /tmp/ant-contrib.tgz  https://sourceforge.net/projects/ant-contrib/files/ant-contrib/ant-contrib-1.0b2/ant-contrib-1.0b2-bin.tar.gz
+RUN echo "2e48f9e429d67708f5690bc307232f08440d01ebe414059292b6543971da9c7cd259c21533b9163b4dd753321c17bd917adf8407d03245a0945fc30a4e633163  /tmp/ant.zip" > /tmp/ant.sha512
+RUN echo "0fd2771dca2b8b014a4cb3246715b32e20ad5d26754186d82eee781507a183d5e63064890b95eb27c091c93c1209528a0b18a6d7e6901899319492a7610e74ad  /tmp/ant-contrib.tgz" >> /tmp/ant.sha512
+RUN sha512sum --check --strict /tmp/ant.sha512
+RUN ln -s /usr/local/apache-ant-1.10.5/bin/ant /usr/bin/ant
+RUN unzip -q -d /usr/local /tmp/ant.zip
+RUN tar xpfz /tmp/ant-contrib.tgz -C /usr/local/apache-ant-1.10.5/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
+
+# Clear up space
+RUN rm /tmp/jdk17.tar.gz /tmp/ant.zip /tmp/ant-contrib.tgz /tmp/jdk17.sig
+
+# Set up jenkins user
+RUN useradd -m -d /home/jenkins jenkins
+RUN mkdir /home/jenkins/.ssh
+RUN echo "Jenkins_User_SSHKey" > /home/jenkins/.ssh/authorized_keys
+RUN chown -R jenkins /home/jenkins/.ssh
+RUN chmod -R og-rwx /home/jenkins/.ssh
+
+RUN service ssh start
+CMD ["/usr/sbin/sshd","-D"]
+
+RUN apt-get update && apt-get install -qq -y git curl make gcc xvfb libxrender1 libxi6 libxtst6 locales fontconfig fakeroot
+# Install SSL Test packages
+RUN apt-get install -qq -y gnutls-bin libnss3 libnss3-tools libnss3-dev pkg-config
+
+RUN locale-gen en_US.utf8
+
+EXPOSE 22
+# Start with docker run -p 2226:22 UUID

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
@@ -1,26 +1,36 @@
 ---
 
-# - name: debug from deploy - task 1
-#   debug:
-#     msg: "{{ docker_image }}"
-
-# - name: task 2
-#   debug:
-#     msg: " Hello "
-
-# - name: task 3
-#   debug:
-#     msg: "{{ arch }} + {{ os }}"
-
-
-- name: Find free port
-
 - name: Transfer dockerfile
+  copy:
+    src: Dockerfiles/
+    dest: /tmp/Dockerfiles/Dockerfile.{{ docker_image }}
 
-- name: build docker images
-  command: docker build --cpu-period=100000 --cpu-quota=800000 -t aqa_{{ item }} --memory=6G -f /tmp/Dockerfiles/Dockerfile.Dockerfile{{ docker_image }} /tmp/Dockerfiles
+- name: Translate architecture in dockerfiles
+  replace:
+    dest: /tmp/Dockerfiles/Dockerfile.{{ docker_image }}
+    regexp: "arch=x64"
+    replace: "arch={{ ansible_architecture }}"
+  when: ansible_architecture != "x86_64"
 
-- name: run container
-  command: docker run --restart unless-stopped -p {{ port }}:22 --cpuset-cpus="0-3" --memory=6G --detach --name {{ docker_image }}.{{ port }} aqa_{{ docker_image }}
+- name: Set jenkins authorized_Key in dockerfiles
+  replace:
+    dest:  /tmp/Dockerfiles/Dockerfile.{{ docker_image }}
+    regexp: "Jenkins_User_SSHKey"
+    replace: "{{ Jenkins_User_SSHKey }}"
+
+- name: Build {{ docker_image }} docker images
+  command: docker build --cpu-period=100000 --cpu-quota=800000 -t aqa_{{ item }} --memory=6G -f /tmp/Dockerfiles/Dockerfile.{{ docker_image }} /tmp/Dockerfiles
+
+# Without specifying a port here, docker will give the container a random unused port
+- name: Run {{ docker_image }} docker container
+  command: docker run --restart unless-stopped -p 22 --cpuset-cpus="0-3" --memory=6G --detach --name {{ docker_image | upper }}.PORT aqa_{{ docker_image }}
+
+# Now we want to rename the running container with the port name
+- name: Find assigned port of {{ docker_image }} container
+  command: docker port {{ docker_image | upper }}.PORT | head -n 1 | cut -d ':' -f 2
+  register: docker_port
+
+- name: Rename {{ docker_image }} container to {{ docker_image | upper }}.{{ docker_port.stdout_lines[0] }}
+  command: docker rename {{ docker_image | upper }}.PORT {{ docker_image | upper }}.{{ docker_port.stdout_lines[0] }}
 
 # - name: run python file which creates jenkins node

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
@@ -32,5 +32,3 @@
 
 - name: Rename {{ docker_image }} container to {{ docker_image | upper }}.{{ docker_port.stdout_lines[0] }}
   command: docker rename {{ docker_image | upper }}.PORT {{ docker_image | upper }}.{{ docker_port.stdout_lines[0] }}
-
-# - name: run python file which creates jenkins node

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
@@ -1,10 +1,11 @@
 ---
-
+# Dockerfiles are transferred from the controller node onto the dockerhost to be used to build and run docker containers
 - name: Transfer dockerfile
   copy:
     src: "roles/DockerStatic/Dockerfiles/Dockerfile.{{ docker_image }}"
     dest: "/tmp/Dockerfile.{{ docker_image }}"
 
+# For images built on non x86_64 dockerhosts
 - name: Translate architecture in dockerfile
   replace:
     dest: /tmp/Dockerfile.{{ docker_image }}

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
@@ -5,7 +5,7 @@
     src: "roles/DockerStatic/Dockerfiles/Dockerfile.{{ docker_image }}"
     dest: "/tmp/Dockerfiles/Dockerfile.{{ docker_image }}"
 
-- name: Translate architecture in dockerfiles
+- name: Translate architecture in dockerfile
   replace:
     dest: /tmp/Dockerfiles/Dockerfile.{{ docker_image }}
     regexp: "arch=x64"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
@@ -2,8 +2,8 @@
 
 - name: Transfer dockerfile
   copy:
-    src: DockerStatic/Dockerfiles/Dockerfile.{{ docker_image }}
-    dest: /tmp/Dockerfiles/Dockerfile.{{ docker_image }}
+    src: "roles/DockerStatic/Dockerfiles/Dockerfile.{{ docker_image }}"
+    dest: "/tmp/Dockerfiles/Dockerfile.{{ docker_image }}"
 
 - name: Translate architecture in dockerfiles
   replace:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
@@ -2,7 +2,7 @@
 
 - name: Transfer dockerfile
   copy:
-    src: Dockerfiles/
+    src: DockerStatic/Dockerfiles/
     dest: /tmp/Dockerfiles/Dockerfile.{{ docker_image }}
 
 - name: Translate architecture in dockerfiles

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
@@ -19,7 +19,7 @@
     replace: "{{ Jenkins_User_SSHKey }}"
 
 - name: Build {{ docker_image }} docker images
-  command: docker build --cpu-period=100000 --cpu-quota=800000 -t aqa_{{ item }} --memory=6G -f /tmp/Dockerfiles/Dockerfile.{{ docker_image }} /tmp/Dockerfiles
+  command: docker build --cpu-period=100000 --cpu-quota=800000 -t aqa_{{ docker_image }} --memory=6G -f /tmp/Dockerfiles/Dockerfile.{{ docker_image }} /tmp/Dockerfiles
 
 # Without specifying a port here, docker will give the container a random unused port
 - name: Run {{ docker_image }} docker container

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
@@ -2,7 +2,7 @@
 
 - name: Transfer dockerfile
   copy:
-    src: DockerStatic/Dockerfiles/
+    src: DockerStatic/Dockerfiles/Dockerfile.{{ docker_image }}
     dest: /tmp/Dockerfiles/Dockerfile.{{ docker_image }}
 
 - name: Translate architecture in dockerfiles

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
@@ -3,23 +3,23 @@
 - name: Transfer dockerfile
   copy:
     src: "roles/DockerStatic/Dockerfiles/Dockerfile.{{ docker_image }}"
-    dest: "/tmp/Dockerfiles/Dockerfile.{{ docker_image }}"
+    dest: "/tmp/Dockerfile.{{ docker_image }}"
 
 - name: Translate architecture in dockerfile
   replace:
-    dest: /tmp/Dockerfiles/Dockerfile.{{ docker_image }}
+    dest: /tmp/Dockerfile.{{ docker_image }}
     regexp: "arch=x64"
     replace: "arch={{ ansible_architecture }}"
   when: ansible_architecture != "x86_64"
 
 - name: Set jenkins authorized_Key in dockerfiles
   replace:
-    dest: /tmp/Dockerfiles/Dockerfile.{{ docker_image }}
+    dest: /tmp/Dockerfile.{{ docker_image }}
     regexp: "Jenkins_User_SSHKey"
     replace: "{{ Jenkins_User_SSHKey }}"
 
 - name: Build {{ docker_image }} docker images
-  command: docker build --cpu-period=100000 --cpu-quota=800000 -t aqa_{{ docker_image }} --memory=6G -f /tmp/Dockerfiles/Dockerfile.{{ docker_image }} /tmp/Dockerfiles
+  command: docker build --cpu-period=100000 --cpu-quota=800000 -t aqa_{{ docker_image }} --memory=6G -f /tmp/Dockerfile.{{ docker_image }} /tmp/
 
 # Without specifying a port here, docker will give the container a random unused port
 - name: Run {{ docker_image }} docker container

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
@@ -14,7 +14,7 @@
 
 - name: Set jenkins authorized_Key in dockerfiles
   replace:
-    dest:  /tmp/Dockerfiles/Dockerfile.{{ docker_image }}
+    dest: /tmp/Dockerfiles/Dockerfile.{{ docker_image }}
     regexp: "Jenkins_User_SSHKey"
     replace: "{{ Jenkins_User_SSHKey }}"
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
@@ -1,0 +1,26 @@
+---
+
+# - name: debug from deploy - task 1
+#   debug:
+#     msg: "{{ docker_image }}"
+
+# - name: task 2
+#   debug:
+#     msg: " Hello "
+
+# - name: task 3
+#   debug:
+#     msg: "{{ arch }} + {{ os }}"
+
+
+- name: Find free port
+
+- name: Transfer dockerfile
+
+- name: build docker images
+  command: docker build --cpu-period=100000 --cpu-quota=800000 -t aqa_{{ item }} --memory=6G -f /tmp/Dockerfiles/Dockerfile.Dockerfile{{ docker_image }} /tmp/Dockerfiles
+
+- name: run container
+  command: docker run --restart unless-stopped -p {{ port }}:22 --cpuset-cpus="0-3" --memory=6G --detach --name {{ docker_image }}.{{ port }} aqa_{{ docker_image }}
+
+# - name: run python file which creates jenkins node

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
@@ -8,8 +8,8 @@
 - name: Translate architecture in dockerfile
   replace:
     dest: /tmp/Dockerfile.{{ docker_image }}
-    regexp: "arch=x64"
-    replace: "arch={{ ansible_architecture }}"
+    regexp: "x64"
+    replace: "{{ ansible_architecture }}"
   when: ansible_architecture != "x86_64"
 
 - name: Set jenkins authorized_Key in dockerfiles
@@ -27,7 +27,7 @@
 
 # Now we want to rename the running container with the port name
 - name: Find assigned port of {{ docker_image }} container
-  command: docker port {{ docker_image | upper }}.PORT | head -n 1 | cut -d ':' -f 2
+  shell: docker port {{ docker_image | upper }}.PORT | head -n 1 | cut -d ':' -f 2
   register: docker_port
 
 - name: Rename {{ docker_image }} container to {{ docker_image | upper }}.{{ docker_port.stdout_lines[0] }}

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
@@ -4,7 +4,7 @@
   set_fact:
     docker_images_list: "{{ docker_images.split(',') | list }}"
 
-- name: Check if dockerfiles exist
+- name: Check if dockerfile exists
   stat:
     path: "DockerStatic/Dockerfiles/Dockerfile.{{ item }}"
   loop: "{{ docker_images_list }}"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: Check if dockerfile exists
   stat:
-    path: "DockerStatic/Dockerfiles/Dockerfile.{{ item }}"
+    path: "../../DockerStatic/Dockerfiles/Dockerfile.{{ item }}"
   loop: "{{ docker_images_list }}"
   register: dockerfiles_exist
 
@@ -16,7 +16,7 @@
 
 - name: Fail if dockerfile does not exist
   fail:
-    msg: "{{ item.stat.path }} does not exist"
+    msg: "{{ item.invocation.module_args.path }} does not exist"
   when: not item.stat.exists
   loop: "{{ dockerfiles_exist.results }}"
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
@@ -11,10 +11,6 @@
   loop: "{{ docker_images_list }}"
   register: dockerfiles_exist
 
-- name: Debug, print dockerfiles_exist
-  debug:
-    msg: "{{ dockerfiles_exist }}"
-
 - name: Fail if dockerfile does not exist
   fail:
     msg: "{{ item.invocation.module_args.path }} does not exist"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
@@ -5,8 +5,9 @@
     docker_images_list: "{{ docker_images.split(',') | list }}"
 
 - name: Check if dockerfile exists
+  delegate_to: localhost
   stat:
-    path: "../../DockerStatic/Dockerfiles/Dockerfile.{{ item }}"
+    path: "DockerStatic/Dockerfiles/Dockerfile.{{ item }}"
   loop: "{{ docker_images_list }}"
   register: dockerfiles_exist
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Check if dockerfile exists
   delegate_to: localhost
   stat:
-    path: "DockerStatic/Dockerfiles/Dockerfile.{{ item }}"
+    path: "../../DockerStatic/Dockerfiles/Dockerfile.{{ item }}"
   loop: "{{ docker_images_list }}"
   register: dockerfiles_exist
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
-
+# This task verifies the docker_images arguments passed into the playbook
+# Then runs the deploy.yml task to build and run each image on the dockerhost
 - name: Set docker images list variable
   set_fact:
     docker_images_list: "{{ docker_images.split(',') | list }}"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
@@ -16,8 +16,8 @@
   when: not item.stat.exists
   loop: "{{ dockerfiles_exist.results }}"
 
-- name: Run deploy.yml for every docker image
-  include_tasks: deploy.yml
-  loop: "{{ docker_images_list }}"
-  loop_control:
-    loop_var: docker_image
+# - name: Run deploy.yml for every docker image
+#   include_tasks: deploy.yml
+#   loop: "{{ docker_images_list }}"
+#   loop_control:
+#     loop_var: docker_image

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
@@ -4,15 +4,6 @@
   set_fact:
     docker_images_list: "{{ docker_images.split(',') | list }}"
 
-- name: PWD
-  delegate_to: localhost
-  command: pwd
-  register: PWD
-
-- name: Print PWD output
-  debug:
-    msg: "{{ PWD.stdout }}"
-
 - name: Check if dockerfile exists
   delegate_to: localhost
   stat:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
@@ -1,30 +1,22 @@
 ---
 
-# This is a wrapper, this role with run a sub role (one which actually builds and runs the container)
-# It will loop the sub role depending on the number of containers the user wants to build
-
-# Does there exist a dockerfile of the chosen OS?
-- name: Verify passed variables
-  debug:
-    msg: "{{ docker_images }}"
-
-# List of docker images to create
-- name: set docker images list
+- name: Set docker images list variable
   set_fact:
     docker_images_list: "{{ docker_images.split(',') | list }}"
 
-# - name: print docker_images_list
-#   debug:
-#     msg: "{{ item }}"
-#   loop: "{{ docker_images_list }}"
+- name: Check if dockerfiles exist
+  stat:
+    path: "DockerStatic/Dockerfiles/Dockerfile.{{ item }}"
+  loop: "{{ docker_images_list }}"
+  register: dockerfiles_exist
 
-- name: Set variables (architecture etc) to be put into dockerfile
-  
-  # set_fact:
-  #   arch: armv7
-  #   os: ubuntu
+- name: Fail if dockerfile does not exist
+  fail:
+    msg: "{{ item.stat.path }} does not exist"
+  when: not item.stat.exists
+  loop: "{{ dockerfiles_exist.results }}"
 
-- name: run deploy.yml with variables
+- name: Run deploy.yml for every docker image
   include_tasks: deploy.yml
   loop: "{{ docker_images_list }}"
   loop_control:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
@@ -4,6 +4,15 @@
   set_fact:
     docker_images_list: "{{ docker_images.split(',') | list }}"
 
+- name: PWD
+  delegate_to: localhost
+  command: pwd
+  register: PWD
+
+- name: Print PWD output
+  debug:
+    msg: "{{ PWD.stdout }}"
+
 - name: Check if dockerfile exists
   delegate_to: localhost
   stat:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Check if dockerfile exists
   delegate_to: localhost
   stat:
-    path: "../../DockerStatic/Dockerfiles/Dockerfile.{{ item }}"
+    path: "../DockerStatic/Dockerfiles/Dockerfile.{{ item }}"
   loop: "{{ docker_images_list }}"
   register: dockerfiles_exist
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
@@ -16,7 +16,7 @@
 - name: Check if dockerfile exists
   delegate_to: localhost
   stat:
-    path: "../DockerStatic/Dockerfiles/Dockerfile.{{ item }}"
+    path: "roles/DockerStatic/Dockerfiles/Dockerfile.{{ item }}"
   loop: "{{ docker_images_list }}"
   register: dockerfiles_exist
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
@@ -17,8 +17,8 @@
   when: not item.stat.exists
   loop: "{{ dockerfiles_exist.results }}"
 
-# - name: Run deploy.yml for every docker image
-#   include_tasks: deploy.yml
-#   loop: "{{ docker_images_list }}"
-#   loop_control:
-#     loop_var: docker_image
+- name: Run deploy.yml for every docker image
+  include_tasks: deploy.yml
+  loop: "{{ docker_images_list }}"
+  loop_control:
+    loop_var: docker_image

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
@@ -11,8 +11,8 @@
   register: dockerfiles_exist
 
 - name: Debug, print dockerfiles_exist
-  msg:
-    debug: "{{ dockerfiles_exist }}"
+  debug:
+    msg: "{{ dockerfiles_exist }}"
 
 - name: Fail if dockerfile does not exist
   fail:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+
+# This is a wrapper, this role with run a sub role (one which actually builds and runs the container)
+# It will loop the sub role depending on the number of containers the user wants to build
+
+# Does there exist a dockerfile of the chosen OS?
+- name: Verify passed variables
+  debug:
+    msg: "{{ docker_images }}"
+
+# List of docker images to create
+- name: set docker images list
+  set_fact:
+    docker_images_list: "{{ docker_images.split(',') | list }}"
+
+# - name: print docker_images_list
+#   debug:
+#     msg: "{{ item }}"
+#   loop: "{{ docker_images_list }}"
+
+- name: Set variables (architecture etc) to be put into dockerfile
+  
+  # set_fact:
+  #   arch: armv7
+  #   os: ubuntu
+
+- name: run deploy.yml with variables
+  include_tasks: deploy.yml
+  loop: "{{ docker_images_list }}"
+  loop_control:
+    loop_var: docker_image

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/main.yml
@@ -10,6 +10,10 @@
   loop: "{{ docker_images_list }}"
   register: dockerfiles_exist
 
+- name: Debug, print dockerfiles_exist
+  msg:
+    debug: "{{ dockerfiles_exist }}"
+
 - name: Fail if dockerfile does not exist
   fail:
     msg: "{{ item.stat.path }} does not exist"


### PR DESCRIPTION
- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/3370

New playbook added `dockernode.yml `which will deploy any number of specified containers onto a chosen dockerhost machine. Example usage: (will add to docs)

```
ansible-playbook AdoptOpenJDK_Unix_Playbook/dockernode.yml -t deploy -e "docker_images=u2204,alp314,deb11"
```

The `deploy` tag must be specified if the user wants to deploy a container. The `docker_images` variable will contain a list of chosen OSs for which we have dockerfiles (error is handled when dockerfile does not exist).

I am testing this at the moment in awx. Once successful we can remove the container build and deploy functionality in https://github.com/adoptium/infrastructure/blob/master/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/tasks/main.yml and leave the `dockerhost.yml` playbook for setting up dockerhost machines only, and use the new `dockernode.yml` playbook for deploying containers