### PR TITLE
inventory: add new rise/scaleway ubuntu 24.04 systems

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -148,13 +148,13 @@ hosts:
       - rise:
           ubuntu2310-riscv64-1: {ip: 62.210.163.38, user: ubuntu}
           ubuntu2310-riscv64-2: {ip: 62.210.163.36, user: ubuntu}
-          ubuntu2310-riscv64-3: {ip: 62.210.163.3, user: ubuntu}
-          ubuntu2310-riscv64-4: {ip: 62.210.163.137, user: ubuntu}
-          ubuntu2310-riscv64-5: {ip: 62.210.163.45, user: ubuntu}
           ubuntu2404-riscv64-1: {ip: 62.210.163.41, user: ubuntu}
           ubuntu2404-riscv64-2: {ip: 62.210.163.196, user: ubuntu}
           ubuntu2404-riscv64-3: {ip: 62.210.163.99, user: ubuntu}
           ubuntu2404-riscv64-4: {ip: 62.210.163.103, user: ubuntu}
+          ubuntu2404-riscv64-5: {ip: 62.210.163.45, user: ubuntu}
+          ubuntu2404-riscv64-6: {ip: 62.210.163.135, user: ubuntu}
+          ubuntu2404-riscv64-7: {ip: 62.210.163.137, user: ubuntu}
 
       - siteox:
           solaris10u11-sparcv9-1: {ip: cloud.siteox.com, port: 53322}

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -151,11 +151,10 @@ hosts:
           ubuntu2310-riscv64-3: {ip: 62.210.163.3, user: ubuntu}
           ubuntu2310-riscv64-4: {ip: 62.210.163.137, user: ubuntu}
           ubuntu2310-riscv64-5: {ip: 62.210.163.45, user: ubuntu}
-          ubuntu2310-riscv64-6: {ip: 62.210.163.168, user: ubuntu}
-          ubuntu2310-riscv64-7: {ip: 62.210.163.105, user: ubuntu}
-          ubuntu2310-riscv64-8: {ip: 62.210.163.164, user: ubuntu}
-          ubuntu2310-riscv64-9: {ip: 62.210.163.6, user: ubuntu}
-          ubuntu2310-riscv64-10: {ip: 62.210.163.102, user: ubuntu}
+          ubuntu2404-riscv64-1: {ip: 62.210.163.41, user: ubuntu}
+          ubuntu2404-riscv64-2: {ip: 62.210.163.196, user: ubuntu}
+          ubuntu2404-riscv64-3: {ip: 62.210.163.99, user: ubuntu}
+          ubuntu2404-riscv64-4: {ip: 62.210.163.103, user: ubuntu}
 
       - siteox:
           solaris10u11-sparcv9-1: {ip: cloud.siteox.com, port: 53322}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

In draft while machine setup is completed. We will ultimately replace all of the 23.10 systems with 24.04 ones.
Part of https://github.com/temurin-compliance/temurin-compliance/issues/522

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
