### PR TITLE
Vagrant: Fix Debian 10 Vagrantfile For Deb repositories.

### DIFF
--- a/ansible/vagrant/Vagrantfile.Debian10
+++ b/ansible/vagrant/Vagrantfile.Debian10
@@ -2,6 +2,12 @@
 # vi: set ft=ruby :
 
 $script = <<SCRIPT
+# Configure DPKG to be noninteractive
+sudo ex +"%s@DPkg@//DPkg" -cwq /etc/apt/apt.conf.d/70debconf
+sudo dpkg-reconfigure debconf -f noninteractive -p critical
+# Update Repository Addresses For Debian
+sudo sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list
+sudo apt-get update
 sudo apt-get install tree -y
 sudo apt-get install software-properties-common -y
 sudo apt-get install gpg -y


### PR DESCRIPTION
Fixes #3655 

Update the Debian 10 repositories to use the archive repositories, and configure dpkg to not require interactive mode during vagrant provisioning.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)

VPC OK: https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Debian10,label=vagrant/1903/