### PR TITLE
Docker: Fix Use Of mirrorlist.centos.org in dockerfiles for arm64 & ppc64le

### DIFF
--- a/ansible/docker/Dockerfile.CentOS7
+++ b/ansible/docker/Dockerfile.CentOS7
@@ -9,7 +9,7 @@ RUN if [ "$(uname -m)" == "x86_64" ]; then \
       echo "Running on x64 architecture"; \
       sed -i -e 's!#baseurl=http://mirror.centos.org/centos/\$releasever!baseurl=https://vault.centos.org/7.9.2009/!g' /etc/yum.repos.d/CentOS-Base.repo; \
     else \
-      echo "Running on another architecture"; \
+      echo "Running on non-x64 architecture"; \
       sed -i 's|#baseurl=http://mirror.centos.org/altarch/\$releasever/|baseurl=http://vault.centos.org/altarch/7.9.2009/|' /etc/yum.repos.d/CentOS-Base.repo; \
     fi
 

--- a/ansible/docker/Dockerfile.CentOS7
+++ b/ansible/docker/Dockerfile.CentOS7
@@ -3,9 +3,21 @@ FROM centos:7
 ARG git_sha
 ARG user=jenkins
 
-RUN sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-Base.repo; \
-    sed -i -e 's!#baseurl=http://mirror.centos.org/centos/\$releasever!baseurl=https://vault.centos.org/7.9.2009/!g' /etc/yum.repos.d/CentOS-Base.repo; \
-    yum -y update; yum clean all; \
+RUN sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-Base.repo
+
+RUN if [ "$(uname -m)" = "aarch64" ]; then \
+      echo "Running on arm64 architecture"; \
+      sed -i 's|#baseurl=http://mirror.centos.org/altarch/\$releasever/|baseurl=http://vault.centos.org/altarch/7.9.2009/|' /etc/yum.repos.d/CentOS-Base.repo; \
+    elif [ "$(uname -m)" = "ppc64le" ]; then \
+      echo "Running on ppc64le architecture"; \
+      sed -i 's|#baseurl=http://mirror.centos.org/altarch/\$releasever/|baseurl=http://vault.centos.org/altarch/7.9.2009/|' /etc/yum.repos.d/CentOS-Base.repo; \
+    else \
+      # Default To x64; \
+      echo "Running on another architecture"; \
+      sed -i -e 's!#baseurl=http://mirror.centos.org/centos/\$releasever!baseurl=https://vault.centos.org/7.9.2009/!g' /etc/yum.repos.d/CentOS-Base.repo; \
+    fi
+
+RUN yum -y update; yum clean all; \
     yum -y install epel-release; \
     yum -y install ansible sudo; yum clean all
 

--- a/ansible/docker/Dockerfile.CentOS7
+++ b/ansible/docker/Dockerfile.CentOS7
@@ -5,16 +5,12 @@ ARG user=jenkins
 
 RUN sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-Base.repo
 
-RUN if [ "$(uname -m)" = "aarch64" ]; then \
-      echo "Running on arm64 architecture"; \
-      sed -i 's|#baseurl=http://mirror.centos.org/altarch/\$releasever/|baseurl=http://vault.centos.org/altarch/7.9.2009/|' /etc/yum.repos.d/CentOS-Base.repo; \
-    elif [ "$(uname -m)" = "ppc64le" ]; then \
-      echo "Running on ppc64le architecture"; \
-      sed -i 's|#baseurl=http://mirror.centos.org/altarch/\$releasever/|baseurl=http://vault.centos.org/altarch/7.9.2009/|' /etc/yum.repos.d/CentOS-Base.repo; \
-    else \
-      # Default To x64; \
-      echo "Running on another architecture"; \
+RUN if [ "$(uname -m)" == "x86_64" ]; then \
+      echo "Running on x64 architecture"; \
       sed -i -e 's!#baseurl=http://mirror.centos.org/centos/\$releasever!baseurl=https://vault.centos.org/7.9.2009/!g' /etc/yum.repos.d/CentOS-Base.repo; \
+    else \
+      echo "Running on another architecture"; \
+      sed -i 's|#baseurl=http://mirror.centos.org/altarch/\$releasever/|baseurl=http://vault.centos.org/altarch/7.9.2009/|' /etc/yum.repos.d/CentOS-Base.repo; \
     fi
 
 RUN yum -y update; yum clean all; \


### PR DESCRIPTION
Fixes #3646 

Update various calls to mirrorlist.centos.org with vault.centos.org, now that mirrorlist has been deprecated following the EOL of Centos 7.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR
