### PR TITLE
docker: Assign port number to static docker container during automated deployment

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
@@ -22,14 +22,20 @@
 - name: Build {{ docker_image }} docker images
   command: docker build --cpu-period=100000 --cpu-quota=800000 -t aqa_{{ docker_image }} --memory=6G -f /tmp/Dockerfile.{{ docker_image }} /tmp/
 
-# Without specifying a port here, docker will give the container a random unused port
+# Finds the highest port number already assigned and +1
+- name: Find available port
+  shell: docker ps --format \"\{\{\.Ports\}\}\" | awk -F[:-] '{print $2}' | sort | tail -n 1
+  register: docker_port_output
+
+- name: Set docker_port variable if empty
+  set_fact:
+    docker_port: 32000
+  when: docker_port_output.stdout == ""
+
+- name: Set docker_port variable when non empty
+  set_fact:
+    docker_port: "{{ docker_port_output.stdout }}"
+  when: not (docker_port_output.stdout == "")
+
 - name: Run {{ docker_image }} docker container
-  command: docker run --restart unless-stopped -p 22 --cpuset-cpus="0-3" --memory=6G --detach --name {{ docker_image | upper }}.PORT aqa_{{ docker_image }}
-
-# Now we want to rename the running container with the port name
-- name: Find assigned port of {{ docker_image }} container
-  shell: docker port {{ docker_image | upper }}.PORT | head -n 1 | cut -d ':' -f 2
-  register: docker_port
-
-- name: Rename {{ docker_image }} container to {{ docker_image | upper }}.{{ docker_port.stdout_lines[0] }}
-  command: docker rename {{ docker_image | upper }}.PORT {{ docker_image | upper }}.{{ docker_port.stdout_lines[0] }}
+  command: docker run --restart unless-stopped -p {{ docker_port|int + 1 }}:22 --cpuset-cpus="0-3" --memory=6G --detach --name {{ docker_image | upper }}.PORT aqa_{{ docker_image }}

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
@@ -34,8 +34,8 @@
 
 - name: Set docker_port variable when non empty
   set_fact:
-    docker_port: "{{ docker_port_output.stdout }}"
+    docker_port: "{{ docker_port_output.stdout | int + 1 }}"
   when: not (docker_port_output.stdout == "")
 
 - name: Run {{ docker_image }} docker container
-  command: docker run --restart unless-stopped -p {{ docker_port | int + 1 }}:22 --cpuset-cpus="0-3" --memory=6G --detach --name {{ docker_image | upper }}.PORT aqa_{{ docker_image }}
+  command: docker run --restart unless-stopped -p {{ docker_port }}:22 --cpuset-cpus="0-3" --memory=6G --detach --name {{ docker_image | upper }}.{{ docker_port }} aqa_{{ docker_image }}

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
@@ -38,4 +38,4 @@
   when: not (docker_port_output.stdout == "")
 
 - name: Run {{ docker_image }} docker container
-  command: docker run --restart unless-stopped -p {{ docker_port|int + 1 }}:22 --cpuset-cpus="0-3" --memory=6G --detach --name {{ docker_image | upper }}.PORT aqa_{{ docker_image }}
+  command: docker run --restart unless-stopped -p {{ docker_port | int + 1 }}:22 --cpuset-cpus="0-3" --memory=6G --detach --name {{ docker_image | upper }}.PORT aqa_{{ docker_image }}


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

fixes https://github.com/adoptium/infrastructure/issues/3505