### PR TITLE
awx: add requirements.yml for galaxy roles

### DIFF
--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -1,0 +1,6 @@
+---
+# Required by AWX for the homebrew and zypper operations
+# in curl/GIT_Source roles
+collections:
+  - name: community.general
+    source: https://galaxy.ansible.com


### PR DESCRIPTION
Some of our roles (`curl` and `GIT_Source`) are trying to use things from ansible galaxy - `homebrew` and `zypper` specifically - which are not available by default, so they fail from AWX when you try to sync the project.

This configuration file, based on the information in https://docs.ansible.com/ansible-tower/3.8.4/html/userguide/projects.html#ansible-galaxy-support, allows us to use the common modules from Ansible Galaxy. Note that this requires `Enable Collection(s) Download` to be set on in the Settings -> Jobs Settings section of the UI (Only available to 
`admin`)

Related to https://github.com/adoptium/infrastructure/issues/3339#issuecomment-1959711161

Testing at https://awx.adoptium.net/#/jobs/playbook/122/output - since it's got past the initial failure at the start (see below) this should be ok to merge now.

```
ERROR! couldn't resolve module/action 'homebrew'. This often indicates a misspelling, missing collection, or incorrect module path.
The error appears to be in '/runner/project/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/curl/tasks/main.yml': line 121, column 3, but may
be elsewhere in the file depending on the exact syntax problem.
The offending line appears to be:
- name: Install latest version of curl for MacOS
  ^ here
```

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
