### PR TITLE
WinPb: Change compiler parameter for NVidia cuda toolkit silent installation

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NVidia_Cuda_Toolkit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NVidia_Cuda_Toolkit/tasks/main.yml
@@ -39,7 +39,7 @@
   tags: NVidia_Cuda_Toolkit
 
 - name: Install NVidia CUDA toolkit - Windows 10
-  win_shell: C:\temp\cuda_9.1.85_win10_network.exe -s compiler_9.1 nvml_dev_9.1
+  win_shell: C:\temp\cuda_9.1.85_win10_network.exe -s nvcc_9.1 nvml_dev_9.1
   when: (not cuda_installed.stat.exists and ansible_distribution_major_version == "10")
   tags: NVidia_Cuda_Toolkit
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->
The silent installation for NVIDIA toolkit is not successful. the playbook run gets executed successfully but the NVIDIA GPU Computing Toolkit folder is not getting created and therefore the CUDA_HOME variable is not getting set causing build compiles to throw error saying CUDA_HOME not found.

The NVidia official documentation mentions nvcc_9.1 as the compiler to be used. After the change the NVIDIA GPU Computing Toolkit folder is getting created successfully.
https://docs.nvidia.com/cuda/archive/9.1/cuda-installation-guide-microsoft-windows/index.html

` C:\temp\cuda_9.1.85_win10_network.exe -s nvcc_9.1 nvml_dev_9.1`

I have only done testing on windows 10,11, 2016,2019 and 2022. I am not sure how it is for Windows 7,8 and Server 2008,2012

Reference ticket:
https://github.com/adoptium/infrastructure/issues/3581



##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
