### PR TITLE
AWX: Add windows collection packages to AWX collections.yml

### DIFF
--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -4,3 +4,6 @@
 collections:
   - name: community.general
     source: https://galaxy.ansible.com
+
+  - name: community.windows
+    source: https://galaxy.ansible.com


### PR DESCRIPTION

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

AWX is unable to resolve some of the windows modules, installing the `community.windows` modules should solve this
```
ERROR! couldn't resolve module/action 'win_lineinfile'. This often indicates a misspelling, missing collection, or incorrect module path.
The error appears to be in '/runner/project/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/logs/tasks/main.yml': line 37, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be

- name: Update Log File
  ^ here
```