### PR TITLE
Dockerstatic: Ensure Hostname Installed On Sles12

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.sles12
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.sles12
@@ -2,7 +2,7 @@ FROM registry.suse.com/suse/sles12sp5:latest
 
 RUN zypper ar https://download.opensuse.org/distribution/leap/15.4/repo/oss/ sles15oss
 RUN zypper --gpg-auto-import-keys refresh
-RUN zypper update -y && zypper install -y wget perl openssh-server unzip zip tar gzip
+RUN zypper update -y && zypper install -y wget perl openssh-server unzip zip tar gzip hostname
 
 RUN wget 'https://api.adoptium.net/v3/binary/latest/17/ga/linux/x64/jdk/hotspot/normal/eclipse?project=jdk' -O /tmp/jdk17.tar.gz
 RUN mkdir -p /usr/lib/jvm/jdk17 && tar -xpzf /tmp/jdk17.tar.gz -C /usr/lib/jvm/jdk17 --strip-components=1


### PR DESCRIPTION
Fixes #3480 

Install hostname on sles12 dockerstatic containers.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR
