### PR TITLE
docker: Install curl-devel onto centos7 static docker containers

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.cent7
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.cent7
@@ -16,7 +16,7 @@ RUN if [ "$(uname -m)" = "aarch64" ]; then \
 
 RUN yum -y update && yum clean all
 
-RUN yum -y update && yum install -y perl openssh-server unzip zip wget epel-release perl-devel perl-Digest-SHA perl-Data-Dumper gettext zlib-devel git curl make gcc libXrender libXi libXtst fontconfig fakeroot xorg-x11-server-Xvfb
+RUN yum -y update && yum install -y perl openssh-server unzip zip wget epel-release perl-devel perl-Digest-SHA perl-Data-Dumper gettext zlib-devel git curl curl-devel make gcc libXrender libXi libXtst fontconfig fakeroot xorg-x11-server-Xvfb
 # Install OpenSSL Packages
 RUN yum install -y gnutls gnutls-utils nss-devel nss-tools
 RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -P ""


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Forgot to add this change in https://github.com/adoptium/infrastructure/pull/3402

Curl-devel is required before compiling git 2.15.0 from source to resolve `fatal: Unable to find remote helper for https`