### PR TITLE
UnixPB: Add new TCK solaris host

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/jckservices_iptables/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/jckservices_iptables/tasks/main.yml
@@ -75,6 +75,7 @@
     - 62.210.163.172 # jck-scaleway-ubuntu2310-riscv64-1
     - 62.210.163.106 # jck-scaleway-ubuntu2310-riscv64-2
     - 20.234.51.61 # jck-azure-ubuntu2204-x64-1
+    - 172.178.96.199 # jck-ubuntu-2204-solaris10
 
 - name: Setup iptables
   iptables:


### PR DESCRIPTION
Update JCKServices with IP of new TCK Solaris host.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR

