### PR TITLE
adds roles xcode_offline and brew to Unix_Playbook

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode_offline/files/.place_holder
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode_offline/files/.place_holder
@@ -1,0 +1,4 @@
+download and copy (soft link) xcode offline files heare:
+Xcode_12.4.xip
+Xcode_13.1.xip
+etc.

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode_offline/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode_offline/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+#########################
+# Xcdde offline install #
+#########################
+
+# Install Xcode withou need to login with appleID 
+# Path /Applications/Xcode.app/ 
+# Requires the following variable:
+#  xcode_version: 12.4 | 13.1 | 13.2.1 | 13.4 | 14.3.1 | 15.0.1
+
+- name: xcode offline
+  include_tasks: xcode_offline.yml
+  tags: xcode_offline

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode_offline/tasks/xcode_offline.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode_offline/tasks/xcode_offline.yml
@@ -1,0 +1,49 @@
+---
+- name: check xcode version
+  shell: xcodebuild -version
+  register: xcodebuild_version
+  failed_when: false
+  tags: xcode_offline
+
+- name: install and configure xcode if not installed
+  block:
+
+    - name: test tag
+      debug:
+        var: xcodebuild_version
+
+    - name: copy xcode file to remote host 
+      copy: 
+        src: Xcode_{{ xcode_version }}.xip
+        dest: '~'
+        force: false
+
+    - name: install xcode {{ xcode_version }}
+      shell: |
+        xip -x ~/Xcode_{{ xcode_version }}.xip
+      args:
+        chdir: /Applications
+      become: yes
+      become_user: "{{ ansible_user }}"
+
+    - name: Configure xcode {{ xcode_version }}
+      become: yes
+      shell: |
+        xcode-select -s /Applications/Xcode.app/Contents/Developer
+        xcodebuild -license accept
+
+    - name: Clean up after install Xcode
+      shell: |
+        rm ~/Xcode_{{ xcode_version }}.xip
+
+    - name: check xcode version
+      shell: xcodebuild -version
+      register: output
+      ignore_errors: true
+
+    - name: check if xcode version is correct
+      debug: 
+        var: output 
+  
+  when: "'Xcode ' + xcode_version not in xcodebuild_version.stdout"
+  tags: xcode_offline

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/brew/tasks/brew.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/brew/tasks/brew.yml
@@ -1,0 +1,83 @@
+---
+
+- name: Check if Homebrew is already installed
+  stat:
+    path: /usr/local/bin/brew
+  register: b
+  when: ansible_architecture == "x86_64"
+  tags: brew
+
+- name: Check if Homebrew is already installed
+  stat:
+    path: /opt/homebrew/bin/brew
+  register: b
+  when: ansible_architecture == "arm64"
+  tags: brew
+
+- set_fact: brew_is_installed="{{b.stat.exists}}"
+  when: b.stat.exists is defined
+  tags: brew
+
+- name: install home brew
+  block:
+    - name: add user j9admin to sudoers
+      template:
+        src: sudoers
+        dest: /etc/sudoers.d/{{ ansible_user }}
+      become: true
+
+    - name: install home brew
+      shell: |
+        NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+
+    - name: check brew installation
+      shell: /usr/local/bin/brew --version
+      register: check_brew
+      ignore_errors: true
+      when: ansible_architecture == "x86_64"
+
+    - set_fact: brew_is_installed="{{check_brew.rc == 0}}"
+      when: check_brew.rc is defined
+
+    - name: check brew installation
+      shell: /opt/homebrew/bin/brew --version
+      register: check_brew
+      ignore_errors: true
+      when: ansible_architecture == "arm64"
+
+    - set_fact: brew_is_installed="{{check_brew.rc == 0}}"
+      when: check_brew.rc is defined
+
+    - name: failed brew installation
+      fail:
+        msg: 'brew is not installed! exiting...'
+      when: not brew_is_installed 
+
+    - name: configure brew x86_64
+      blockinfile:
+        state: present
+        insertafter: EOF
+        dest: ~/.zprofile
+        marker: "<!-- added by Ansible -->"
+        content: |
+          eval $(/usr/local/bin/brew shellenv)
+      when: ansible_architecture == "x86_64"
+
+    - name: configure brew arm64
+      blockinfile:
+        state: present
+        insertafter: EOF
+        dest: ~/.zprofile
+        marker: "<!-- added by Ansible -->"
+        content: |
+          eval $(/opt/homebrew/bin/brew shellenv)
+      when: ansible_architecture == "arm64"
+
+    - name: remove user j9admin from sudoers
+      file:
+        path: /etc/sudoers.d/{{ ansible_user }}
+        state: absent
+      become: true
+
+  when: not brew_is_installed
+  tags: brew

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/brew/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/brew/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+########
+# brew #
+########
+
+- name: Install homebrew
+  include_tasks: brew.yml
+  when: ansible_distribution == "MacOSX"
+  tags: brew
+  

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/brew/templates/sudoers
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/brew/templates/sudoers
@@ -1,0 +1,1 @@
+{{ ansible_user }} ALL=(ALL) NOPASSWD: ALL


### PR DESCRIPTION
The new Xcode_offline role will install xcode from an offline copy in /files dire. The brew role also will install brew on macos. Both rely on installing python on mac machine in advance.


##### Checklist
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)

