### PR TITLE
github: Fix Semgrep GitHub Action To Be Diff Aware

### DIFF
--- a/.github/workflows/semgrep_diff.yml
+++ b/.github/workflows/semgrep_diff.yml
@@ -19,5 +19,5 @@ jobs:
       # Step 2: Differential scan
       - name: Differential scan
         run: |
-          semgrep scan --error --metrics=off --config="p/trailofbits" \
-            --baseline-commit ${{ github.event.before }}
+          semgrep ci \
+            --config="p/trailofbits"


### PR DESCRIPTION
The new semgrep action was incorrectly only analysing the last commit on a branch.

This PR amends semgrep to run in CI/diff aware mode, and thus make the checks run across all commits for a PR.


##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR

