### PR TITLE
UnixPB: Update OpenSuse Common Tasks For Security

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/openSUSE.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/openSUSE.yml
@@ -26,15 +26,6 @@
     - (ansible_distribution_major_version == "12")
   tags: SUSE_gcc48
 
-- name: Sed change gpgcheck for gcc repo on x86_64
-  replace:
-    path: /etc/zypp/repos.d/devel_gcc.repo
-    regexp: 'gpgcheck=1'
-    replace: "gpgcheck=0"
-  when:
-    - (ansible_distribution_major_version == "12" and ansible_architecture == "x86_64")
-  tags: SUSE_gcc48
-
 # Skipping ansible lint as shell module is required to use the --force-resolution option (lint error 305)
 - name: Install gcc48
   shell: zypper -n in --force-resolution gcc48
@@ -154,7 +145,7 @@
     dest: /tmp/
     mode: 0440
     timeout: 25
-    validate_certs: no
+    validate_certs: yes
     checksum: sha256:d9dc32efba7e74f788fcc4f212a43216fc37cf5f23f4c2339664d473353aedf6
   when:
     - (ansible_distribution_major_version == "12" and ansible_architecture == "x86_64")


### PR DESCRIPTION
Ref: TOB5

The fixes in this PR address a few security vulnerabilities in the OpenSuse common tasks. This playbook does not run, due to issues with the repositories being no longer available, and requiring rework: planned in #3365 


##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR