### PR TITLE
GHA: MacOS Revert Ubuntu keyserver workaround

### DIFF
--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -27,15 +27,14 @@ jobs:
     - name: Install Python
       run: brew install python@3.12 --overwrite
 
+    - name: Configure dirmgr
+      run: |
+        mkdir -p ~/.gnupg/
+        touch ~/.gnupg/dirmngr.conf
+        echo "standard-resolver" >  ~/.gnupg/dirmngr.conf
+
     - name: Install Ansible
       run: brew install ansible
-
-    # This is to fix an issue with the github macos14 runner, that cant resolve keyserver.ubuntu.com
-    # but this does work when replaced with the IP address. Spotted during the GPG verification of ANT step
-    # Upstream Bug : https://github.com/actions/runner-images/issues/9777
-    - name: Replace keyserver address with IP address
-      run: |
-        sed -i '' 's/keyserver\.ubuntu\.com/185.125.188.27/g' ansible/playbooks/Supporting_Scripts/package_signature_verification.sh
 
     - name: Run Ansible Playbook
       run: |


### PR DESCRIPTION
Fixes #3739 

Upstream bug, that required the workaround has now been resolved. So removing the workaround.

See: https://github.com/actions/runner-images/issues/9777 for additional required dirmgr configuration
&
See https://github.com/actions/runner-images/issues/8649 for the reverse lookup fix (upstream bug)

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR

