### PR TITLE
inventory: add Azure x64 awx.adoptium.net

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -14,6 +14,7 @@ hosts:
           ubuntu2004-x64-1: {ip: 40.121.206.1, user: webmaster, description: jckservices.adoptium.net}
           ubuntu2204-x64-1: {ip: 172.187.163.163, user: adoptopenjdk, description: infra-wazuh-server}
           ubuntu2204-x64-2: {ip: 20.90.182.165, description: trss.adoptium.net}
+          ubuntu2204-x64-3: {ip: 172.187.93.97, description: awx.adoptium.net}
 
       - digitalocean:
           ubuntu2004-x64-1: {ip: 178.62.115.224, description: bastillion.adoptopenjdk.net}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

Ref: https://github.com/adoptium/infrastructure/issues/3339
It's possible we'll switch over to an aarch64 host for this since that should now work, but for now this is the live server and where the DNS entry points to.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
