### PR TITLE
UnixPB: Restart NTPD after disabling of GUI

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/disable_gui/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/disable_gui/tasks/main.yml
@@ -25,3 +25,31 @@
     - desktop_installed.stat.exists
     - gui_disabled.stdout == ''
   tags: disable_gui
+
+# Restart NTPD On Centos 7  after gui disablement 
+
+- name: Gather Facts About The Services Present
+  service_facts:
+  tags: disable_gui
+
+- name: Check If NTPD Exists In The Service Facts
+  set_fact:
+    ntpd_entry_exists: "{{ 'ntpd.service' in services }}"
+  when: ansible_facts.services is defined
+  tags: disable_gui
+
+- name: Set Fact Where NTPD Is Not Available As A Service
+  set_fact:
+    ntpd_entry_exists: "false"
+  when: ansible_facts.services is not defined
+  tags: disable_gui
+
+- name: Start NTP for CentOS7 following GUI disablement
+  service:
+    name: ntpd
+    state: restarted
+    enabled: yes
+  when:
+    - ntpd_entry_exists | default(false) | bool
+    - (ansible_distribution == "CentOS" and ansible_distribution_major_version == "7" )
+  tags: disable_gui

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/disable_gui/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/disable_gui/tasks/main.yml
@@ -26,7 +26,7 @@
     - gui_disabled.stdout == ''
   tags: disable_gui
 
-# Restart NTPD On Centos 7  after gui disablement 
+# Restart NTPD On Centos 7  after gui disablement
 
 - name: Gather Facts About The Services Present
   service_facts:


### PR DESCRIPTION
Fixes #3478 

The task to disable the GUI, also kills the NTPD service on CentOS7. This has been observed in the weekly playbook runs to refresh the Unix servers.

This has been debugged and investigated to relate to this command 

`systemctl isolate multi-user.target`



##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)

VPC Completed OK: https://ci.adoptium.net/job/VagrantPlaybookCheck/1860/