### PR TITLE
inventory: test-marist-ubuntu2404-s390x-1 added to inventory

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -144,7 +144,7 @@ hosts:
           rhel8-s390x-2: {ip: 148.100.74.2}
           sles12-s390x-2: {ip: 148.100.74.193}
           sles15-s390x-2: {ip: 148.100.74.154, ansible_python_interpreter: /usr/bin/python3}
-          ubuntu2004-s390x-1: {ip: 148.100.74.240}
+          ubuntu2404-s390x-1: {ip: 148.100.75.204}
           ubuntu2204-s390x-1: {ip: 148.100.74.105}
 
       # Rise machines are hosted in Scaleway


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

test-marist-ubuntu2004-s390x-1 upgraded to test-marist-ubuntu2404-s390x-1 as of https://github.com/adoptium/infrastructure/issues/3501#issuecomment-2260357969