### PR TITLE
GHA: Update Solaris Check Github Action With Valid Tools

### DIFF
--- a/.github/workflows/build_vagrant.yml
+++ b/.github/workflows/build_vagrant.yml
@@ -39,7 +39,7 @@ jobs:
     #   run: pip2 install ansible
 
     - name: Check Python
-      run: sudo ls -l /usr/bin/python*
+      run: sudo apt-get install -y python3.10
 
     - name: Download and add the HashiCorp GPG key
       run: sudo curl -fsSL https://apt.releases.hashicorp.com/gpg -o /tmp/hashicorp.gpg

--- a/.github/workflows/build_vagrant.yml
+++ b/.github/workflows/build_vagrant.yml
@@ -28,8 +28,14 @@ jobs:
     # Use Python2 & Pip To Install On Ubuntu 22.04
     # Rather Than The System Packages
 
-    # - name: Install Python 2
-    #   run: sudo apt-get install python2
+    - name: Install Python 2
+      run: sudo add-apt-repository ppa:deadsnakes/ppa
+
+    - name: Update Repos
+      run: sudo apt-get update
+
+    - name: Install Python 2
+      run: sudo apt-get install python2
     #
     # - name: Python 2 Get Pip Bootstrap Script
     #   run: curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
@@ -115,4 +121,4 @@ jobs:
 
     - name: Run Ansible Playbook
       working-directory: ansible
-      run: ansible-playbook -i playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx -e 'ansible_python_interpreter=/usr/bin/python2.7' --ssh-common-args='-o HostKeyAlgorithms=ssh-rsa,ssh-dss,ecdsa-sha2-nistp256,ssh-ed25519 -o PubKeyAcceptedKeyTypes=ssh-rsa' -u vagrant -b --skip-tags adoptopenjdk,cups playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+      run: ansible-playbook -i playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx -e 'ansible_python_interpreter=/usr/bin/python2' --ssh-common-args='-o HostKeyAlgorithms=ssh-rsa,ssh-dss,ecdsa-sha2-nistp256,ssh-ed25519 -o PubKeyAcceptedKeyTypes=ssh-rsa' -u vagrant -b --skip-tags adoptopenjdk,cups playbooks/AdoptOpenJDK_Unix_Playbook/main.yml

--- a/.github/workflows/build_vagrant.yml
+++ b/.github/workflows/build_vagrant.yml
@@ -38,9 +38,6 @@ jobs:
     # - name: Install Ansible Using PIP2
     #   run: pip2 install ansible
 
-    - name: Check Python
-      run: find / -name python
-
     - name: Download and add the HashiCorp GPG key
       run: sudo curl -fsSL https://apt.releases.hashicorp.com/gpg -o /tmp/hashicorp.gpg
 
@@ -116,4 +113,4 @@ jobs:
 
     - name: Run Ansible Playbook
       working-directory: ansible
-      run: ansible-playbook -i playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx -e 'ansible_python_interpreter=/usr/bin/python3.10' --ssh-common-args='-o HostKeyAlgorithms=ssh-rsa,ssh-dss,ecdsa-sha2-nistp256,ssh-ed25519 -o PubKeyAcceptedKeyTypes=ssh-rsa' -u vagrant -b --skip-tags adoptopenjdk,cups playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+      run: ansible-playbook -i playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx -e 'ansible_python_interpreter=/opt/hostedtoolcache/Python/3.10.15/x64/python' --ssh-common-args='-o HostKeyAlgorithms=ssh-rsa,ssh-dss,ecdsa-sha2-nistp256,ssh-ed25519 -o PubKeyAcceptedKeyTypes=ssh-rsa' -u vagrant -b --skip-tags adoptopenjdk,cups playbooks/AdoptOpenJDK_Unix_Playbook/main.yml

--- a/.github/workflows/build_vagrant.yml
+++ b/.github/workflows/build_vagrant.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   build-solaris:
     name: Solaris
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
 
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -28,30 +28,17 @@ jobs:
     # Use Python2 & Pip To Install On Ubuntu 22.04
     # Rather Than The System Packages
 
-    #
-    # - name: Python 2 Get Pip Bootstrap Script
-    #   run: curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
-    #
-    # - name: Python 2 Get Pip
-    #   run: sudo python2 get-pip.py
-    #
-    # - name: Install Ansible Using PIP2
-    #   run: pip2 install ansible
+    - name: Install Python 2
+      run: sudo apt-get install python2
 
-    - name: Download and add the HashiCorp GPG key
-      run: sudo curl -fsSL https://apt.releases.hashicorp.com/gpg -o /tmp/hashicorp.gpg
+    - name: Python 2 Get Pip Bootstrap Script
+      run: curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
 
-    - name: Add the HashiCorp GPG key to the keyring
-      run: sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg /tmp/hashicorp.gpg
+    - name: Python 2 Get Pip
+      run: sudo python2 get-pip.py
 
-    - name: Add the HashiCorp repository
-      run: sudo echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-
-# Update apt package index
-# apt-get update
-
-# Install Vagrant
-# apt-get install -y vagrant
+    - name: Install Ansible Using PIP2
+      run: pip2 install ansible
 
     - name: Update Repos
       run: sudo apt-get update
@@ -113,4 +100,4 @@ jobs:
 
     - name: Run Ansible Playbook
       working-directory: ansible
-      run: ansible-playbook -i playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx -e 'ansible_python_interpreter=/opt/hostedtoolcache/Python/3.10.15/x64/python' --ssh-common-args='-o HostKeyAlgorithms=ssh-rsa,ssh-dss,ecdsa-sha2-nistp256,ssh-ed25519 -o PubKeyAcceptedKeyTypes=ssh-rsa' -u vagrant -b --skip-tags adoptopenjdk,cups playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+      run: ansible-playbook -i playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx --ssh-common-args='-o HostKeyAlgorithms=ssh-rsa,ssh-dss,ecdsa-sha2-nistp256,ssh-ed25519 -o PubKeyAcceptedKeyTypes=ssh-rsa' -u vagrant -b --skip-tags adoptopenjdk,cups playbooks/AdoptOpenJDK_Unix_Playbook/main.yml

--- a/.github/workflows/build_vagrant.yml
+++ b/.github/workflows/build_vagrant.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   build-solaris:
     name: Solaris
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
 
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -27,18 +27,33 @@ jobs:
     # As Solaris Needs An Older Version Of Ansible/Python
     # Use Python2 & Pip To Install On Ubuntu 22.04
     # Rather Than The System Packages
-    
-    - name: Install Python 2
-      run: sudo apt-get install python2
-    
-    - name: Python 2 Get Pip Bootstrap Script
-      run: curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
 
-    - name: Python 2 Get Pip
-      run: sudo python2 get-pip.py
+    # - name: Install Python 2
+    #   run: sudo apt-get install python2
+    #
+    # - name: Python 2 Get Pip Bootstrap Script
+    #   run: curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
+    #
+    # - name: Python 2 Get Pip
+    #   run: sudo python2 get-pip.py
+    #
+    # - name: Install Ansible Using PIP2
+    #   run: pip2 install ansible
 
-    - name: Install Ansible Using PIP2
-      run: pip2 install ansible
+    - name: Download and add the HashiCorp GPG key
+      run: sudo curl -fsSL https://apt.releases.hashicorp.com/gpg -o /tmp/hashicorp.gpg
+
+    - name: Add the HashiCorp GPG key to the keyring
+      run: sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg /tmp/hashicorp.gpg
+
+    - name: Add the HashiCorp repository
+      run: sudo echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+
+# Update apt package index
+# apt-get update
+
+# Install Vagrant
+# apt-get install -y vagrant
 
     - name: Update Repos
       run: sudo apt-get update
@@ -100,4 +115,4 @@ jobs:
 
     - name: Run Ansible Playbook
       working-directory: ansible
-      run: ansible-playbook -i playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx --ssh-common-args='-o HostKeyAlgorithms=ssh-rsa,ssh-dss,ecdsa-sha2-nistp256,ssh-ed25519 -o PubKeyAcceptedKeyTypes=ssh-rsa' -u vagrant -b --skip-tags adoptopenjdk,cups playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+      run: ansible-playbook -i playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx -e 'ansible_python_interpreter=/usr/bin/python2.7' --ssh-common-args='-o HostKeyAlgorithms=ssh-rsa,ssh-dss,ecdsa-sha2-nistp256,ssh-ed25519 -o PubKeyAcceptedKeyTypes=ssh-rsa' -u vagrant -b --skip-tags adoptopenjdk,cups playbooks/AdoptOpenJDK_Unix_Playbook/main.yml

--- a/.github/workflows/build_vagrant.yml
+++ b/.github/workflows/build_vagrant.yml
@@ -39,7 +39,7 @@ jobs:
     #   run: pip2 install ansible
 
     - name: Check Python
-      run: sudo apt-get install -y python3.10
+      run: find / -name python
 
     - name: Download and add the HashiCorp GPG key
       run: sudo curl -fsSL https://apt.releases.hashicorp.com/gpg -o /tmp/hashicorp.gpg

--- a/.github/workflows/build_vagrant.yml
+++ b/.github/workflows/build_vagrant.yml
@@ -28,14 +28,6 @@ jobs:
     # Use Python2 & Pip To Install On Ubuntu 22.04
     # Rather Than The System Packages
 
-    - name: Install Python 2
-      run: sudo add-apt-repository ppa:deadsnakes/ppa
-
-    - name: Update Repos
-      run: sudo apt-get update
-
-    - name: Install Python 2
-      run: sudo apt-get install python2
     #
     # - name: Python 2 Get Pip Bootstrap Script
     #   run: curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
@@ -45,6 +37,9 @@ jobs:
     #
     # - name: Install Ansible Using PIP2
     #   run: pip2 install ansible
+
+    - name: Check Python
+      run: sudo ls -l /usr/bin/python*
 
     - name: Download and add the HashiCorp GPG key
       run: sudo curl -fsSL https://apt.releases.hashicorp.com/gpg -o /tmp/hashicorp.gpg
@@ -121,4 +116,4 @@ jobs:
 
     - name: Run Ansible Playbook
       working-directory: ansible
-      run: ansible-playbook -i playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx -e 'ansible_python_interpreter=/usr/bin/python2' --ssh-common-args='-o HostKeyAlgorithms=ssh-rsa,ssh-dss,ecdsa-sha2-nistp256,ssh-ed25519 -o PubKeyAcceptedKeyTypes=ssh-rsa' -u vagrant -b --skip-tags adoptopenjdk,cups playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+      run: ansible-playbook -i playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx -e 'ansible_python_interpreter=/usr/bin/python3.10' --ssh-common-args='-o HostKeyAlgorithms=ssh-rsa,ssh-dss,ecdsa-sha2-nistp256,ssh-ed25519 -o PubKeyAcceptedKeyTypes=ssh-rsa' -u vagrant -b --skip-tags adoptopenjdk,cups playbooks/AdoptOpenJDK_Unix_Playbook/main.yml

--- a/.github/workflows/build_vagrant.yml
+++ b/.github/workflows/build_vagrant.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   build-solaris:
     name: Solaris
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
 
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -40,14 +40,23 @@ jobs:
     - name: Install Ansible Using PIP2
       run: pip2 install ansible
 
-    - name: Update Repos
-      run: sudo apt-get update
-
     - name: Install VirtualBox
       run: sudo apt-get install virtualbox
 
+    - name: Add Hashicorp GPG Key
+      run: wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+
+    - name: Add Hashicorp Repository
+      run: echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+
+    - name: Update Repos
+      run: sudo apt-get update
+
     - name: Install Vagrant
       run: sudo apt-get install vagrant
+
+    - name: Add User To VBOX group
+      run: sudo usermod -a -G vboxusers $USER
 
     - name: Cache Solaris10.box
       id: solaris-10-cache
@@ -87,7 +96,7 @@ jobs:
         # Copy the machine's ssh key for the VMs to use, after removing prior files
         ssh-keygen -q -f $PWD/id_rsa -t rsa -N ''
         vagrant plugin install vagrant-vbguest
-        vagrant up
+        vagrant up --provider=virtualbox
         vagrantPORT=$(vagrant port | grep host | awk '{ print $4 }')
         rm -f playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx
         echo "[127.0.0.1]:${vagrantPORT}" >> playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx


### PR DESCRIPTION
Fixes #3760 

Update the solaris github action to use a valid combination of Ubuntu, Virtualbox & Vagrant, until a version of Vagrant compatible with Virtualbox 7.1 is available.

This PR allows the Solaris check Github action to run normally.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR
