### PR TITLE
WinPB: Update Wix Installation To Install SDK

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2022/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2022/tasks/main.yml
@@ -94,7 +94,7 @@
 - name: Download Visual Studio Community 2022
   win_get_url:
     url: 'https://aka.ms/vs/17/release/vs_Community.exe'
-    checksum: d757db0e5ac12b73d1f1bad8f0de05f0974a268c6a720324ea93239c6872a94e
+    checksum: 5d75942b56df540a0325e764e7eb46498ec12e15b73adea05d8aa58d323efd90
     checksum_algorithm: sha256
     dest: 'C:\temp\vs_community22.exe'
     force: no

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/WiX/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/WiX/tasks/main.yml
@@ -63,4 +63,3 @@
     path: 'C:\temp\dotnet-install.exe'
     state: absent
   tags: Wix
-

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/WiX/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/WiX/tasks/main.yml
@@ -13,11 +13,38 @@
   register: wix_installed
   tags: Wix
 
+- name: Test if DotNet SDK is already installed
+  win_stat:
+    path: 'C:\\Program Files\dotnet\dotnet.exe'
+  register: dotnet_installed
+  tags: Wix
+
+- name: Download .NET Installer
+  win_get_url:
+    url: https://download.visualstudio.microsoft.com/download/pr/b6f19ef3-52ca-40b1-b78b-0712d3c8bf4d/426bd0d376479d551ce4d5ac0ecf63a5/dotnet-sdk-8.0.302-win-x64.exe
+    dest: 'C:\temp\dotnet-install.exe'
+    checksum: bc6019e0192edd180ca7b299a16b95327941b0b53806cdb125be194aea12492d
+    checksum_algorithm: sha256
+  when: (not dotnet_installed.stat.exists)
+  tags: Wix
+
+- name: Install .NET SDK If dotnet not installed
+  raw: C:\temp\dotnet-install.exe /quiet
+  when: (not dotnet_installed.stat.exists)
+  tags: Wix
+
+- name: Test if WiX is already installed
+  win_stat:
+    path: 'C:\\Users\{{ Jenkins_Username }}\.dotnet/tools/wix'
+  register: wix_installed
+  tags: Wix
+
 - name: Test WiX version
   # generates an output like 5.0.0+41e11442
   win_shell: wix --version
   register: installed_wix_version
   become_user: "{{ Jenkins_Username }}"
+  become_method: runas
   become: true
   when: wix_installed.stat.exists
   tags: Wix
@@ -25,6 +52,15 @@
 - name: Install Wix Toolset when not installed or version is not correct
   win_shell: dotnet tool install --global wix --version {{ wix_version }}
   become_user: "{{ Jenkins_Username }}"
+  become_method: runas
   become: true
   when: (not wix_installed.stat.exists) or (installed_wix_version.stdout.find(wix_version) == -1)
+  register: wixinstall_out
   tags: Wix
+
+- name: Delete downloaded .NET installer
+  win_file:
+    path: 'C:\temp\dotnet-install.exe'
+    state: absent
+  tags: Wix
+

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/WiX/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/WiX/tasks/main.yml
@@ -55,7 +55,6 @@
   become_method: ansible.builtin.runas
   become: true
   when: (not wix_installed.stat.exists) or (installed_wix_version.stdout.find(wix_version) == -1)
-  register: wixinstall_out
   tags: Wix
 
 - name: Delete downloaded .NET installer

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/WiX/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/WiX/tasks/main.yml
@@ -44,7 +44,7 @@
   win_shell: wix --version
   register: installed_wix_version
   become_user: "{{ Jenkins_Username }}"
-  become_method: runas
+  become_method: ansible.builtin.runas
   become: true
   when: wix_installed.stat.exists
   tags: Wix
@@ -52,7 +52,7 @@
 - name: Install Wix Toolset when not installed or version is not correct
   win_shell: dotnet tool install --global wix --version {{ wix_version }}
   become_user: "{{ Jenkins_Username }}"
-  become_method: runas
+  become_method: ansible.builtin.runas
   become: true
   when: (not wix_installed.stat.exists) or (installed_wix_version.stdout.find(wix_version) == -1)
   register: wixinstall_out


### PR DESCRIPTION
Update the Wix5 installation task, as the .NET SDK is not installed by default, and the wix installation requires it.

This also addresses a bug, where the playbook incorrectly uses sudo as a become method, which should be runas in Windows.

Fixes #3617 

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)