### PR TITLE
unixPB: Move cmake install from homebrew to be a cask

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/MacOSX.yml
@@ -8,7 +8,6 @@
 Build_Tool_Packages:
   - autoconf
   - automake # for compiling freetype on JDK8u
-  - cmake # OpenJ9
   - coreutils
   - gnupg
   - gnu-sed
@@ -22,6 +21,7 @@ Build_Tool_Packages_NOT_10_12:
 
 Build_Tool_Casks:
   - packages
+  - cmake # OpenJ9
 
 Test_Tool_Packages:
   - mercurial


### PR DESCRIPTION
Draft because I've no idea if this will work (untested)
Problem seems to be this:
```
TASK [Common : Install Build Tool Packages] ************************************
changed: [localhost] => (item=autoconf)
changed: [localhost] => (item=automake)
failed: [localhost] (item=cmake) => {"ansible_loop_var": "item", "changed": false, "item": "cmake", "msg": "Warning: Treating cmake as a formula. For the cask, use homebrew/cask/cmake or specify the `--cask` flag."}
changed: [localhost] => (item=coreutils)
```
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
