### PR TITLE
inventory: s390x and ppc64le dockerhosts have been upgraded to ubuntu 2404

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -88,11 +88,11 @@ hosts:
           ubuntu2204-armv8-1: {ip: 139.178.86.243, description: Ampere Altra 160 cores, 512Gb}
 
       - osuosl:
-          ubuntu2004-ppc64le-1: {ip: 140.211.168.214}
+          ubuntu2404-ppc64le-1: {ip: 140.211.168.214}
           ubuntu2404-aarch64-1: {ip: 140.211.167.67}
 
       - marist:
-          ubuntu2204-s390x-1: {ip: 148.100.74.237, user: linux1}
+          ubuntu2404-s390x-1: {ip: 148.100.74.237, user: linux1}
 
       - skytap:
           ubuntu2004-ppc64le-1: {ip: 20.61.136.212, description: 32CPU, 400G}


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/3585