### PR TITLE
inventory: Fix typo with static docker machine

### DIFF
--- a/ansible/DockerInventory.json
+++ b/ansible/DockerInventory.json
@@ -157,7 +157,7 @@
                 "port": "32772"
             },
             {
-                "nodeName": "test-docker-debain12-armv8l-1",
+                "nodeName": "test-docker-debian12-armv8l-1",
                 "port": "2231"
             },
             {


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Just a typo fix. The name has been fixed in jenkins too