### PR TITLE
docker: Use JDK17 for SLES dockerfiles

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.sles12
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.sles12
@@ -4,9 +4,9 @@ RUN zypper ar https://download.opensuse.org/distribution/leap/15.4/repo/oss/ sle
 RUN zypper --gpg-auto-import-keys refresh
 RUN zypper update -y && zypper install -y wget perl openssh-server unzip zip tar gzip
 
-RUN wget 'https://api.adoptium.net/v3/binary/latest/11/ga/linux/s390x/jdk/hotspot/normal/eclipse?project=jdk' -O /tmp/jdk11.tar.gz
-RUN mkdir -p /usr/lib/jvm/jdk11 && tar -xpzf /tmp/jdk11.tar.gz -C /usr/lib/jvm/jdk11 --strip-components=1
-RUN ln -s /usr/lib/jvm/jdk11/bin/java /usr/bin/java
+RUN wget 'https://api.adoptium.net/v3/binary/latest/17/ga/linux/x64/jdk/hotspot/normal/eclipse?project=jdk' -O /tmp/jdk17.tar.gz
+RUN mkdir -p /usr/lib/jvm/jdk17 && tar -xpzf /tmp/jdk17.tar.gz -C /usr/lib/jvm/jdk17 --strip-components=1
+RUN ln -s /usr/lib/jvm/jdk17/bin/java /usr/bin/java
 
 # Install ant
 RUN wget -q -O /tmp/ant.zip 'https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.zip'
@@ -19,7 +19,7 @@ RUN unzip -q -d /usr/local /tmp/ant.zip
 RUN tar xpfz /tmp/ant-contrib.tar.gz -C /usr/local/apache-ant-1.10.5/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
 
 # Clear up space
-RUN rm /tmp/jdk11.tar.gz /tmp/ant.zip /tmp/ant-contrib.tar.gz
+RUN rm /tmp/jdk17.tar.gz /tmp/ant.zip /tmp/ant-contrib.tar.gz
 
 # Set up jenkins user
 RUN useradd -m -d /home/jenkins jenkins

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.sles15
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.sles15
@@ -3,9 +3,9 @@ FROM registry.suse.com/suse/sle15
 RUN zypper addrepo https://download.opensuse.org/distribution/leap/15.4/repo/oss/ "Main Repository" && zypper --gpg-auto-import-keys refresh
 RUN zypper update -y && zypper install -y perl openssh-server unzip zip wget tar gzip
 
-RUN wget 'https://api.adoptium.net/v3/binary/latest/11/ga/linux/s390x/jdk/hotspot/normal/eclipse?project=jdk' -O /tmp/jdk11.tar.gz
-RUN mkdir -p /usr/lib/jvm/jdk11 && tar -xpzf /tmp/jdk11.tar.gz -C /usr/lib/jvm/jdk11 --strip-components=1
-RUN ln -s /usr/lib/jvm/jdk11/bin/java /usr/bin/java
+RUN wget 'https://api.adoptium.net/v3/binary/latest/17/ga/linux/x64/jdk/hotspot/normal/eclipse?project=jdk' -O /tmp/jdk17.tar.gz
+RUN mkdir -p /usr/lib/jvm/jdk17 && tar -xpzf /tmp/jdk17.tar.gz -C /usr/lib/jvm/jdk17 --strip-components=1
+RUN ln -s /usr/lib/jvm/jdk17/bin/java /usr/bin/java
 
 # Install ant
 RUN wget -q -O /tmp/ant.zip 'https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.zip'
@@ -18,7 +18,7 @@ RUN unzip -q -d /usr/local /tmp/ant.zip
 RUN tar xpfz /tmp/ant-contrib.tar.gz -C /usr/local/apache-ant-1.10.5/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
 
 # Clear up space
-RUN rm /tmp/jdk11.tar.gz /tmp/ant.zip /tmp/ant-contrib.tar.gz
+RUN rm /tmp/jdk17.tar.gz /tmp/ant.zip /tmp/ant-contrib.tar.gz
 
 # Set up jenkins user
 RUN useradd -m -d /home/jenkins jenkins


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Use JDK17 for the java agent. Use the x64 binary in the dockerfile. The dockernode playbook will change the architecture if needed