### PR TITLE
packer: auto rebuild base image for intel

### DIFF
--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -40,8 +40,14 @@ jobs:
     - name: Init Packer
       run: packer init orka.pkr.hcl
       working-directory: ansible/packer
+    
+    - name: Run Packer (base image)
+      # Skip arm64 for now as Xcode download takes too long
+      if: matrix.os != 'sonoma-arm64'
+      run: packer build --only=macstadium-orka.${{ matrix.os }} orka-base.pkr.hcl
+      working-directory: ansible/packer
 
-    - name: Run Packer
+    - name: Run Packer (final image)
       run: packer build --only=macstadium-orka.${{ matrix.os }} orka.pkr.hcl
       working-directory: ansible/packer
       env:

--- a/ansible/packer/orka-base.pkr.hcl
+++ b/ansible/packer/orka-base.pkr.hcl
@@ -62,7 +62,9 @@ build {
   }
 
   # Pause the provisioner until user interacts (for install Xcode etc)
-  provisioner "breakpoint" {}
+  provisioner "breakpoint" {
+    only = ["macstadium-orka.sonoma-arm64"]
+  }
 
   # Install homebrew and ansible
   provisioner "shell" {
@@ -85,6 +87,8 @@ EOF
 
   # Install Xcode
   provisioner "ansible-local" {
+    # We only install Xcode on the arm64 VM (build tools is enough for the Intel test VMs)
+    only = ["macstadium-orka.sonoma-arm64"]
     playbook_file = "../playbooks/AdoptOpenJDK_Unix_Playbook/main.yml"
     playbook_dir = "../playbooks/AdoptOpenJDK_Unix_Playbook"
     extra_arguments = [

--- a/ansible/packer/orka.pkr.hcl
+++ b/ansible/packer/orka.pkr.hcl
@@ -47,6 +47,8 @@ build {
 
   # Ensure ansible package is up to date
   provisioner "shell" {
+    # Only needed on arm64 as we rebuild intel base frequently
+    only = ["macstadium-orka.sonoma-arm64"]
     inline = [
       "source /Users/admin/.zprofile; brew upgrade ansible",
     ]


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

We can easily (and quickly) rebuild the base image for intel which means that it will always contain security updates etc. I've enabled this for intel but cannot make the same change for arm64 yet as it the Xcode download is too flaky.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
