### PR TITLE
github: Fix latest linter errors

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/yum/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/yum/tasks/main.yml
@@ -70,8 +70,6 @@
     - name: Unpack yum bundle
       command:
         cmd: /usr/bin/tar -xf /tmp/yum/yum_bundle.tar -C /tmp/yum
-        # Neither zip nor gtar is not available, disable warning about unpack:
-        warn: false
 
     - name: Install yum bundle
       command: rpm -i /tmp/yum/*.rpm

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ccache/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ccache/tasks/main.yml
@@ -16,7 +16,6 @@
 
 - name: Download ccache.tar.gz
   command: wget -O /tmp/ccache.tar.gz https://github.com/ccache/ccache/releases/download/v{{ ccacheVersion }}/ccache-{{ ccacheVersion }}.tar.gz
-    warn=False
   when: ccache_status.rc != 0
   tags: ccache
 


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Using `warn: False`/`warn=False` is deprecated, which is causing linter errors
`FAILED! => {"changed": false, "msg": "Unsupported parameters for (ansible.legacy.command) module: warn. Supported parameters include: _raw_params, _uses_shell, argv, chdir, creates, executable, removes, stdin, stdin_add_newline, strip_empty_ends."}`

```
inline-env-var: Command module does not accept setting environment variables inline.
ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/yum/tasks/main.yml:70 Task/Handler: Unpack yum bundle

inline-env-var: Command module does not accept setting environment variables inline.
ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ccache/tasks/main.yml:17 Task/Handler: Download ccache.tar.gz
```

For the aix yum task, the yum role is deprecated. We install dnf on 7.2+ so I am comfortable removing the `warn` option there. For the ccache role, running the task without the `warn` makes no difference to the output, so i've removed it for that task