### PR TITLE
unixPb: Update Ant version to latest 1.10.15

### DIFF
--- a/.github/workflows/check_dockerstatic.yml
+++ b/.github/workflows/check_dockerstatic.yml
@@ -25,8 +25,8 @@ jobs:
       max-parallel: 4
       matrix:
        include:
-         - os: alpine3.19
-           dockerfile: "Dockerfile.alp319"
+         - os: alpine3.20
+           dockerfile: "Dockerfile.alp320"
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Test Dockerfile on ${{ matrix.os }}
@@ -59,8 +59,8 @@ jobs:
       max-parallel: 4
       matrix:
        include:
-         - os: fedora39
-           dockerfile: "Dockerfile.f39"
+         - os: fedora41
+           dockerfile: "Dockerfile.f41"
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Test Dockerfile on ${{ matrix.os }}
@@ -76,12 +76,12 @@ jobs:
       max-parallel: 4
       matrix:
        include:
-         - os: ubuntu18.04
-           dockerfile: "Dockerfile.u1804"
          - os: ubuntu20.04
            dockerfile: "Dockerfile.u2004"
          - os: ubuntu22.04
            dockerfile: "Dockerfile.u2204"
+         - os: ubuntu24.04
+           dockerfile: "Dockerfile.u2404"
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Test Dockerfile on ${{ matrix.os }}

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/group_vars/all/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/group_vars/all/main.yml
@@ -45,6 +45,9 @@ Vendor_Playbook: /Vendor_Files/Vendor_Playbook/Vendor.yml
 Asian_Locales: Disabled
 Slack_Notification: Disabled
 
+ant_version: 1.10.15
+ant_checksum: sha512:1de7facbc9874fa4e5a2f045d5c659f64e0b89318c1dbc8acc6aae4595c4ffaf90a7b1ffb57f958dd08d6e086d3fff07aa90e50c77342a0aa5c9b4c36bff03a9
+
 key:
-  apache_ant: CE8075A251547BEE249BC151A2115AE15F6B8B72 # Stefan Bodewig <bodewig@apache.org>
+  apache_ant: 0A123C1ED3F13A6A0140E166C71FB765CD9DE313 # Jaikiran Pai <jaikiran@apache.org>
   adoptium: 3B04D753C9050D9A5D343F39843C48A565F8F04B # Adoptium GPG Key (DEB/RPM Signing Key) <temurin-dev@eclipse.org>

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/ant/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/ant/tasks/main.yml
@@ -20,23 +20,23 @@
 
     - name: Download Apache Ant
       get_url:
-        url: https://archive.apache.org/dist/ant/binaries/apache-ant-1.9.9-bin.zip
-        dest: /tmp/apache-ant-1.9.9-bin.zip
+        url: https://archive.apache.org/dist/ant/binaries/apache-ant-{{ ant_version }}-bin.zip
+        dest: /tmp/apache-ant-{{ ant_version }}-bin.zip
         mode: 0440
         timeout: 25
       when: ant.stat.islnk is not defined
 
     - name: GPG Signature verification
-      script: ../Supporting_Scripts/package_signature_verification.sh -f /tmp/apache-ant-1.9.9-bin.zip -sl "https://archive.apache.org/dist/ant/binaries/apache-ant-1.9.9-bin.zip.asc" -k {{ key.apache_ant }}
+      script: ../Supporting_Scripts/package_signature_verification.sh -f /tmp/apache-ant-{{ ant_version }}-bin.zip -sl "https://archive.apache.org/dist/ant/binaries/apache-ant-{{ ant_version }}-bin.zip.asc" -k {{ key.apache_ant }}
       when: ant.stat.islnk is not defined
 
     - name: Unarchive Ant
       unarchive:
-        src: /tmp/apache-ant-1.9.9-bin.zip
+        src: /tmp/apache-ant-{{ ant_version }}-bin.zip
         dest: /opt
         copy: False
       when: ant.stat.islnk is not defined
 
     - name: Create symlink for ant
-      file: src=/opt/apache-ant-1.9.9/bin/ant dest=/usr/bin/ant state=link
+      file: src=/opt/apache-ant-{{ ant_version }}/bin/ant dest=/usr/bin/ant state=link
       when: ant.stat.islnk is not defined

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/group_vars/all/adoptopenjdk_variables.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/group_vars/all/adoptopenjdk_variables.yml
@@ -33,6 +33,10 @@ Vendor_Playbook: /Vendor_Files/Vendor_Playbook/Vendor.yml
 # Default BootJDK installed
 bootjdk: hotspot
 
+# Version of Ant used
+ant_version: 1.10.15
+ant_checksum: sha512:1de7facbc9874fa4e5a2f045d5c659f64e0b89318c1dbc8acc6aae4595c4ffaf90a7b1ffb57f958dd08d6e086d3fff07aa90e50c77342a0aa5c9b4c36bff03a9
+
 # GPG Public Keys
 key:
   curl: 27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2 # Daniel Stenberg <daniel@haxx.se>

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/group_vars/all/adoptopenjdk_variables.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/group_vars/all/adoptopenjdk_variables.yml
@@ -40,7 +40,7 @@ ant_checksum: sha512:1de7facbc9874fa4e5a2f045d5c659f64e0b89318c1dbc8acc6aae4595c
 # GPG Public Keys
 key:
   curl: 27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2 # Daniel Stenberg <daniel@haxx.se>
-  apache_ant: CE8075A251547BEE249BC151A2115AE15F6B8B72 # Stefan Bodewig <bodewig@apache.org>
+  apache_ant: 0A123C1ED3F13A6A0140E166C71FB765CD9DE313 # Jaikiran Pai <jaikiran@apache.org>
   apache_maven: B02137D875D833D9B23392ECAE5A7FB608A0221C # Robert Scholte <rfscholte@apache.org>
   autoconf: A7A16B4A2527436A # Eric Blake <eblake@redhat.com>
   cmake: EC8FEF3A7BFB4EDA # Brad King <brad.king@kitware.com>

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Ant-Contrib/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Ant-Contrib/tasks/main.yml
@@ -11,7 +11,7 @@
 
 - name: Set ant_lib_dir variable for on {{ ansible_distribution }} {{ ansible_architecture }}
   set_fact:
-    ant_lib_dir: /usr/local/apache-ant-1.10.5/lib
+    ant_lib_dir: /usr/local/apache-ant-"{{ ant_version }}"/lib
   tags: ant-contrib
 
 - name: "Print ant_lib_dir variable"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.al2023
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.al2023
@@ -1,5 +1,8 @@
 FROM amazonlinux:2023
 
+ARG ant_version="1.10.15"
+ARG ant_512checksum="1de7facbc9874fa4e5a2f045d5c659f64e0b89318c1dbc8acc6aae4595c4ffaf90a7b1ffb57f958dd08d6e086d3fff07aa90e50c77342a0aa5c9b4c36bff03a9"
+
 RUN dnf -y update && dnf install -y perl openssh-server unzip zip wget tar
 RUN dnf install -y --allowerasing gnupg2
 RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -P ""
@@ -10,15 +13,15 @@ RUN gpg --keyserver keyserver.ubuntu.com --recv-keys 3B04D753C9050D9A5D343F39843
 RUN wget -q `curl -s 'https://api.adoptium.net/v3/assets/feature_releases/21/ga?architecture=x64&heap_size=normal&image_type=jdk&jvm_impl=hotspot&os=linux&page=0&page_size=1&project=jdk&vendor=eclipse' | grep signature_link | awk '{split($0,a,"\""); print a[4]}'` -O /tmp/jdk21.sig
 RUN gpg --verify /tmp/jdk21.sig /tmp/jdk21.tar.gz
 RUN mkdir -p /usr/lib/jvm/jdk21 && tar -xpzf /tmp/jdk21.tar.gz -C /usr/lib/jvm/jdk21 --strip-components=1
-# Install ant 1.10.12
-RUN wget -q -O /tmp/ant.zip 'https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.12-bin.zip'
+# Install ant
+RUN wget -q -O /tmp/ant.zip "https://archive.apache.org/dist/ant/binaries/apache-ant-$ant_version-bin.zip"
 RUN wget -q -O /tmp/ant-contrib.tgz  https://sourceforge.net/projects/ant-contrib/files/ant-contrib/ant-contrib-1.0b2/ant-contrib-1.0b2-bin.tar.gz
-RUN echo "7e6fbcc3563df4bd87c883ad86a161a71da2774e0ed71a1b3aad82cbff1a7656ed9a0acb5ce40652129376dfd79f1ef74ec3369c1067d412a63062fea62ceccd  /tmp/ant.zip" > /tmp/ant.sha512
+RUN echo "$ant_512checksum  /tmp/ant.zip" > /tmp/ant.sha512
 RUN echo "0fd2771dca2b8b014a4cb3246715b32e20ad5d26754186d82eee781507a183d5e63064890b95eb27c091c93c1209528a0b18a6d7e6901899319492a7610e74ad  /tmp/ant-contrib.tgz" >> /tmp/ant.sha512
 RUN sha512sum --check --strict /tmp/ant.sha512
-RUN ln -s /usr/local/apache-ant-1.10.12/bin/ant /usr/bin/ant
+RUN ln -s /usr/local/apache-ant-$ant_version/bin/ant /usr/bin/ant
 RUN unzip -q -d /usr/local /tmp/ant.zip
-RUN tar xpfz /tmp/ant-contrib.tgz -C /usr/local/apache-ant-1.10.12/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
+RUN tar xpfz /tmp/ant-contrib.tgz -C /usr/local/apache-ant-$ant_version/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
 # Clear up space
 RUN rm /tmp/jdk21.tar.gz /tmp/ant.zip /tmp/ant-contrib.tgz /tmp/jdk21.sig
 # Set up jenkins user

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alp320
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alp320
@@ -1,5 +1,8 @@
 FROM alpine:3.20
 
+ARG ant_version="1.10.15"
+ARG ant_512checksum="1de7facbc9874fa4e5a2f045d5c659f64e0b89318c1dbc8acc6aae4595c4ffaf90a7b1ffb57f958dd08d6e086d3fff07aa90e50c77342a0aa5c9b4c36bff03a9"
+
 RUN apk --update add bash shadow openssh-server openssh-client unzip zip wget git curl make gcc perl xvfb \
         libxrender libxi libxtst procps musl-dev perl-doc alsa-lib libx11 msttcorefonts-installer fontconfig libxext freetype zlib fakeroot gnupg
 
@@ -20,14 +23,14 @@ RUN gpg --verify /tmp/jdk21.sig /tmp/jdk21.tar.gz
 RUN mkdir -p /usr/lib/jvm/jdk21 && tar -xpzf /tmp/jdk21.tar.gz -C /usr/lib/jvm/jdk21 --strip-components=1
 
 # Install ant and ant-contrib.
-RUN wget -O /tmp/ant.zip 'https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.9-bin.zip'
+RUN wget -O /tmp/ant.zip "https://archive.apache.org/dist/ant/binaries/apache-ant-$ant_version-bin.zip"
 RUN wget -O /tmp/ant-contrib.tgz  https://sourceforge.net/projects/ant-contrib/files/ant-contrib/ant-contrib-1.0b2/ant-contrib-1.0b2-bin.tar.gz
-RUN echo "d085f59349edf22a93d835aa30aea2521ed39bdb99d57d941f1ebd8d115a561bb28aecc781915ff2a0d9f7caf7bae536cdda0910bb432b2a4bce8b7b90c2903b  /tmp/ant.zip" > /tmp/ant.sha512
+RUN echo "$ant_512checksum  /tmp/ant.zip" > /tmp/ant.sha512
 RUN echo "0fd2771dca2b8b014a4cb3246715b32e20ad5d26754186d82eee781507a183d5e63064890b95eb27c091c93c1209528a0b18a6d7e6901899319492a7610e74ad  /tmp/ant-contrib.tgz" >> /tmp/ant.sha512
 RUN sha512sum -c /tmp/ant.sha512
 RUN unzip -q -d /usr/local /tmp/ant.zip
-RUN tar xpfz /tmp/ant-contrib.tgz -C /usr/local/apache-ant-1.10.9/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
-RUN ln -s /usr/local/apache-ant-1.10.9/bin/ant /usr/bin/ant
+RUN tar xpfz /tmp/ant-contrib.tgz -C /usr/local/apache-ant-$ant_version/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
+RUN ln -s /usr/local/apache-ant-$ant_version/bin/ant /usr/bin/ant
 
 # Create user jenkins with random password. Prevents locked user account that makes SSH'ing into
 # the container impossible.

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.deb12
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.deb12
@@ -1,4 +1,8 @@
 FROM debian:12
+
+ARG ant_version="1.10.15"
+ARG ant_512checksum="1de7facbc9874fa4e5a2f045d5c659f64e0b89318c1dbc8acc6aae4595c4ffaf90a7b1ffb57f958dd08d6e086d3fff07aa90e50c77342a0aa5c9b4c36bff03a9"
+
 # Install Base Requirements
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 RUN apt-get update && apt-get install -y perl openssh-server unzip zip wget apt-utils gnupg curl
@@ -16,14 +20,14 @@ RUN gpg --verify /tmp/jdk17.sig /tmp/jdk17.tar.gz
 
 RUN mkdir -p /usr/lib/jvm/jdk17 && tar -xpzf /tmp/jdk17.tar.gz -C /usr/lib/jvm/jdk17 --strip-components=1
 # Install ant via WGET
-RUN wget -q -O /tmp/ant.zip 'https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.12-bin.zip'
+RUN wget -q -O /tmp/ant.zip "https://archive.apache.org/dist/ant/binaries/apache-ant-$ant_version-bin.zip"
 RUN wget -q -O /tmp/ant-contrib.tgz  https://sourceforge.net/projects/ant-contrib/files/ant-contrib/ant-contrib-1.0b2/ant-contrib-1.0b2-bin.tar.gz
-RUN echo "7e6fbcc3563df4bd87c883ad86a161a71da2774e0ed71a1b3aad82cbff1a7656ed9a0acb5ce40652129376dfd79f1ef74ec3369c1067d412a63062fea62ceccd  /tmp/ant.zip" > /tmp/ant.sha512
+RUN echo "$ant_512checksum  /tmp/ant.zip" > /tmp/ant.sha512
 RUN echo "0fd2771dca2b8b014a4cb3246715b32e20ad5d26754186d82eee781507a183d5e63064890b95eb27c091c93c1209528a0b18a6d7e6901899319492a7610e74ad  /tmp/ant-contrib.tgz" >> /tmp/ant.sha512
 RUN sha512sum --check --strict /tmp/ant.sha512
-RUN ln -s /usr/local/apache-ant-1.10.12/bin/ant /usr/bin/ant
+RUN ln -s /usr/local/apache-ant-$ant_version/bin/ant /usr/bin/ant
 RUN unzip -q -d /usr/local /tmp/ant.zip
-RUN tar xpfz /tmp/ant-contrib.tgz -C /usr/local/apache-ant-1.10.12/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
+RUN tar xpfz /tmp/ant-contrib.tgz -C /usr/local/apache-ant-$ant_version/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
 # Housekeep Downloaded Archives
 RUN rm /tmp/jdk17.tar.gz /tmp/ant.zip /tmp/ant-contrib.tgz /tmp/jdk17.sig
 # Set up jenkins user

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.f41
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.f41
@@ -1,5 +1,8 @@
 FROM fedora:41
 
+ARG ant_version="1.10.15"
+ARG ant_512checksum="1de7facbc9874fa4e5a2f045d5c659f64e0b89318c1dbc8acc6aae4595c4ffaf90a7b1ffb57f958dd08d6e086d3fff07aa90e50c77342a0aa5c9b4c36bff03a9"
+
 RUN yum -y update && yum install -y perl openssh-server unzip zip wget
 RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -P ""
 # Get latest jdk17 ga
@@ -9,15 +12,15 @@ RUN gpg --keyserver keyserver.ubuntu.com --recv-keys 3B04D753C9050D9A5D343F39843
 RUN wget -q `curl -s 'https://api.adoptium.net/v3/assets/feature_releases/17/ga?architecture=x64&heap_size=normal&image_type=jdk&jvm_impl=hotspot&os=linux&page=0&page_size=1&project=jdk&vendor=eclipse' | grep signature_link | awk '{split($0,a,"\""); print a[4]}'` -O /tmp/jdk17.sig
 RUN gpg --verify /tmp/jdk17.sig /tmp/jdk17.tar.gz
 RUN mkdir -p /usr/lib/jvm/jdk17 && tar -xpzf /tmp/jdk17.tar.gz -C /usr/lib/jvm/jdk17 --strip-components=1
-# Install ant 1.10.12
-RUN wget -q -O /tmp/ant.zip 'https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.12-bin.zip'
+# Install ant
+RUN wget -q -O /tmp/ant.zip "https://archive.apache.org/dist/ant/binaries/apache-ant-$ant_version-bin.zip"
 RUN wget -q -O /tmp/ant-contrib.tgz  https://sourceforge.net/projects/ant-contrib/files/ant-contrib/ant-contrib-1.0b2/ant-contrib-1.0b2-bin.tar.gz
-RUN echo "7e6fbcc3563df4bd87c883ad86a161a71da2774e0ed71a1b3aad82cbff1a7656ed9a0acb5ce40652129376dfd79f1ef74ec3369c1067d412a63062fea62ceccd  /tmp/ant.zip" > /tmp/ant.sha512
+RUN echo "$ant_512checksum  /tmp/ant.zip" > /tmp/ant.sha512
 RUN echo "0fd2771dca2b8b014a4cb3246715b32e20ad5d26754186d82eee781507a183d5e63064890b95eb27c091c93c1209528a0b18a6d7e6901899319492a7610e74ad  /tmp/ant-contrib.tgz" >> /tmp/ant.sha512
 RUN sha512sum --check --strict /tmp/ant.sha512
-RUN ln -s /usr/local/apache-ant-1.10.12/bin/ant /usr/bin/ant
+RUN ln -s /usr/local/apache-ant-$ant_version/bin/ant /usr/bin/ant
 RUN unzip -q -d /usr/local /tmp/ant.zip
-RUN tar xpfz /tmp/ant-contrib.tgz -C /usr/local/apache-ant-1.10.12/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
+RUN tar xpfz /tmp/ant-contrib.tgz -C /usr/local/apache-ant-$ant_version/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
 # Clear up space
 RUN rm /tmp/jdk17.tar.gz /tmp/ant.zip /tmp/ant-contrib.tgz /tmp/jdk17.sig
 # Set up jenkins user

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.sles12
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.sles12
@@ -1,5 +1,8 @@
 FROM registry.suse.com/suse/sles12sp5:latest
 
+ARG ant_version="1.10.15"
+ARG ant_512checksum="1de7facbc9874fa4e5a2f045d5c659f64e0b89318c1dbc8acc6aae4595c4ffaf90a7b1ffb57f958dd08d6e086d3fff07aa90e50c77342a0aa5c9b4c36bff03a9"
+
 RUN zypper ar https://download.opensuse.org/distribution/leap/15.4/repo/oss/ sles15oss
 RUN zypper --gpg-auto-import-keys refresh
 RUN zypper update -y && zypper install -y wget perl openssh-server unzip zip tar gzip hostname
@@ -9,14 +12,14 @@ RUN mkdir -p /usr/lib/jvm/jdk17 && tar -xpzf /tmp/jdk17.tar.gz -C /usr/lib/jvm/j
 RUN ln -s /usr/lib/jvm/jdk17/bin/java /usr/bin/java
 
 # Install ant
-RUN wget -q -O /tmp/ant.zip 'https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.zip'
+RUN wget -q -O /tmp/ant.zip "https://archive.apache.org/dist/ant/binaries/apache-ant-$ant_version-bin.zip"
 RUN wget -q -O /tmp/ant-contrib.tar.gz  https://sourceforge.net/projects/ant-contrib/files/ant-contrib/ant-contrib-1.0b2/ant-contrib-1.0b2-bin.tar.gz
-RUN echo "2e48f9e429d67708f5690bc307232f08440d01ebe414059292b6543971da9c7cd259c21533b9163b4dd753321c17bd917adf8407d03245a0945fc30a4e633163  /tmp/ant.zip" > /tmp/ant.sha512
+RUN echo "$ant_512checksum  /tmp/ant.zip" > /tmp/ant.sha512
 RUN echo "0fd2771dca2b8b014a4cb3246715b32e20ad5d26754186d82eee781507a183d5e63064890b95eb27c091c93c1209528a0b18a6d7e6901899319492a7610e74ad  /tmp/ant-contrib.tar.gz" >> /tmp/ant.sha512
 RUN sha512sum --check --strict /tmp/ant.sha512
-RUN ln -s /usr/local/apache-ant-1.10.5/bin/ant /usr/bin/ant
+RUN ln -s /usr/local/apache-ant-$ant_version/bin/ant /usr/bin/ant
 RUN unzip -q -d /usr/local /tmp/ant.zip
-RUN tar xpfz /tmp/ant-contrib.tar.gz -C /usr/local/apache-ant-1.10.5/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
+RUN tar xpfz /tmp/ant-contrib.tar.gz -C /usr/local/apache-ant-$ant_version/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
 
 # Clear up space
 RUN rm /tmp/jdk17.tar.gz /tmp/ant.zip /tmp/ant-contrib.tar.gz

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.sles15
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.sles15
@@ -1,5 +1,8 @@
 FROM registry.suse.com/suse/sle15
 
+ARG ant_version="1.10.15"
+ARG ant_512checksum="1de7facbc9874fa4e5a2f045d5c659f64e0b89318c1dbc8acc6aae4595c4ffaf90a7b1ffb57f958dd08d6e086d3fff07aa90e50c77342a0aa5c9b4c36bff03a9"
+
 RUN zypper addrepo https://download.opensuse.org/distribution/leap/15.4/repo/oss/ "Main Repository" && zypper --gpg-auto-import-keys refresh
 RUN zypper update -y && zypper install -y perl openssh-server unzip zip wget tar gzip
 
@@ -8,14 +11,14 @@ RUN mkdir -p /usr/lib/jvm/jdk17 && tar -xpzf /tmp/jdk17.tar.gz -C /usr/lib/jvm/j
 RUN ln -s /usr/lib/jvm/jdk17/bin/java /usr/bin/java
 
 # Install ant
-RUN wget -q -O /tmp/ant.zip 'https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.zip'
+RUN wget -q -O /tmp/ant.zip "https://archive.apache.org/dist/ant/binaries/apache-ant-$ant_version-bin.zip"
 RUN wget -q -O /tmp/ant-contrib.tar.gz  https://sourceforge.net/projects/ant-contrib/files/ant-contrib/ant-contrib-1.0b2/ant-contrib-1.0b2-bin.tar.gz
-RUN echo "2e48f9e429d67708f5690bc307232f08440d01ebe414059292b6543971da9c7cd259c21533b9163b4dd753321c17bd917adf8407d03245a0945fc30a4e633163  /tmp/ant.zip" > /tmp/ant.sha512
+RUN echo "$ant_512checksum  /tmp/ant.zip" > /tmp/ant.sha512
 RUN echo "0fd2771dca2b8b014a4cb3246715b32e20ad5d26754186d82eee781507a183d5e63064890b95eb27c091c93c1209528a0b18a6d7e6901899319492a7610e74ad  /tmp/ant-contrib.tar.gz" >> /tmp/ant.sha512
 RUN sha512sum --check --strict /tmp/ant.sha512
-RUN ln -s /usr/local/apache-ant-1.10.5/bin/ant /usr/bin/ant
+RUN ln -s /usr/local/apache-ant-$ant_version/bin/ant /usr/bin/ant
 RUN unzip -q -d /usr/local /tmp/ant.zip
-RUN tar xpfz /tmp/ant-contrib.tar.gz -C /usr/local/apache-ant-1.10.5/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
+RUN tar xpfz /tmp/ant-contrib.tar.gz -C /usr/local/apache-ant-$ant_version/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
 
 # Clear up space
 RUN rm /tmp/jdk17.tar.gz /tmp/ant.zip /tmp/ant-contrib.tar.gz

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.u2404
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.u2404
@@ -3,6 +3,9 @@ FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -qq -y perl openssh-server unzip zip gnupg curl
 
+ARG ant_version="1.10.15"
+ARG ant_512checksum="1de7facbc9874fa4e5a2f045d5c659f64e0b89318c1dbc8acc6aae4595c4ffaf90a7b1ffb57f958dd08d6e086d3fff07aa90e50c77342a0aa5c9b4c36bff03a9"
+
 # Get latest jdk17 ga
 RUN wget -q 'https://api.adoptium.net/v3/binary/latest/17/ga/linux/x64/jdk/hotspot/normal/eclipse?project=jdk' -O /tmp/jdk17.tar.gz
 RUN gpg --keyserver keyserver.ubuntu.com --recv-keys 3B04D753C9050D9A5D343F39843C48A565F8F04B
@@ -12,14 +15,14 @@ RUN gpg --verify /tmp/jdk17.sig /tmp/jdk17.tar.gz
 RUN mkdir -p /usr/lib/jvm/jdk17 && tar -xpzf /tmp/jdk17.tar.gz -C /usr/lib/jvm/jdk17 --strip-components=1
 
 # Install ant
-RUN wget -q -O /tmp/ant.zip 'https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.zip'
+RUN wget -q -O /tmp/ant.zip "https://archive.apache.org/dist/ant/binaries/apache-ant-$ant_version-bin.zip"
 RUN wget -q -O /tmp/ant-contrib.tgz  https://sourceforge.net/projects/ant-contrib/files/ant-contrib/ant-contrib-1.0b2/ant-contrib-1.0b2-bin.tar.gz
-RUN echo "2e48f9e429d67708f5690bc307232f08440d01ebe414059292b6543971da9c7cd259c21533b9163b4dd753321c17bd917adf8407d03245a0945fc30a4e633163  /tmp/ant.zip" > /tmp/ant.sha512
+RUN echo "$ant_512checksum  /tmp/ant.zip" > /tmp/ant.sha512
 RUN echo "0fd2771dca2b8b014a4cb3246715b32e20ad5d26754186d82eee781507a183d5e63064890b95eb27c091c93c1209528a0b18a6d7e6901899319492a7610e74ad  /tmp/ant-contrib.tgz" >> /tmp/ant.sha512
 RUN sha512sum --check --strict /tmp/ant.sha512
-RUN ln -s /usr/local/apache-ant-1.10.5/bin/ant /usr/bin/ant
+RUN ln -s /usr/local/apache-ant-$ant_version/bin/ant /usr/bin/ant
 RUN unzip -q -d /usr/local /tmp/ant.zip
-RUN tar xpfz /tmp/ant-contrib.tgz -C /usr/local/apache-ant-1.10.5/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
+RUN tar xpfz /tmp/ant-contrib.tgz -C /usr/local/apache-ant-$ant_version/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
 
 # Clear up space
 RUN rm /tmp/jdk17.tar.gz /tmp/ant.zip /tmp/ant-contrib.tgz /tmp/jdk17.sig

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.ubi9
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.ubi9
@@ -1,4 +1,8 @@
 FROM redhat/ubi9
+
+ARG ant_version="1.10.15"
+ARG ant_512checksum="1de7facbc9874fa4e5a2f045d5c659f64e0b89318c1dbc8acc6aae4595c4ffaf90a7b1ffb57f958dd08d6e086d3fff07aa90e50c77342a0aa5c9b4c36bff03a9"
+
 # Install Base Requirements
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 RUN dnf -y update && dnf install -y perl openssh-server unzip zip wget epel-release
@@ -28,14 +32,14 @@ RUN wget -q `curl -s 'https://api.adoptium.net/v3/assets/feature_releases/17/ga?
 RUN gpg --verify /tmp/jdk17.sig /tmp/jdk17.tar.gz
 RUN mkdir -p /usr/lib/jvm/jdk17 && tar -xpzf /tmp/jdk17.tar.gz -C /usr/lib/jvm/jdk17 --strip-components=1
 # Install ant via WGET
-RUN wget -q -O /tmp/ant.zip 'https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.zip'
+RUN wget -q -O /tmp/ant.zip 'https://archive.apache.org/dist/ant/binaries/apache-ant-$ant_version-bin.zip'
 RUN wget -q -O /tmp/ant-contrib.tgz  https://sourceforge.net/projects/ant-contrib/files/ant-contrib/ant-contrib-1.0b2/ant-contrib-1.0b2-bin.tar.gz
-RUN echo "2e48f9e429d67708f5690bc307232f08440d01ebe414059292b6543971da9c7cd259c21533b9163b4dd753321c17bd917adf8407d03245a0945fc30a4e633163  /tmp/ant.zip" > /tmp/ant.sha512
+RUN echo "$ant_512checksum  /tmp/ant.zip" > /tmp/ant.sha512
 RUN echo "0fd2771dca2b8b014a4cb3246715b32e20ad5d26754186d82eee781507a183d5e63064890b95eb27c091c93c1209528a0b18a6d7e6901899319492a7610e74ad  /tmp/ant-contrib.tgz" >> /tmp/ant.sha512
 RUN sha512sum --check --strict /tmp/ant.sha512
-RUN ln -s /usr/local/apache-ant-1.10.5/bin/ant /usr/bin/ant
+RUN ln -s /usr/local/apache-ant-$ant_version/bin/ant /usr/bin/ant
 RUN unzip -q -d /usr/local /tmp/ant.zip
-RUN tar xpfz /tmp/ant-contrib.tgz -C /usr/local/apache-ant-1.10.5/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
+RUN tar xpfz /tmp/ant-contrib.tgz -C /usr/local/apache-ant-$ant_version/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
 # Housekeep Downloaded Archives
 RUN rm /tmp/jdk17.tar.gz /tmp/ant.zip /tmp/ant-contrib.tgz /tmp/gpgkey.rpm /tmp/jdk17.sig
 # Set up jenkins user

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ant/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ant/tasks/main.yml
@@ -7,7 +7,7 @@
 # ant_version and ant_checksum are set in group_vars/adoptopenjdk_variables.yml
 
 - name: Check if Apache Ant is already installed in custom location /usr/local
-  shell: ls /usr/local/apache-ant-"{{ ant_version }}" >/dev/null 2>&1
+  shell: ls /usr/local/apache-ant-{{ ant_version }} >/dev/null 2>&1
   failed_when: false
   register: ant_installed
   changed_when: false
@@ -17,7 +17,7 @@
 
 - name: Download Apache Ant binaries
   get_url:
-    url: https://archive.apache.org/dist/ant/binaries/apache-ant-"{{ ant_version }}"-bin.zip
+    url: https://archive.apache.org/dist/ant/binaries/apache-ant-{{ ant_version }}-bin.zip
     dest: /tmp/
     mode: 0440
     timeout: 25
@@ -30,7 +30,7 @@
   tags: ant
 
 - name: Download Apache Ant binaries (macOS) and (Solaris)
-  command: wget https://archive.apache.org/dist/ant/binaries/apache-ant-"{{ ant_version }}"-bin.zip -O /tmp/apache-ant-"{{ ant_version }}"-bin.zip
+  command: wget https://archive.apache.org/dist/ant/binaries/apache-ant-{{ ant_version }}-bin.zip -O /tmp/apache-ant-{{ ant_version }}-bin.zip
   when:
     - ant_installed.rc != 0
     - ansible_distribution == "MacOSX" or ansible_distribution == "Solaris"
@@ -45,14 +45,14 @@
   tags: ant
 
 - name: GPG Signature verification
-  script: ../Supporting_Scripts/package_signature_verification.sh -f /tmp/apache-ant-"{{ ant_version }}"-bin.zip -sl "https://archive.apache.org/dist/ant/binaries/apache-ant-{{ ant_version }}-bin.zip.asc" -k {{ key.apache_ant }}
+  script: ../Supporting_Scripts/package_signature_verification.sh -f /tmp/apache-ant-{{ ant_version }}-bin.zip -sl "https://archive.apache.org/dist/ant/binaries/apache-ant-{{ ant_version }}-bin.zip.asc" -k {{ key.apache_ant }}
   when: ant_installed.rc != 0
   tags: ant
 
 - name: Extract ant
   become: true
   unarchive:
-    src: /tmp/apache-ant-"{{ ant_version }}"-bin.zip
+    src: /tmp/apache-ant-{{ ant_version }}-bin.zip
     dest: /usr/local
     copy: false
   when:
@@ -70,7 +70,7 @@
 - name: Create /usr/local/bin/ant symlink
   become: true
   file:
-    src: /usr/local/apache-ant-"{{ ant_version }}"/bin/ant
+    src: /usr/local/apache-ant-{{ ant_version }}/bin/ant
     dest: /usr/local/bin/ant
     state: link
   when:
@@ -82,7 +82,7 @@
     path: "{{ item }}"
     state: absent
   with_items:
-    - /tmp/apache-ant-"{{ ant_version }}"-bin.zip
+    - /tmp/apache-ant-{{ ant_version }}-bin.zip
   when:
     - ant_installed.rc != 0
   failed_when: false

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ant/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ant/tasks/main.yml
@@ -4,9 +4,10 @@
 ##############
 
 # Install Apache Ant from binaries on RHEL and Centos
+# ant_version and ant_checksum are set in group_vars/adoptopenjdk_variables.yml
 
 - name: Check if Apache Ant is already installed in custom location /usr/local
-  shell: ls /usr/local/apache-ant-1.10.5 >/dev/null 2>&1
+  shell: ls /usr/local/apache-ant-"{{ ant_version }}" >/dev/null 2>&1
   failed_when: false
   register: ant_installed
   changed_when: false
@@ -16,12 +17,12 @@
 
 - name: Download Apache Ant binaries
   get_url:
-    url: https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.zip
+    url: https://archive.apache.org/dist/ant/binaries/apache-ant-"{{ ant_version }}"-bin.zip
     dest: /tmp/
     mode: 0440
     timeout: 25
     validate_certs: no
-    checksum: sha512:2e48f9e429d67708f5690bc307232f08440d01ebe414059292b6543971da9c7cd259c21533b9163b4dd753321c17bd917adf8407d03245a0945fc30a4e633163
+    checksum: "{{ ant_checksum }}"
   when:
     - ant_installed.rc != 0
     - ansible_distribution != "MacOSX"
@@ -29,7 +30,7 @@
   tags: ant
 
 - name: Download Apache Ant binaries (macOS) and (Solaris)
-  command: wget https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.zip -O /tmp/apache-ant-1.10.5-bin.zip
+  command: wget https://archive.apache.org/dist/ant/binaries/apache-ant-"{{ ant_version }}"-bin.zip -O /tmp/apache-ant-"{{ ant_version }}"-bin.zip
   when:
     - ant_installed.rc != 0
     - ansible_distribution == "MacOSX" or ansible_distribution == "Solaris"
@@ -44,14 +45,14 @@
   tags: ant
 
 - name: GPG Signature verification
-  script: ../Supporting_Scripts/package_signature_verification.sh -f /tmp/apache-ant-1.10.5-bin.zip -sl "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.zip.asc" -k {{ key.apache_ant }}
+  script: ../Supporting_Scripts/package_signature_verification.sh -f /tmp/apache-ant-"{{ ant_version }}"-bin.zip -sl "https://archive.apache.org/dist/ant/binaries/apache-ant-{{ ant_version }}-bin.zip.asc" -k {{ key.apache_ant }}
   when: ant_installed.rc != 0
   tags: ant
 
 - name: Extract ant
   become: true
   unarchive:
-    src: /tmp/apache-ant-1.10.5-bin.zip
+    src: /tmp/apache-ant-"{{ ant_version }}"-bin.zip
     dest: /usr/local
     copy: false
   when:
@@ -69,7 +70,7 @@
 - name: Create /usr/local/bin/ant symlink
   become: true
   file:
-    src: /usr/local/apache-ant-1.10.5/bin/ant
+    src: /usr/local/apache-ant-"{{ ant_version }}"/bin/ant
     dest: /usr/local/bin/ant
     state: link
   when:
@@ -81,7 +82,7 @@
     path: "{{ item }}"
     state: absent
   with_items:
-    - /tmp/apache-ant-1.10.5-bin.zip
+    - /tmp/apache-ant-"{{ ant_version }}"-bin.zip
   when:
     - ant_installed.rc != 0
   failed_when: false

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/group_vars/all/adoptopenjdk_variables.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/group_vars/all/adoptopenjdk_variables.yml
@@ -16,9 +16,12 @@ Nagios_Plugins: Disabled
 bootjdk: hotspot
 heapsize: normal
 
+ant_version: 1.10.15
+ant_checksum: 1de7facbc9874fa4e5a2f045d5c659f64e0b89318c1dbc8acc6aae4595c4ffaf90a7b1ffb57f958dd08d6e086d3fff07aa90e50c77342a0aa5c9b4c36bff03a9
+
 ## Nagios Server Details
 Nagios_Master_IP: 78.47.239.96
 
 # GPG Public Keys
 key:
-  apache_ant: CE8075A251547BEE249BC151A2115AE15F6B8B72 # Stefan Bodewig <bodewig@apache.org>
+  apache_ant: 0A123C1ED3F13A6A0140E166C71FB765CD9DE313 # Jaikiran Pai <jaikiran@apache.org>

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/ANT/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/ANT/tasks/main.yml
@@ -3,9 +3,9 @@
 # Apache ANT Installation #
 ###########################
 
-- name: Test if Ant is already installed
+- name: Test if Ant {{ ant_version }} is already installed
   win_stat:
-    path: 'C:\apache-ant\apache-ant-1.10.5'
+    path: 'C:\apache-ant\apache-ant-{{ ant_version }}'
   register: ant_installed
   tags: ANT
 
@@ -17,11 +17,11 @@
 
 - name: Download Apache ANT
   win_get_url:
-    url: https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.zip
+    url: https://archive.apache.org/dist/ant/binaries/apache-ant-{{ ant_version }}-bin.zip
     dest: c:\temp\ant.zip
     force: no
-    checksum: 9028e2fc64491cca0f991acc09b06ee7fe644afe41d1d6caf72702ca25c4613c
-    checksum_algorithm: sha256
+    checksum: "{{ ant_checksum }}"
+    checksum_algorithm: sha512
   when: (not ant_installed.stat.exists) and (not ant_download.stat.exists)
   register: ant_download
   tags: ANT
@@ -31,7 +31,7 @@
     file: ../../GPG_signature_verification/tasks/main.yml
   vars:
     file_path: c:/temp/ant.zip
-    signature_link: "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.zip.asc"
+    signature_link: "https://archive.apache.org/dist/ant/binaries/apache-ant-{{ ant_version }}-bin.zip.asc"
     GPG_key: "{{ key.apache_ant }}"
   when: (not ant_installed.stat.exists)
   tags: ANT
@@ -45,7 +45,7 @@
   tags: ANT
 
 - name: Set ANT_HOME
-  raw: setx ANT_HOME "C:\apache-ant\apache-ant-1.10.5" /m
+  raw: setx ANT_HOME "C:\apache-ant\apache-ant-{{ ant_version }}" /m
   when: (not ant_installed.stat.exists)
   tags: ANT
 
@@ -59,7 +59,7 @@
 
 - name: Test if ant-contrib is already installed
   win_stat:
-    path: 'C:\apache-ant\apache-ant-1.10.5\lib\ant-contrib.jar'
+    path: 'C:\apache-ant\apache-ant-{{ ant_version }}\lib\ant-contrib.jar'
   register: ant_contrib_installed
   tags: ANT
 
@@ -84,7 +84,7 @@
 - name: Copy the ant-contrib.jar to ANT's lib folder
   win_copy:
     src: C:\temp\ant-contrib\ant-contrib\lib\ant-contrib.jar
-    dest: C:\apache-ant\apache-ant-1.10.5\lib\ant-contrib.jar
+    dest: C:\apache-ant\apache-ant-{{ ant_version }}\lib\ant-contrib.jar
     remote_src: True
   when: (not ant_contrib_installed.stat.exists)
   tags: ANT


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/3074

To do:
- [x] Build each modified static container's dockerfile
- [x] Test playbook changes
- [x] Run AQA pipelines on affected static containers and machines