### PR TITLE
unixPB: Fix SLES 15 Devel-Tools repo url

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/SLES.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/SLES.yml
@@ -23,7 +23,7 @@
 
 - name: Add Devel-Tools repository (SLES15)
   zypper_repository:
-    repo: https://download.opensuse.org/repositories/devel:/tools/15.4/devel:tools.repo
+    repo: https://download.opensuse.org/repositories/devel:/tools/15.5/devel:tools.repo
     auto_import_keys: yes
     state: present
   when:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->
Fixes: https://github.com/adoptium/infrastructure/issues/3436

Updated the SLES 15 Devel-Tools repo link to 15.5: https://download.opensuse.org/repositories/devel:/tools/15.5/

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
