### PR TITLE
inventory: remove spearhead

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -73,9 +73,6 @@ hosts:
           win2012r2-x64-2: {ip: 169.48.4.142, user: Administrator}
           win2022-x64-1: {ip: 52.118.206.11, user: Administrator}
 
-      - spearhead:
-          freebsd12-x64-1: {ip: 185.131.222.224}
-
   - docker:
 
       - skytap:

--- a/ansible/playbooks/nagios/roles/Nagios_Config/files/Nagios_Server_Config.py
+++ b/ansible/playbooks/nagios/roles/Nagios_Config/files/Nagios_Server_Config.py
@@ -29,8 +29,7 @@ special_templates = {'test-equinix_esxi-solaris10-x64-1': 'test-solaris-noport-t
 
 ## Define Any Hosts That Should Be Excluded
 
-excluded_hosts = {'build-spearhead-freebsd12-x64-1',
-                  'test-inspira-solaris10u11-sparcv9-1',
+excluded_hosts = {'test-inspira-solaris10u11-sparcv9-1',
                   'build-inspira-solaris10u11-sparcv9-1',
                   'build-inspira-solaris10u11-sparcv9-2',
                   'infrastructure-aws-ubuntu1804-x64-1',

--- a/ansible/plugins/inventory/adoptopenjdk_yaml.py
+++ b/ansible/plugins/inventory/adoptopenjdk_yaml.py
@@ -47,7 +47,7 @@ valid = {
 
   # providers - validated for consistency
   'provider': ('alibaba', 'azure', 'marist', 'osuosl',
-        'macstadium', 'macincloud', 'ibmcloud', 'spearhead', 'siteox',
+        'macstadium', 'macincloud', 'ibmcloud', 'siteox',
         'equinix', 'linaro','digitalocean', 'ibm', 'godaddy',
         'aws', 'inspira', 'equinix_esxi', 'nine', 'scaleway', 'skytap',
         'hetzner')


### PR DESCRIPTION
We haven't looked at FreeBSD as a supported platform for years, and the machine does not appear to be contactable, therefore removing.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
