### PR TITLE
Changes to support RHEL7/s390x image creation and devkit inclusion

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -85,6 +85,7 @@ have at the moment:
 | Dockerfile | Image | Platforms  | Where is this built? | In use?
 |---|---|---|---|---|
 | [Centos7](./ansible/docker/Dockerfile.CentOS7) | [`adoptopenjdk/centos7_build_image`](https://hub.docker.com/r/adoptopenjdk/centos7_build_image) | linux on amd64, arm64, ppc64le | [Jenkins](https://ci.adoptium.net/job/centos7_docker_image_updater/) | Yes
+| [RHEL7](./ansible/docker/Dockerfile.RHEL7) | n/a - restricted | s390x | [Jenkins](https://ci.adoptium.net/job/rhel7_docker_image_updater/) | Yes
 | [Centos6](./ansible/docker/Dockerfile.CentOS6) | [`adoptopenjdk/centos6_build_image`](https://hub.docker.com/r/adoptopenjdk/centos6_build_image)| linux/amd64 | [GH Actions](.github/workflows/build.yml) | Yes
 | [Alpine3](./ansible/docker/Dockerfile.Alpine3) | [`adoptopenjdk/alpine3_build_image`](https://hub.docker.com/r/adoptopenjdk/alpine3_build_image) | linux/x64 & linux/arm64 | [Jenkins](https://ci.adoptium.net/job/centos7_docker_image_updater/) | Yes
 | [Ubuntu 20.04 (riscv64 only)](./ansible/docker/Dockerfile.Ubuntu2004-riscv64) | [`adoptopenjdk/ubuntu2004_build_image:linux-riscv64`](https://hub.docker.com/r/adoptopenjdk/ubuntu2004_build_image) | linux/riscv64 | [Jenkins](https://ci.adoptium.net/job/centos7_docker_image_updater/) | Yes

--- a/FAQ.md
+++ b/FAQ.md
@@ -85,17 +85,30 @@ have at the moment:
 | Dockerfile | Image | Platforms  | Where is this built? | In use?
 |---|---|---|---|---|
 | [Centos7](./ansible/docker/Dockerfile.CentOS7) | [`adoptopenjdk/centos7_build_image`](https://hub.docker.com/r/adoptopenjdk/centos7_build_image) | linux on amd64, arm64, ppc64le | [Jenkins](https://ci.adoptium.net/job/centos7_docker_image_updater/) | Yes
-| [RHEL7](./ansible/docker/Dockerfile.RHEL7) | n/a - restricted | s390x | [Jenkins](https://ci.adoptium.net/job/rhel7_docker_image_updater/) | Yes
+| [RHEL7](./ansible/docker/Dockerfile.RHEL7) | n/a - restricted (*) | s390x | [Jenkins](https://ci.adoptium.net/job/rhel7_docker_image_updater/) | Yes
 | [Centos6](./ansible/docker/Dockerfile.CentOS6) | [`adoptopenjdk/centos6_build_image`](https://hub.docker.com/r/adoptopenjdk/centos6_build_image)| linux/amd64 | [GH Actions](.github/workflows/build.yml) | Yes
 | [Alpine3](./ansible/docker/Dockerfile.Alpine3) | [`adoptopenjdk/alpine3_build_image`](https://hub.docker.com/r/adoptopenjdk/alpine3_build_image) | linux/x64 & linux/arm64 | [Jenkins](https://ci.adoptium.net/job/centos7_docker_image_updater/) | Yes
 | [Ubuntu 20.04 (riscv64 only)](./ansible/docker/Dockerfile.Ubuntu2004-riscv64) | [`adoptopenjdk/ubuntu2004_build_image:linux-riscv64`](https://hub.docker.com/r/adoptopenjdk/ubuntu2004_build_image) | linux/riscv64 | [Jenkins](https://ci.adoptium.net/job/centos7_docker_image_updater/) | Yes
 
+<details>
+<summary>(*) - Caveats:</summary>
+
+The RHEL7 image creation for s390x has to be run on a RHEL host using a
+container implementation supplied by Red Hat, and we are using RHEL8 for
+this as it has a stable implemention.  The image creation requires the
+following:
+
+1. The host needs to have an active RHEL subscription
+2. The RHEL7 devkit (which cannot be made public) to be available in a tar file under /usr/local on the host as per the name in the Dockerfile
+</details>
+
 When a change lands into master, the relevant dockerfiles are built using
 the appropriate CI system listed in the table above by configuring them with
-the ansible playbooks and pushing them up to Docker Hub where they can be
-consumed by our jenkins build agents when the `DOCKER_IMAGE` value is
-defined on the jenkins build pipelines as configured in the
-[pipeline_config files](https://github.com/AdoptOpenJDK/ci-jenkins-pipelines/tree/master/pipelines/jobs/configurations).
+the ansible playbooks and - with the exception of the RHEL7 image for s390x -
+pushing them up to Docker Hub where they can be consumed by our jenkins
+build agents when the `DOCKER_IMAGE` value is defined on the jenkins build
+pipelines as configured in the [pipeline_config
+files](https://github.com/AdoptOpenJDK/ci-jenkins-pipelines/tree/master/pipelines/jobs/configurations).
 
 ### Adding a new dockerBuild dockerhub repository
 

--- a/ansible/docker/Dockerfile.RHEL7
+++ b/ansible/docker/Dockerfile.RHEL7
@@ -33,4 +33,4 @@ ENV \
 # devkit, and the process for that runs as non-root ...
 # Disabled for now as we're going to copy from /usr/local/devkit on the host
 RUN yum clean all
-RUN yum install --downloadonly glibc glibc-headers glibc-devel cups-libs cups-devel libX11 libX11-devel xorg-x11-proto-devel alsa-lib alsa-lib-devel libXext libXext-devel libXtst libXtst-devel libXrender libXrender-devel libXrandr libXrandr-devel freetype freetype-devel libXt libXt-devel libSM libSM-devel libICE libICE-devel libXi libXi-devel libXdmcp libXdmcp-devel libXau libXau-devel libgcc libxcrypt zlib zlib-devel libffi libffi-devel fontconfig fontconfig-devel kernel-headers
+RUN yum reinstall --downloadonly glibc glibc-headers glibc-devel cups-libs cups-devel libX11 libX11-devel xorg-x11-proto-devel alsa-lib alsa-lib-devel libXext libXext-devel libXtst libXtst-devel libXrender libXrender-devel libXrandr libXrandr-devel freetype freetype-devel libXt libXt-devel libSM libSM-devel libICE libICE-devel libXi libXi-devel libXdmcp libXdmcp-devel libXau libXau-devel libgcc libxcrypt zlib zlib-devel libffi libffi-devel fontconfig fontconfig-devel kernel-headers

--- a/ansible/docker/Dockerfile.RHEL7
+++ b/ansible/docker/Dockerfile.RHEL7
@@ -1,10 +1,5 @@
 FROM registry.access.redhat.com/rhel7
-# This dockerfile should be built using this from the top level of the repository:
-#  ROSIPW=******* docker build --no-cache -t rhel7_build_image -f ansible/docker/Dockerfile.RHEL7 --build-arg ROSIUSER=******* --secret id=ROSIPW --build-arg git_sha="$(git rev-parse --short HEAD)" `pwd`
-ARG ROSIUSER
-RUN sed -i 's/\(def in_container():\)/\1\n    return False/g' /usr/lib64/python*/*-packages/rhsm/config.py
-RUN --mount=type=secret,id=ROSIPW,required=true subscription-manager register --username=${ROSIUSER} --password="$(cat /run/secrets/ROSIPW)" --auto-attach
-RUN subscription-manager repos --enable rhel-7-for-system-z-optional-rpms
+RUN yum-config-manager --enable rhel-7-for-system-z-optional-rpms
 # ^^ Optional repo needed for Xvfb
 
 ARG git_sha
@@ -15,6 +10,7 @@ RUN yum --enablerepo=rhel-7-server-ansible-2-for-system-z-rpms install -y ansibl
 RUN yum clean all
 
 COPY . /ansible
+COPY devkit /usr/local/devkit
 
 RUN echo "localhost ansible_connection=local" > /ansible/hosts
 
@@ -31,7 +27,10 @@ RUN useradd -c "Jenkins user" -d /home/${user} -u 1002 -g 1003 -m ${user}
 ENV \
     JDK7_BOOT_DIR="/usr/lib/jvm/java-1.7.0-openjdk" \
     JDK8_BOOT_DIR="/usr/lib/jvm/java-1.8.0-openjdk" \
-    JDK10_BOOT_DIR="/usr/lib/jvm/jdk-10" \
     JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"
-RUN subscription-manager unregister
 
+# While this does bloat the image it is required for building the
+# devkit, and the process for that runs as non-root ...
+# Disabled for now as we're going to copy from /usr/local/devkit on the host
+RUN yum clean all
+RUN yum install --downloadonly glibc glibc-headers glibc-devel cups-libs cups-devel libX11 libX11-devel xorg-x11-proto-devel alsa-lib alsa-lib-devel libXext libXext-devel libXtst libXtst-devel libXrender libXrender-devel libXrandr libXrandr-devel freetype freetype-devel libXt libXt-devel libSM libSM-devel libICE libICE-devel libXi libXi-devel libXdmcp libXdmcp-devel libXau libXau-devel libgcc libxcrypt zlib zlib-devel libffi libffi-devel fontconfig fontconfig-devel kernel-headers

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -94,6 +94,7 @@
       when:
         - (ansible_distribution != "Alpine" or ansible_architecture != "aarch64")
         - ansible_architecture != "riscv64"
+        - ansible_architecture != "s390x"
       tags: build_tools
     - role: adoptopenjdk_install  # JDK11 Build Bootstrap
       jdk_version: 10
@@ -120,6 +121,7 @@
         - ansible_distribution != "Solaris"
         - ansible_architecture != "riscv64"
         - ansible_architecture != "armv7l"
+        - ansible_architecture != "s390x"
       tags: build_tools
     - role: adoptopenjdk_install  # Current LTS
       jdk_version: 21


### PR DESCRIPTION
Part of https://github.com/adoptium/temurin-build/issues/3700

This updates the s390x Dockerfile to remove the hack that was required while we were using docker-ce as the docker provider. The default `docker` package on RHEL7 means that the RHEL subscription from the host machine is automatically made available to containers running on the host, so that is simplified. NOTE: Only `build-marist-rhel79-s390x-2` has these changes during this prototype phase - `-1` still has `docker-ce` so will be incompatible with this change and the dockerfile will no longer run.

The playbook changes prevent attempts to install adoptium JDK8 or JDK20 as they do not exist on s390x.

The primary reason for these changes is to attempt to incorporate the devkits into the build. Since the RHEL7 ones cannot be public the dockerfile change in here copies from `/usr/local/devkit` on the host system. It should look something like this:
```
[jenkins@build-marist-rhel79-s390x-1 ~]$ ls -l /usr/local/devkit
total 0
lrwxrwxrwx. 1 root    root     18 Mar 26 12:28 s390x-on-s390x -> s390x-on-s390x.RH7
drwxrwxr-x. 9 jenkins jenkins 159 Mar 26 11:51 s390x-on-s390x.F19
drwxrwxr-x. 9 jenkins jenkins 159 Mar 26 07:51 s390x-on-s390x.RH7
```
And the contents of the two directories at the time of writing are populated by extracting the two files from the table below (the second of which is not publicly accessible). Note that the RH7 link is to a filename with `Centos7` in it. This is purely because the devkit has been built based on the Centos7 options as per the patch in https://github.com/adoptium/ci-jenkins-pipelines/pull/955/files#diff-160c3a9fceef67470c20f80d568a1dafd1641290063f4da4c42e3292bf1d9311- it is built from the RHEL7 RPMs as CentOS7 was not available on s390x:

Platform / download link | sha256sum
---|---
[devkit-gcc-11.3.0-linux-s390x-F19#12](https://ci.adoptium.net/job/build-scripts/job/utils/job/devkit/job/gcc-11.3.0/job/devkit-gcc-11.3.0-linux-s390x-F19/12/artifact/workspace/devkit-gcc-11.3.0-Fedora_19-b01-s390x-linux-gnu.tar.xz) | `b490fa37af027659531b1bdfc884b25743b5934e3c57e69393215328d30b74a5`
[devkit-gcc-11.3.0-linux-s390x#31](https://ci.adoptium.net/job/build-scripts/job/utils/job/devkit/job/gcc-11.3.0/job/devkit-gcc-11.3.0-linux-s390x/lastSuccessfulBuild/artifact/workspace/devkit-gcc-11.3.0-Centos7.9.2009-b01-s390x-linux-gnu.tar.xz) | `727458249f56ea73b30308993a0cf94e21c7b259f3abbbd422dd522a287d0dd8`

These changes are being tested by https://ci.adoptium.net/job/rhel7_docker_image_updater which builds the new image and stores it on the machine.

I wrestled a little with the `yum` download at the end, but decided it was preferable from a security perspective to bloat the image with the prereqs for the devkit rather than have it downloaded on the host (which may not be the same version) or store it locally on the host which would be messy.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
