### PR TITLE
[ansible] Update JDK11_BOOT_DIR to use /usr/lib/jvm/jdk-11

### DIFF
--- a/ansible/docker/Dockerfile.Ubuntu2004-riscv64
+++ b/ansible/docker/Dockerfile.Ubuntu2004-riscv64
@@ -20,8 +20,8 @@ RUN groupadd -g 1000 ${user}
 RUN useradd -c "Jenkins user" -d /home/${user} -u 1000 -g 1000 -m ${user}
 
 ENV \
-    JDK11_BOOT_DIR="/usr/lib/jvm/java-11-openjdk-riscv64" \
+    JDK11_BOOT_DIR="/usr/lib/jvm/jdk-11" \
     JDK17_BOOT_DIR="/usr/lib/jvm/jdk-17" \
     JDK19_BOOT_DIR="/usr/lib/jvm/jdk-19" \
     JDK21_BOOT_DIR="/usr/lib/jvm/jdk-21" \
-    JAVA_HOME="/usr/lib/jvm/java-11-openjdk-riscv64"
+    JAVA_HOME="/usr/lib/jvm/jdk-11"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [x] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
