### PR TITLE
WinPb: Update cuda path to v9.1

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NVidia_Cuda_Toolkit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NVidia_Cuda_Toolkit/tasks/main.yml
@@ -2,9 +2,9 @@
 #######################
 # NVidia Cuda Toolkit #
 #######################
-- name: Check if NVidia CUDA toolkit is aready installed
+- name: Check if NVidia CUDA toolkit is already installed
   win_stat:
-    path: 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v9.0'
+    path: 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v9.1'
   register: cuda_installed
   tags: NVidia_Cuda_Toolkit
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->
Update the cuda path (C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v9.0) to v9.1 in the check to see  if NVidia CUDA toolkit is already installed

Need to update the CUDA_VERSION=9.0 in build-farm/platform-specific-configurations/windows.sh in temurin-build repo after change is merged.
##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
