### PR TITLE
Inventory: Replace Marist s390x build host.

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -52,7 +52,7 @@ hosts:
 
       - marist:
           rhel79-s390x-1: {ip: 148.100.75.212, user: linux1}
-          rhel79-s390x-2: {ip: 148.100.74.54, user: linux1}
+          rhel8-s390x-1: {ip: 148.100.75.98, user: linux1}
 
       - osuosl:
           aix72-ppc64-1: {ip: 140.211.9.166, description: p8-java1-adopt10.osuosl.org, 7200-02-04-1914}


### PR DESCRIPTION
Fixes #3499 

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR
- [X] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
