### PR TITLE
bump latest mac run to macos-14

### DIFF
--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         include:
           - os: [macos-11]
-          - os: [macos-13]
+          - os: [macos-14]
     steps:
 
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode11/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode11/tasks/main.yml
@@ -11,7 +11,7 @@
 - name: Check if SAS variable is defined
   set_fact:
     apple_variables: yes
-  when: not xcode11_installed.stat.exists and XCode11.7_SAS_TOKEN is defined
+  when: not xcode11_installed.stat.exists and vars['XCode11.7_SAS_TOKEN'] is defined
 
 - name: Display Information when XCode11.7_SAS_TOKEN is not defined
   debug:


### PR DESCRIPTION
This mean that the playbooks get tested on an M1 macOS host but this should also fix the failing GH action

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
