### PR TITLE
Docker: Fix Use Of mirrorlist.centos.org in dockerfiles and Unix playbooks.

### DIFF
--- a/ansible/docker/Dockerfile.CentOS7
+++ b/ansible/docker/Dockerfile.CentOS7
@@ -3,8 +3,11 @@ FROM centos:7
 ARG git_sha
 ARG user=jenkins
 
-RUN yum -y update; yum -y install epel-release
-RUN yum -y install ansible sudo; yum clean all
+RUN sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-Base.repo; \
+    sed -i -e 's!#baseurl=http://mirror.centos.org/centos/\$releasever!baseurl=https://vault.centos.org/7.9.2009/!g' /etc/yum.repos.d/CentOS-Base.repo; \
+    yum -y update; yum clean all; \
+    yum -y install epel-release; \
+    yum -y install ansible sudo; yum clean all
 
 COPY . /ansible
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
@@ -153,6 +153,45 @@
     - ansible_architecture == "x86_64" and ansible_distribution_major_version == "6"
   tags: build_tools
 
+- name: Change the baseurl for CentOS SCL (CentOS7)
+  lineinfile:
+    path: /etc/yum.repos.d/CentOS-SCLo-scl.repo
+    regexp: '^# baseurl=http://mirror.centos.org/centos/7/sclo/\$basearch/sclo/'
+    line: 'baseurl=https://vault.centos.org/7.9.2009/sclo/$basearch/sclo/'
+    state: present
+  when:
+    - ansible_architecture == "x86_64" and ansible_distribution_major_version == "7"
+  tags: build_tools
+
+- name: Change the baseurl for CentOS SCL RH (CentOS7)
+  lineinfile:
+    path: /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
+    regexp: '^#baseurl=http://mirror.centos.org/centos/7/sclo/\$basearch/rh/'
+    line: 'baseurl=https://vault.centos.org/7.9.2009/sclo/$basearch/rh/'
+    state: present
+  when:
+    - ansible_architecture == "x86_64" and ansible_distribution_major_version == "7"
+  tags: build_tools
+
+# - name: Remove the mirrorlist URL for Centos 7 SCL Repositories
+#   shell: |
+#     sed -i -e 's!^mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-SCLo-scl*.repo
+#   when:
+#     - ansible_architecture == "x86_64" and ansible_distribution_major_version == "7"
+#   tags: build_tools
+
+- name: Remove the mirrorlist URL for Centos 7 SCL Repositories
+  lineinfile:
+    path: "{{ item }}"
+    regexp: '^mirrorlist'
+    line: '#mirrorlist'
+    state: present
+  with_fileglob:
+    - /etc/yum.repos.d/CentOS-SCLo-scl*.repo
+  when:
+    - ansible_architecture == "x86_64" and ansible_distribution_major_version == "7"
+  tags: build_tools
+
 - name: Install additional build tools for CentOS on x86
   package: "name={{ item }} state=latest"
   with_items: "{{ Additional_Build_Tools_CentOS_x86 }}"

--- a/ansible/vagrant/Vagrantfile.CentOS7
+++ b/ansible/vagrant/Vagrantfile.CentOS7
@@ -2,9 +2,13 @@
 # vi: set ft=ruby :
 
 $script = <<SCRIPT
+sudo sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-Base.repo
+sudo sed -i -e 's!#baseurl=http://mirror.centos.org/centos/\$releasever!baseurl=https://vault.centos.org/7.9.2009/!g' /etc/yum.repos.d/CentOS-Base.repo
 sudo yum -y update
+sudo yum -y install epel-release
 sudo yum install -y libselinux-python
 sudo yum install -y ansible
+sudo yum clean all
 sudo mkdir /ansible
 sudo cp /etc/ansible/ansible.cfg /ansible
 sudo touch /ansible/hosts


### PR DESCRIPTION
Fixes #3642 

Update various calls to mirrorlist.centos.org with vault.centos.org, now that mirrorlist has been deprecated following the EOL of Centos 7.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)

VPC in progress:

https://ci.adoptium.net/job/VagrantPlaybookCheck/1897/OS=CentOS8,label=vagrant/console
https://ci.adoptium.net/job/VagrantPlaybookCheck/1897/OS=CentOS7,label=vagrant/console