### PR TITLE
packer: add workflow to automatically update orka images

### DIFF
--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -1,0 +1,45 @@
+name: Packer
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+    - .github/workflows/packer.yml
+    - ansible/playbooks/AdoptOpenJDK_Unix_Playbook/**
+    - ansible/packer/**
+    branches:
+    - master
+
+jobs:
+  packer:
+    name: Update macOS Orka Image
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+    # This is to fix an issue with the github macos14 runner, that cant resolve keyserver.ubuntu.com
+    # but this does work when replaced with the IP address. Spotted during the GPG verification of ANT step
+    # Upstream Bug : https://github.com/actions/runner-images/issues/9777
+    - name: Replace keyserver address with IP address
+      run: |
+        sed -i '' 's/keyserver\.ubuntu\.com/185.125.188.27/g' ansible/playbooks/Supporting_Scripts/package_signature_verification.sh
+
+    - name: Install openconnect
+      run: sudo apt-get install -y openconnect
+
+    - name: Connect to Orka VPN
+      run: |
+        echo ${{ secrets.ORKA_VPN_PASSWORD }} | sudo openconnect 207.254.69.34 \
+        --protocol=anyconnect --user=${{ secrets.ORKA_VPN_USERNAME }} \
+        --passwd-on-stdin --background \
+        --servercert ${{ secrets.ORKA_VPN_SERVER_CERT }}
+
+    - name: Init Packer
+      run: packer init orka.pkr.hcl
+      working-directory: ansible/packer
+
+    - name: Run Packer
+      run: packer build orka.pkr.hcl
+      working-directory: ansible/packer
+      env:
+        ORKA_TOKEN: ${{ secrets.ORKA_TOKEN }}


### PR DESCRIPTION
Adds support for auto regenerating the Orka macOS images on PR merge. For now while we don't have an accurate way of installing xcode this will only update the top layer

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
