### PR TITLE
UnixPB: Install JQ for mac repro tests.

### DIFF
--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -24,7 +24,10 @@ jobs:
 
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
-    - name: Install dependencies
+    - name: Install Python
+      run: brew install python@3.12 --overwrite
+
+    - name: Install Ansible
       run: brew install ansible
 
     # This is to fix an issue with the github macos14 runner, that cant resolve keyserver.ubuntu.com

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/MacOSX.yml
@@ -25,6 +25,7 @@ Build_Tool_Casks:
 Test_Tool_Packages:
   - mercurial
   - pulseaudio
+  - jq
 
 JCK_Tool_Casks:
   - blackhole-2ch # Used to emulate a line in feed for JCK tests


### PR DESCRIPTION
Ensure JQ is installed on Mac Hosts for Reproducible build tests.

See: #3593 

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC not applicable for this PR ( No Mac testing option. )