### PR TITLE
Vagrant: Fix VPC For Ubuntu 20.04

### DIFF
--- a/ansible/vagrant/Vagrantfile.Ubuntu2004
+++ b/ansible/vagrant/Vagrantfile.Ubuntu2004
@@ -6,13 +6,16 @@ $script = <<SCRIPT
 if [ -r /vagrant/id_rsa.pub ]; then
         mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys
 fi
+# Add The PPA Repo To Get Later Version Of ansible
+sudo apt-add-repository ppa:ansible/ansible
+sudo apt update
 SCRIPT
 
 # 2 = version of configuration file for Vagrant 1.1+ leading up to 2.0.x
 Vagrant.configure("2") do |config|
 
   config.vm.define :adoptopenjdkU20 do |adoptopenjdkU20|
-    adoptopenjdkU20.vm.box = "generic/ubuntu2004"
+    adoptopenjdkU20.vm.box = "bento/ubuntu-20.04"
     adoptopenjdkU20.vm.synced_folder ".", "/vagrant"
     adoptopenjdkU20.vm.hostname = "adoptopenjdkU20"
     adoptopenjdkU20.vm.network :private_network, type: "dhcp"


### PR DESCRIPTION
Switch box to use bento box, which has larger /boot partition. Also include ppa repository to ensure more recent ansible is installed.

VPC OK: https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Ubuntu2004,label=vagrant/1905/ 

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
