### PR TITLE
Packer: Install Xcode For Intel Macs.

### DIFF
--- a/ansible/packer/orka-base.pkr.hcl
+++ b/ansible/packer/orka-base.pkr.hcl
@@ -87,7 +87,6 @@ EOF
 
   # Install Xcode
   provisioner "ansible-local" {
-    # We only install Xcode on the arm64 VM (build tools is enough for the Intel test VMs)
     playbook_file = "../playbooks/AdoptOpenJDK_Unix_Playbook/main.yml"
     playbook_dir = "../playbooks/AdoptOpenJDK_Unix_Playbook"
     extra_arguments = [

--- a/ansible/packer/orka-base.pkr.hcl
+++ b/ansible/packer/orka-base.pkr.hcl
@@ -88,7 +88,6 @@ EOF
   # Install Xcode
   provisioner "ansible-local" {
     # We only install Xcode on the arm64 VM (build tools is enough for the Intel test VMs)
-    only = ["macstadium-orka.sonoma-arm64"]
     playbook_file = "../playbooks/AdoptOpenJDK_Unix_Playbook/main.yml"
     playbook_dir = "../playbooks/AdoptOpenJDK_Unix_Playbook"
     extra_arguments = [


### PR DESCRIPTION
Fixes #3720 

Intel Macs now require Xcode for reproducible build tests.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR

