### PR TITLE
inventory: Update win2016 machine ip address

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -102,7 +102,7 @@ hosts:
           ubuntu1804-armv8-2: {ip: 114.119.175.125}
 
       - azure:
-          win2016-x64-1: {ip: 52.149.211.210, user: adoptopenjdk}
+          win2016-x64-1: {ip: 172.172.147.29, user: adoptopenjdk}
           win2019-x64-1: {ip: 13.92.177.186, user: adoptopenjdk}
           win2022-x64-1: {ip: 51.132.234.42, user: adoptopenjdk}
           win2022-x64-2: {ip: 20.26.116.218, user: adoptopenjdk}


### PR DESCRIPTION
Following the reboot of the non-responsive windows 2016 test azure machine, its IP address was changed, as it is not assigned a static public IP address.

The machine is now back in service, but it has a new IP address.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR
- [X] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
