### PR TITLE
inventory: Add dockerhost-osuosl-ubuntu2204-aarch64-1 to inventory.yml

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -94,6 +94,7 @@ hosts:
 
       - osuosl:
           ubuntu2004-ppc64le-1: {ip: 140.211.168.214}
+          ubuntu2204-aarch64-1: {ip: 140.211.167.67}
 
       - marist:
           ubuntu2204-s390x-1: {ip: 148.100.74.237, user: linux1}


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/2991