### PR TITLE
UnixPB: Extend support of few docker related tasks to lastest OS versions

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
@@ -20,7 +20,7 @@
     ################
     # Pre Install  #
     ################
-    - name: Prepare for RHEL/CentOS 7/8
+    - name: Prepare for RHEL/CentOS 7/8/9
       include_tasks: rhel.yml
       when:
         - ansible_distribution == "RedHat" or ansible_distribution == "CentOS"
@@ -31,7 +31,7 @@
       when:
         - ansible_distribution == "Ubuntu"
 
-    - name: Prepare for Debian / Raspbian
+    - name: Prepare for Debian/Raspbian
       include_tasks: debian.yml
       when:
         - ansible_distribution == "Debian"
@@ -39,7 +39,7 @@
     ##################
     # Install Docker #
     ##################
-    - name: Install docker based on OS (Ubuntu, RHEL/CentOS 7/8, Debian)
+    - name: Install docker based on OS (Ubuntu, RHEL/CentOS 7/8/9, Debian)
       package:
         name:
           - docker-ce
@@ -71,35 +71,33 @@
     ################
     # Post Install #
     ################
-    - name: Add Jenkins user to the docker group for Ubuntu, Debian, SLES, CentOS7  and RHEL7
+    - name: Add Jenkins user to the docker group for Ubuntu, Debian, SLES, CentOS/RHEL 7/8/9
       user:
         name: "{{ Jenkins_Username }}"
         groups: docker
         append: yes
         state: present
-      when:
-        - (ansible_distribution == "Ubuntu" or ansible_distribution == "Debian") or (ansible_distribution == "SLES") or ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS" ) and ansible_distribution_major_version == "7")
-      tags:
-        - jenkins
+      when: ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version >= "7")) or
+            ansible_distribution == "Ubuntu" or ansible_distribution == "Debian" or ansible_distribution == "SLES"
+      tags: jenkins
 
-    - name: Add Nagios user to the docker group for Ubuntu, Debian, SLES, CentOS7  and RHEL7
+    - name: Add Nagios user to the docker group for Ubuntu, Debian, SLES, CentOS/RHEL 7/8/9
       user:
         name: nagios
         groups: docker
         append: yes
         state: present
       when:
-        - (ansible_distribution == "Ubuntu" or ansible_distribution == "Debian") or (ansible_distribution == "SLES") or ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS" ) and ansible_distribution_major_version == "7")
+        - ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version >= "7")) or
+          ansible_distribution == "Ubuntu" or ansible_distribution == "Debian" or ansible_distribution == "SLES"
         - Nagios_Plugins == "Enabled"
-      tags:
-        - docker
+      tags: docker
 
-- name: Enable and Start Docker Service for Ubuntu, Debian, SLES, CentOS7  and RHEL7
+- name: Enable and Start Docker Service for Ubuntu, Debian, SLES, CentOS/RHEL 7/8/9
   service:
     name: docker
     state: started
     enabled: yes
-  when:
-    - (ansible_distribution == "Ubuntu" or ansible_distribution == "Debian") or (ansible_distribution == "SLES") or ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS" ) and ansible_distribution_major_version == "7")
-  tags:
-    - docker
+  when: ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version >= "7")) or
+        ansible_distribution == "Ubuntu" or ansible_distribution == "Debian" or ansible_distribution == "SLES"
+  tags: docker


### PR DESCRIPTION
Few tasks(Jenkins/Nagios user to Docker group, Enable & Disable Docker service) in Docker role are limited to only a few OS versions. This PR extends it's support to the latest OS versions.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
