### PR TITLE
Inventory: Remove IBMCloud Win2012 Machines

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -70,8 +70,6 @@ hosts:
           solaris10u11-sparcv9-1: {ip: cloud.siteox.com, port: 24322}
 
       - ibmcloud:
-          win2012r2-x64-1: {ip: 169.48.4.138, user: Administrator}
-          win2012r2-x64-2: {ip: 169.48.4.142, user: Administrator}
           win2022-x64-1: {ip: 52.118.206.11, user: Administrator}
 
   - docker:
@@ -173,5 +171,3 @@ hosts:
           rhel6-x64-1: {ip: 169.48.4.140}
           rhel7-x64-1: {ip: 169.48.4.136}
           ubuntu1604-x64-1: {ip: 169.48.4.141}
-          win2012r2-x64-1: {ip: 169.48.4.131, user: Administrator}
-          win2012r2-x64-2: {ip: 169.48.4.139, user: Administrator}


### PR DESCRIPTION
Remove the now decomissioned windows2012 machines, which will ber replaced as per: https://github.com/adoptium/infrastructure/issues/3238 

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes]
- [X] VPC/QPC not applicable for this PR
- [X] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
