### PR TITLE
WinPb: Correct the checksum for vs_Community.exe

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2022/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2022/tasks/main.yml
@@ -94,7 +94,7 @@
 - name: Download Visual Studio Community 2022
   win_get_url:
     url: 'https://aka.ms/vs/17/release/vs_Community.exe'
-    checksum: 25ce0b366052fdd7eabe151b96c1c781c75e26cb228c9acda71cfe20d1415176
+    checksum: 8653debb099fe571c681c7f06334e703ea801168590787a727faef61e0cffc42
     checksum_algorithm: sha256
     dest: 'C:\temp\vs_community22.exe'
     force: no


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->
There is a need to correct the checksum value for vs_Community.exe file.
failed job: https://github.com/adoptium/infrastructure/actions/runs/9393130716/job/25868653756?pr=3582


```
C:\Users\Administrator\Downloads>certutil -hashfile vs_Community.exe SHA256
SHA256 hash of file vs_Community.exe:
8653debb099fe571c681c7f06334e703ea801168590787a727faef61e0cffc42
CertUtil: -hashfile command completed successfully.
```

important links: https://github.com/adoptium/infrastructure/pull/3582

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
