### PR TITLE
WindowsPB: Add Incredibuild Dashboard Configuration Task

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -85,6 +85,7 @@
     - IcedTea-Web                 # For Jenkins webstart
     - WiX                         # For creating installers
     - NSClient                    # Required For Nagios Monitoring
+    - Incredibuild                # Configure Incredibuild Dashboard Service
     - shortNames
     - Dragonwell                  # Dragonwell bootstrap image
     - role: Jenkins_Service_Installation # Automate installing the jenkins service

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Incredibuild/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Incredibuild/tasks/main.yml
@@ -27,7 +27,7 @@
     backup: yes
   when: incredibuild_conf_file.stat.exists
 
-- name: Stop the IBX Dashboard service if it exists
+- name: Start the IBX Dashboard service if it exists
   ansible.windows.win_service:
     name: IBXDashboard
     state: started

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Incredibuild/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Incredibuild/tasks/main.yml
@@ -1,0 +1,34 @@
+---
+#######################################
+# Incredibuild - Configuration Tasks  #
+#######################################
+
+- name: Check if the ibxbuild service exists
+  ansible.windows.win_service_info:
+    name: IBXDashboard
+  register: service_info
+
+- name: Stop the IBX Dashboard service if it exists
+  ansible.windows.win_service:
+    name: IBXDashboard
+    state: stopped
+  when: service_info.exists
+
+- name: Check if incredibuild.conf file exists
+  win_stat:
+    path: 'C:\Program Files (x86)\IncrediBuild\Dashboard\Apache24\conf\incredibuild.conf'
+  register: incredibuild_conf_file
+
+- name: Replace APACHE_PORT in incredibuild.conf if file exists
+  win_lineinfile:
+    path: 'C:\Program Files (x86)\IncrediBuild\Dashboard\Apache24\conf\incredibuild.conf'
+    regexp: '^define APACHE_PORT \d+$'
+    line: 'define APACHE_PORT 31000'
+    backup: yes
+  when: incredibuild_conf_file.stat.exists
+
+- name: Stop the IBX Dashboard service if it exists
+  ansible.windows.win_service:
+    name: IBXDashboard
+    state: started
+  when: service_info.exists


### PR DESCRIPTION
Fixes:  https://github.com/adoptium/aqa-tests/issues/5474

As seen in the above issue, the jwebserver tests fail due to a conflict with a process on port 8000. After investigation, this turns out to be a clash with the incredibuild dashboard service.

This change, reconfigures the Incredibuild dashboard service to use a different port. ( The incredibuild service uses port 30000, so 31000 seemed appropriate for the dashboard. Also having carried out investigation, I cannot find any other services using this port on Windows.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)

VPC Completed OK : https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Win2022,label=vagrant/1959/console