### PR TITLE
docker: Docker image tag must be lowercase when building dockerstatic image

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
@@ -9,7 +9,7 @@
 - name: Set docker buildx command if building arm32 container
   set_fact:
     docker_build_command: "docker buildx build --platform linux/v7/arm"
-    arm32_suffix: ".ARM32"
+    arm32_suffix: ".arm32"
     ansible_architecture: arm
     docker_run_command: "docker run --platform linux/v7/arm"
   when: build_arm32 is defined and build_arm32 == "yes"
@@ -53,4 +53,4 @@
   when: not (docker_port_output.stdout == "")
 
 - name: Run {{ docker_image }} docker container
-  command: "{{ docker_run_command }} --restart unless-stopped -p {{ docker_port }}:22 --cpuset-cpus='0-3' --memory=6G --detach --name {{ docker_image | upper }}.{{ docker_port }}{{ arm32_suffix }} aqa_{{ docker_image }}{{ arm32_suffix }}"
+  command: "{{ docker_run_command }} --restart unless-stopped -p {{ docker_port }}:22 --cpuset-cpus='0-3' --memory=6G --detach --name {{ docker_image | upper }}.{{ docker_port }}{{ arm32_suffix | upper }} aqa_{{ docker_image }}{{ arm32_suffix }}"


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Fixes this error `["ERROR: invalid tag \"aqa_u2404.ARM32\": repository name must be lowercase"]`