### PR TITLE
[ansible] Download cross-build jdk11u from CI

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -107,7 +107,6 @@
       when:
         - (ansible_distribution != "Alpine" or ansible_architecture != "aarch64")
         - ansible_distribution != "Solaris"
-        - ansible_architecture != "riscv64"
       tags: build_tools
     - role: adoptopenjdk_install  # Previous LTS
       jdk_version: 17

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
@@ -134,7 +134,7 @@
     - ansible_distribution != "MacOSX"
     - not ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and ansible_distribution_major_version == "6")
     - ansible_os_family != "Solaris"
-    - not (ansible_architecture == "riscv64" and (jdk_version == 21 or jdk_version == 19 or jdk_version == 17)) # Linux-riscv64 for JDK 17, 19, 21 are special cased
+    - not (ansible_architecture == "riscv64" and (jdk_version == 21 or jdk_version == 19 or jdk_version == 17 or jdk_version == 11)) # Linux-riscv64 for JDK 11, 17, 19, 21 are special cased
     - adoptopenjdk_installed.rc != 0
   tags: adoptopenjdk_install
     # Api does not return release information for JDK10
@@ -263,6 +263,37 @@
     - name: Remove jdk17.tar.gz (Linux-riscv64)
       file:
         path: /tmp/jdk17.tar.gz
+        state: absent
+
+# JDK 11 on Linux-riscv64 is a special-case because the Ubuntu openjdk-11-jdk package is just too
+# damn slow (it's Zero VM) and times out on CI
+- name: Install JDK {{ jdk_version }} on Linux-riscv64
+  when:
+    - ansible_architecture == "riscv64" and jdk_version == 11
+    - adoptopenjdk_installed.rc != 0
+  tags: adoptopenjdk_install
+    # Api does not return release information for JDK10
+  block:
+    - name: Download jdk{{ jdk_version }} release (Linux-riscv64)
+      get_url:
+        url: https://ci.adoptium.net/userContent/riscv/OpenJDK11U-jdk_riscv64_linux_hotspot_2024-02-08-16-01.tar.gz
+        dest: /tmp/jdk11.tar.gz
+        mode: 0440
+        checksum: sha256:b14e237de3929f235671c38694a9458e7aeab1720065edc1888aa8754a2e21b2
+      retries: 3
+      delay: 5
+      register: adoptopenjdk_download
+      until: adoptopenjdk_download is not failed
+
+    - name: Install latest jdk{{ jdk_version }} release if one not already installed (Linux-riscv64)
+      unarchive:
+        src: /tmp/jdk11.tar.gz
+        dest: /usr/lib/jvm
+        remote_src: yes
+
+    - name: Remove jdk11.tar.gz (Linux-riscv64)
+      file:
+        path: /tmp/jdk11.tar.gz
         state: absent
 
 # # CentOS6 needs it's own task so it can use a different python interpreter.


### PR DESCRIPTION
We don't want to rely on openjdk-11-jdk from Ubuntu 20.04 repositories, it's based on Zero VM and just too slow for use as boot/build JDK.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [x] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
