### PR TITLE
inventory: remove more macstadium VMs

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -52,9 +52,6 @@ hosts:
       - equinix_esxi:
           solaris10-x64-1: {ip: 145.40.115.43}
 
-      - macstadium:
-          macos1014-x64-1: {ip: 208.83.1.170, user: Administrator, description: G3B i7-4C/16G/250G}
-
       - marist:
           rhel79-s390x-1: {ip: 148.100.75.212, user: linux1}
           rhel79-s390x-2: {ip: 148.100.74.54, user: linux1}
@@ -147,7 +144,6 @@ hosts:
 
       - macstadium:
           macos1014-x64-1: {ip: 207.254.29.43, user: administrator, description: G3B i7/4C/16G/250G}
-          macos11-arm64-2: {ip: 199.7.163.52, user: Administrator, description: G5A M1/8C/8G/256G}
 
       - marist:
           rhel7-s390x-2: {ip: 148.100.74.92}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
