### PR TITLE
UnixPB: Update NTPD task to restart ntpd service on CentOS correctly

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NTP_TIME/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NTP_TIME/tasks/main.yml
@@ -45,7 +45,7 @@
   when:
     - (ansible_distribution == "RedHat" and ansible_distribution_major_version != "8") or
       (ansible_distribution == "SLES" and ansible_distribution_major_version == "12") or
-      (ansible_distribution == "centos" and ansible_distribution_major_version == "7" )
+      (ansible_distribution == "CentOS" and ansible_distribution_major_version == "7" )
   tags: ntp_time
 
 - name: Start NTP for SUSE12


### PR DESCRIPTION
Fixes #3411 

VPC Completed OK : https://ci.adoptium.net/job/VagrantPlaybookCheck/1833/
CentOS 7 playbook restarts the service now.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)

