### PR TITLE
unixPB: update jckservices iptables config for new riscv64 machines

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/jckservices_iptables/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/jckservices_iptables/tasks/main.yml
@@ -72,11 +72,11 @@
     - 207.254.73.168 # gn324-macos11-x86_64
     - 207.254.28.13 # esmv4-macos11-arm64
     - 207.254.28.99 # noh7B-macos12-arm64
-    - 62.210.163.172 # jck-scaleway-ubuntu2310-riscv64-1
-    - 62.210.163.106 # jck-scaleway-ubuntu2310-riscv64-2
     - 20.234.51.61 # jck-azure-ubuntu2204-x64-1
     - 172.178.96.199 # jck-ubuntu-2204-solaris10
     - 62.210.163.131 # jck-rise-ubuntu2404-risc64-1
+    - 62.210.163.164 # jck-rise-ubuntu2404-risc64-2
+    - 62.210.163.34 # jck-rise-ubuntu2404-risc64-3
 
 - name: Setup iptables
   iptables:


### PR DESCRIPTION
Updates for new 24.04 systems for temurin-compliance. Part of  https://github.com/adoptium/infrastructure/issues/3598 - machines added at https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/4760

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
