### PR TITLE
Unbreak aarch64 dockerbuild under Ubuntu 22.04

### DIFF
--- a/ansible/docker/Dockerfile.Ubuntu2204
+++ b/ansible/docker/Dockerfile.Ubuntu2204
@@ -18,7 +18,6 @@ RUN rm -rf /ansible
 
 RUN groupadd -g 1000 ${user}
 RUN useradd -c "Jenkins user" -d /home/${user} -u 1000 -g 1000 -m ${user}
-RUN mv /bin/uname /bin/uname.real && echo "/bin/uname.real \$@ | sed 's/aarch64/armv7l/g'" > /bin/uname && chmod 755 /bin/uname
 
 ENV \
     JDK7_BOOT_DIR="/usr/lib/jvm/jdk8" \


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

This line should only ever have been in the ubuntu 16.04 one as it's the image we use for arm32. Anyone building a later image should have it able to work on aarch64.