### PR TITLE
unixPB: Clean_Up role: remove warn: no

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Clean_Up/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Clean_Up/tasks/main.yml
@@ -20,8 +20,6 @@
 
 - name: Remove yum dependencies that are no longer required - RedHat and CentOS
   command: yum -y autoremove
-  args:
-    warn: no
   when:
     - (ansible_distribution == "RedHat" and ansible_distribution_major_version != "6") or (ansible_distribution == "CentOS" and ansible_distribution_major_version != "6")
     - ansible_architecture != "aarch64"


### PR DESCRIPTION
This syntax is invalid and does not work with the new AWX server
Fixes https://github.com/adoptium/infrastructure/issues/3425

While there may be a better solution here, this will allow the deployments to continue to succeed ... I've tested this in a separate AWX template

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
