### PR TITLE
unixPB: Add new Scaleway TC machine to iptables config

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/jckservices_iptables/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/jckservices_iptables/tasks/main.yml
@@ -76,6 +76,7 @@
     - 62.210.163.106 # jck-scaleway-ubuntu2310-riscv64-2
     - 20.234.51.61 # jck-azure-ubuntu2204-x64-1
     - 172.178.96.199 # jck-ubuntu-2204-solaris10
+    - 62.210.163.131 # jck-rise-ubuntu2404-risc64-1
 
 - name: Setup iptables
   iptables:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
