### PR TITLE
docker: Add docker buildx functionality to dockernode playbook for arm32 containers

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/dockernode.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/dockernode.yml
@@ -12,8 +12,8 @@
   roles:
     - role: Debug
       tags: debug
-    - role: Get_Vendor_Files
-      tags: deploy
+    # - role: Get_Vendor_Files
+    #   tags: deploy
     - role: deploy_container
       tags: deploy
     - role: remove_container

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/dockernode.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/dockernode.yml
@@ -12,8 +12,8 @@
   roles:
     - role: Debug
       tags: debug
-    # - role: Get_Vendor_Files
-    #   tags: deploy
+    - role: Get_Vendor_Files
+      tags: deploy
     - role: deploy_container
       tags: deploy
     - role: remove_container

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/README.md
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/README.md
@@ -33,11 +33,11 @@ The `dockerhost.yml` playbook can deploy single, multiple and duplicate containe
 
 will deploy 1 Ubuntu 22.04 container, 1 Alpine 3.19 container and 3 Ubuntu 18.04 containers.
 
-If you would like to build an arm32 container on an arm64 dockerhost, pass the `build_arm` variable:
+If you would like to build an arm32 container on an arm64 dockerhost, pass the `build_arm32` variable:
 
 ```
 ansible-playbook -u root -i <host-file> AdoptOpenJDK_Unix_Playbook
-/dockernode.yml -t "deploy" -e "docker_images=u2204 build_arm=yes"
+/dockernode.yml -t "deploy" -e "docker_images=u2204 build_arm32=yes"
 ```
 
 ## Setting up a new DockerStatic container (manually)

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/README.md
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/README.md
@@ -33,7 +33,7 @@ The `dockerhost.yml` playbook can deploy single, multiple and duplicate containe
 
 will deploy 1 Ubuntu 22.04 container, 1 Alpine 3.19 container and 3 Ubuntu 18.04 containers.
 
-If you would like to build an arm32 container on an arm64 dockerhost, pass the `build_arm` variable when running the playbook:
+If you would like to build an arm32 container on an arm64 dockerhost, pass the `build_arm`:
 
 ```
 ansible-playbook -u root -i <host-file> AdoptOpenJDK_Unix_Playbook

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/README.md
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/README.md
@@ -33,7 +33,7 @@ The `dockerhost.yml` playbook can deploy single, multiple and duplicate containe
 
 will deploy 1 Ubuntu 22.04 container, 1 Alpine 3.19 container and 3 Ubuntu 18.04 containers.
 
-If you would like to build an arm32 container on an arm64 dockerhost, pass the `build_arm`:
+If you would like to build an arm32 container on an arm64 dockerhost, pass the `build_arm` variable:
 
 ```
 ansible-playbook -u root -i <host-file> AdoptOpenJDK_Unix_Playbook

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/README.md
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/README.md
@@ -33,6 +33,13 @@ The `dockerhost.yml` playbook can deploy single, multiple and duplicate containe
 
 will deploy 1 Ubuntu 22.04 container, 1 Alpine 3.19 container and 3 Ubuntu 18.04 containers.
 
+If you would like to build an arm32 container on an arm64 dockerhost, pass the `build_arm` variable when running the playbook:
+
+```
+ansible-playbook -u root -i <host-file> AdoptOpenJDK_Unix_Playbook
+/dockernode.yml -t "deploy" -e "docker_images=u2204 build_arm=yes"
+```
+
 ## Setting up a new DockerStatic container (manually)
 
 If you would like to setup an individual container on one of these machines, follow these instructions:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
@@ -3,7 +3,7 @@
 - name: Set ansible_architecture to arm if bulidng arm32 containers on arm64
   set_fact:
     ansible_architecture: arm
-  when: build_arm is defined
+  when: build_arm is defined and build_arm == "yes"
 
 - name: Set docker build command
   set_fact:
@@ -12,7 +12,7 @@
 - name: Set docker buildx command if building arm container
   set_fact:
     docker_build_command: "docker buildx build --platform linux/v7/arm"
-  when: build_arm is defined
+  when: build_arm is defined and build_arm == "yes"
 
 - name: debug
   debug:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
@@ -1,60 +1,54 @@
 ---
 
-- name: Set ansible_architecture to arm if bulidng arm32 containers on arm64
-  set_fact:
-    ansible_architecture: arm
-  when: build_arm is defined and build_arm == "yes"
-
 - name: Set docker build command
   set_fact:
     docker_build_command: "docker build"
+    arm_suffix: ""
 
 - name: Set docker buildx command if building arm container
   set_fact:
     docker_build_command: "docker buildx build --platform linux/v7/arm"
+    arm_suffix: ".ARM32"
+    ansible_architecture: arm
   when: build_arm is defined and build_arm == "yes"
 
-- name: debug
-  debug:
-    msg: "{{ docker_build_command }}"
+# Dockerfiles are transferred from the controller node onto the dockerhost to be used to build and run docker containers
+- name: Transfer dockerfile
+  copy:
+    src: "roles/DockerStatic/Dockerfiles/Dockerfile.{{ docker_image }}"
+    dest: "/tmp/Dockerfile.{{ docker_image }}"
 
-# # Dockerfiles are transferred from the controller node onto the dockerhost to be used to build and run docker containers
-# - name: Transfer dockerfile
-#   copy:
-#     src: "roles/DockerStatic/Dockerfiles/Dockerfile.{{ docker_image }}"
-#     dest: "/tmp/Dockerfile.{{ docker_image }}"
+# For images built on non x86_64 dockerhosts
+- name: Translate architecture in dockerfile
+  replace:
+    dest: /tmp/Dockerfile.{{ docker_image }}
+    regexp: "x64"
+    replace: "{{ ansible_architecture }}"
+  when: ansible_architecture != "x86_64"
 
-# # For images built on non x86_64 dockerhosts
-# - name: Translate architecture in dockerfile
-#   replace:
-#     dest: /tmp/Dockerfile.{{ docker_image }}
-#     regexp: "x64"
-#     replace: "{{ ansible_architecture }}"
-#   when: ansible_architecture != "x86_64"
+- name: Set jenkins authorized_Key in dockerfiles
+  replace:
+    dest: /tmp/Dockerfile.{{ docker_image }}
+    regexp: "Jenkins_User_SSHKey"
+    replace: "{{ Jenkins_User_SSHKey }}"
 
-# - name: Set jenkins authorized_Key in dockerfiles
-#   replace:
-#     dest: /tmp/Dockerfile.{{ docker_image }}
-#     regexp: "Jenkins_User_SSHKey"
-#     replace: "{{ Jenkins_User_SSHKey }}"
+- name: Build {{ docker_image }} docker images {{ docker_build_command }}
+  command: "{{ docker_build_command }} --cpu-period=100000 --cpu-quota=800000 -t aqa_{{ docker_image }}{{ arm_suffix }} --memory=6G -f /tmp/Dockerfile.{{ docker_image }} /tmp/"
 
-# - name: Build {{ docker_image }} docker images {{ docker_build_command }}
-#   command: "{{ docker_build_command }} --cpu-period=100000 --cpu-quota=800000 -t aqa_{{ docker_image }} --memory=6G -f /tmp/Dockerfile.{{ docker_image }} /tmp/"
+# Finds the highest port number already assigned and +1
+- name: Find available port
+  shell: docker ps --format \"\{\{\.Ports\}\}\" | awk -F[:-] '{print $2}' | sort | tail -n 1
+  register: docker_port_output
 
-# # Finds the highest port number already assigned and +1
-# - name: Find available port
-#   shell: docker ps --format \"\{\{\.Ports\}\}\" | awk -F[:-] '{print $2}' | sort | tail -n 1
-#   register: docker_port_output
+- name: Set docker_port variable if empty
+  set_fact:
+    docker_port: 32000
+  when: docker_port_output.stdout == ""
 
-# - name: Set docker_port variable if empty
-#   set_fact:
-#     docker_port: 32000
-#   when: docker_port_output.stdout == ""
+- name: Set docker_port variable when non empty
+  set_fact:
+    docker_port: "{{ docker_port_output.stdout | int + 1 }}"
+  when: not (docker_port_output.stdout == "")
 
-# - name: Set docker_port variable when non empty
-#   set_fact:
-#     docker_port: "{{ docker_port_output.stdout | int + 1 }}"
-#   when: not (docker_port_output.stdout == "")
-
-# - name: Run {{ docker_image }} docker container
-#   command: docker run --restart unless-stopped -p {{ docker_port }}:22 --cpuset-cpus="0-3" --memory=6G --detach --name {{ docker_image | upper }}.{{ docker_port }} aqa_{{ docker_image }}
+- name: Run {{ docker_image }} docker container
+  command: docker run --restart unless-stopped -p {{ docker_port }}:22 --cpuset-cpus="0-3" --memory=6G --detach --name {{ docker_image | upper }}.{{ docker_port }}{{ arm_suffix }} aqa_{{ docker_image }}{{ arm_suffix }}

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
@@ -3,14 +3,14 @@
 - name: Set docker build command
   set_fact:
     docker_build_command: "docker build"
-    arm_suffix: ""
+    arm32_suffix: ""
 
-- name: Set docker buildx command if building arm container
+- name: Set docker buildx command if building arm32 container
   set_fact:
     docker_build_command: "docker buildx build --platform linux/v7/arm"
-    arm_suffix: ".ARM32"
+    arm32_suffix: ".ARM32"
     ansible_architecture: arm
-  when: build_arm is defined and build_arm == "yes"
+  when: build_arm32 is defined and build_arm32 == "yes"
 
 # Dockerfiles are transferred from the controller node onto the dockerhost to be used to build and run docker containers
 - name: Transfer dockerfile
@@ -33,7 +33,7 @@
     replace: "{{ Jenkins_User_SSHKey }}"
 
 - name: Build {{ docker_image }} docker images {{ docker_build_command }}
-  command: "{{ docker_build_command }} --cpu-period=100000 --cpu-quota=800000 -t aqa_{{ docker_image }}{{ arm_suffix }} --memory=6G -f /tmp/Dockerfile.{{ docker_image }} /tmp/"
+  command: "{{ docker_build_command }} --cpu-period=100000 --cpu-quota=800000 -t aqa_{{ docker_image }}{{ arm32_suffix }} --memory=6G -f /tmp/Dockerfile.{{ docker_image }} /tmp/"
 
 # Finds the highest port number already assigned and +1
 - name: Find available port
@@ -51,4 +51,4 @@
   when: not (docker_port_output.stdout == "")
 
 - name: Run {{ docker_image }} docker container
-  command: docker run --restart unless-stopped -p {{ docker_port }}:22 --cpuset-cpus="0-3" --memory=6G --detach --name {{ docker_image | upper }}.{{ docker_port }}{{ arm_suffix }} aqa_{{ docker_image }}{{ arm_suffix }}
+  command: docker run --restart unless-stopped -p {{ docker_port }}:22 --cpuset-cpus="0-3" --memory=6G --detach --name {{ docker_image | upper }}.{{ docker_port }}{{ arm32_suffix }} aqa_{{ docker_image }}{{ arm32_suffix }}

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
@@ -1,41 +1,60 @@
 ---
-# Dockerfiles are transferred from the controller node onto the dockerhost to be used to build and run docker containers
-- name: Transfer dockerfile
-  copy:
-    src: "roles/DockerStatic/Dockerfiles/Dockerfile.{{ docker_image }}"
-    dest: "/tmp/Dockerfile.{{ docker_image }}"
 
-# For images built on non x86_64 dockerhosts
-- name: Translate architecture in dockerfile
-  replace:
-    dest: /tmp/Dockerfile.{{ docker_image }}
-    regexp: "x64"
-    replace: "{{ ansible_architecture }}"
-  when: ansible_architecture != "x86_64"
-
-- name: Set jenkins authorized_Key in dockerfiles
-  replace:
-    dest: /tmp/Dockerfile.{{ docker_image }}
-    regexp: "Jenkins_User_SSHKey"
-    replace: "{{ Jenkins_User_SSHKey }}"
-
-- name: Build {{ docker_image }} docker images
-  command: docker build --cpu-period=100000 --cpu-quota=800000 -t aqa_{{ docker_image }} --memory=6G -f /tmp/Dockerfile.{{ docker_image }} /tmp/
-
-# Finds the highest port number already assigned and +1
-- name: Find available port
-  shell: docker ps --format \"\{\{\.Ports\}\}\" | awk -F[:-] '{print $2}' | sort | tail -n 1
-  register: docker_port_output
-
-- name: Set docker_port variable if empty
+- name: Set ansible_architecture to arm if we are bulidng arm32 containers on arm64
   set_fact:
-    docker_port: 32000
-  when: docker_port_output.stdout == ""
+    ansible_architecture: arm
+  when: build_arm != ""
 
-- name: Set docker_port variable when non empty
+- name: Set docker build command
   set_fact:
-    docker_port: "{{ docker_port_output.stdout | int + 1 }}"
-  when: not (docker_port_output.stdout == "")
+    docker_build_command: "docker build"
 
-- name: Run {{ docker_image }} docker container
-  command: docker run --restart unless-stopped -p {{ docker_port }}:22 --cpuset-cpus="0-3" --memory=6G --detach --name {{ docker_image | upper }}.{{ docker_port }} aqa_{{ docker_image }}
+- name: Set docker buildx command
+  set_fact:
+    docker_build_command: "docker buildx build --platform linux/v7/arm"
+  when: build_arm != ""
+
+- name: debug
+  debug:
+    msg: "{{ docker_build_command }}"
+
+# # Dockerfiles are transferred from the controller node onto the dockerhost to be used to build and run docker containers
+# - name: Transfer dockerfile
+#   copy:
+#     src: "roles/DockerStatic/Dockerfiles/Dockerfile.{{ docker_image }}"
+#     dest: "/tmp/Dockerfile.{{ docker_image }}"
+
+# # For images built on non x86_64 dockerhosts
+# - name: Translate architecture in dockerfile
+#   replace:
+#     dest: /tmp/Dockerfile.{{ docker_image }}
+#     regexp: "x64"
+#     replace: "{{ ansible_architecture }}"
+#   when: ansible_architecture != "x86_64"
+
+# - name: Set jenkins authorized_Key in dockerfiles
+#   replace:
+#     dest: /tmp/Dockerfile.{{ docker_image }}
+#     regexp: "Jenkins_User_SSHKey"
+#     replace: "{{ Jenkins_User_SSHKey }}"
+
+# - name: Build {{ docker_image }} docker images {{ docker_build_command }}
+#   command: "{{ docker_build_command }} --cpu-period=100000 --cpu-quota=800000 -t aqa_{{ docker_image }} --memory=6G -f /tmp/Dockerfile.{{ docker_image }} /tmp/"
+
+# # Finds the highest port number already assigned and +1
+# - name: Find available port
+#   shell: docker ps --format \"\{\{\.Ports\}\}\" | awk -F[:-] '{print $2}' | sort | tail -n 1
+#   register: docker_port_output
+
+# - name: Set docker_port variable if empty
+#   set_fact:
+#     docker_port: 32000
+#   when: docker_port_output.stdout == ""
+
+# - name: Set docker_port variable when non empty
+#   set_fact:
+#     docker_port: "{{ docker_port_output.stdout | int + 1 }}"
+#   when: not (docker_port_output.stdout == "")
+
+# - name: Run {{ docker_image }} docker container
+#   command: docker run --restart unless-stopped -p {{ docker_port }}:22 --cpuset-cpus="0-3" --memory=6G --detach --name {{ docker_image | upper }}.{{ docker_port }} aqa_{{ docker_image }}

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
@@ -1,18 +1,18 @@
 ---
 
-- name: Set ansible_architecture to arm if we are bulidng arm32 containers on arm64
+- name: Set ansible_architecture to arm if bulidng arm32 containers on arm64
   set_fact:
     ansible_architecture: arm
-  when: build_arm != ""
+  when: build_arm is defined
 
 - name: Set docker build command
   set_fact:
     docker_build_command: "docker build"
 
-- name: Set docker buildx command
+- name: Set docker buildx command if building arm container
   set_fact:
     docker_build_command: "docker buildx build --platform linux/v7/arm"
-  when: build_arm != ""
+  when: build_arm is defined
 
 - name: debug
   debug:


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly


Ref https://github.com/adoptium/infrastructure/issues/3579

Adds ability to build arm32 containers using docker buildx. Updates docs accordingly