### PR TITLE
docker: Fix dockerinventory script to group containers by label not ip

### DIFF
--- a/ansible/DockerInventory.json
+++ b/ansible/DockerInventory.json
@@ -16,6 +16,10 @@
                 "port": "32784"
             },
             {
+                "nodeName": "test-docker-centos7-x64-1",
+                "port": "No port"
+            },
+            {
                 "nodeName": "test-docker-fedora39-x64-2",
                 "port": "32779"
             },
@@ -40,7 +44,7 @@
                 "port": "32782"
             }
         ],
-        "containersCount": 9
+        "containersCount": 10
     },
     {
         "name": "dockerhost-azure-ubuntu2404-x64-1",
@@ -96,6 +100,12 @@
             }
         ],
         "containersCount": 12
+    },
+    {
+        "name": "dockerhost-azure-win2022-x64-1",
+        "ip": "No ip",
+        "containers": [],
+        "containersCount": 0
     },
     {
         "name": "dockerhost-equinix-ubuntu2204-armv8-1",
@@ -232,7 +242,7 @@
         "containersCount": 15
     },
     {
-        "name": "dockerhost-marist-ubuntu2204-s390x-1",
+        "name": "dockerhost-marist-ubuntu2404-s390x-1",
         "ip": "148.100.74.237",
         "containers": [
             {
@@ -255,7 +265,18 @@
         "containersCount": 4
     },
     {
-        "name": "dockerhost-osuosl-ubuntu2004-ppc64le-1",
+        "name": "dockerhost-osuosl-ubuntu2404-aarch64-1",
+        "ip": "140.211.167.67",
+        "containers": [
+            {
+                "nodeName": "test-docker-ubuntu2404-armv7-1",
+                "port": "32000"
+            }
+        ],
+        "containersCount": 1
+    },
+    {
+        "name": "dockerhost-osuosl-ubuntu2404-ppc64le-1",
         "ip": "140.211.168.214",
         "containers": [
             {
@@ -276,17 +297,6 @@
             }
         ],
         "containersCount": 4
-    },
-    {
-        "name": "dockerhost-osuosl-ubuntu2404-aarch64-1",
-        "ip": "140.211.167.67",
-        "containers": [
-            {
-                "nodeName": "test-docker-ubuntu2404-armv7-1",
-                "port": "32000"
-            }
-        ],
-        "containersCount": 1
     },
     {
         "name": "dockerhost-skytap-ubuntu2004-ppc64le-1",

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/scripts/updateDockerStaticInventory.py
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/scripts/updateDockerStaticInventory.py
@@ -71,7 +71,8 @@ def main():
                 nodeConfig = server.get_node_config(node["name"])
                 nodeIP = getIP(nodeConfig)
                 nodePort = getNodePort(nodeConfig)
-                if nodeIP == dockerhost["ip"] and node["name"] != dockerhost["name"]:
+                nodeLabel = getLabel(nodeConfig)
+                if nodeLabel.find(dockerhost["name"]) > -1:
                     nodeObject = {"nodeName": node["name"], "port": nodePort}
                     containers.append(nodeObject)
             except jenkins.NotFoundException:
@@ -87,3 +88,10 @@ def main():
 
 if __name__ == "__main__":
     main()
+    # username, password = sys.argv[1:3]
+    # server = createServer(username, password)
+    # nodeConfig = server.get_node_config("test-docker-ubi8-x64-3")
+    # dockerhost = "dockerhost-skytap-ubuntu2204-x64-1"
+    # label = getLabel(nodeConfig)
+    # print(label)
+    # print(label.find(dockerhost))

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/scripts/updateDockerStaticInventory.py
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/scripts/updateDockerStaticInventory.py
@@ -69,7 +69,6 @@ def main():
         for node in nodes:
             try:
                 nodeConfig = server.get_node_config(node["name"])
-                nodeIP = getIP(nodeConfig)
                 nodePort = getNodePort(nodeConfig)
                 nodeLabel = getLabel(nodeConfig)
                 if nodeLabel.find(dockerhost["name"]) > -1:
@@ -88,10 +87,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-    # username, password = sys.argv[1:3]
-    # server = createServer(username, password)
-    # nodeConfig = server.get_node_config("test-docker-ubi8-x64-3")
-    # dockerhost = "dockerhost-skytap-ubuntu2204-x64-1"
-    # label = getLabel(nodeConfig)
-    # print(label)
-    # print(label.find(dockerhost))


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Fixes https://github.com/adoptium/infrastructure/issues/3735

The script now groups together static containers by looking for the `hw.dockerhost.$dockerhost` label in their jenkins config, instead of by ip