### PR TITLE
winPB: Update Wix Installer Download URL & Checksum

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2022/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2022/tasks/main.yml
@@ -94,7 +94,7 @@
 - name: Download Visual Studio Community 2022
   win_get_url:
     url: 'https://aka.ms/vs/17/release/vs_Community.exe'
-    checksum: 51d8dc03605a4fa11d445795cb1cc7ea1a518b0b0ce466cdaa805fc6029d7058
+    checksum: 6dfb021f82e9e7f89de632c08a654c0695d7701c3f47bb894508717a9948048f
     checksum_algorithm: sha256
     dest: 'C:\temp\vs_community22.exe'
     force: no

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/WiX/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/WiX/tasks/main.yml
@@ -10,10 +10,10 @@
 
 - name: Download WiX
   win_get_url:
-    url: https://wixtoolset.org/downloads/v3.14.0.3910/wix314.exe
+    url: https://github.com/wixtoolset/wix3/releases/download/wix314rtm/wix314.exe
     dest: 'C:\temp\wix.exe'
     follow_redirects: all
-    checksum: f333d4cf132f03b75222aa107633d28ce5ba8d612892b38cfc2ddc4cd92ad6de
+    checksum: 704439ea88fc9e5a3647eedeeb45943f9a392e3d209f58512280130096847937
     checksum_algorithm: sha256
   when: (not wix_installed.stat.exists)
   tags: Wix


### PR DESCRIPTION
Fixes #3439 

The Wix toolset installer has been moved to a different URL, this updates the windows playbook appropriately.

VPC Run: https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Win2022,label=vagrant/1834/console

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
