### PR TITLE
docker: Add Centos Stream 9 dockerfile to static dockerfiles

### DIFF
--- a/.github/workflows/check_dockerstatic.yml
+++ b/.github/workflows/check_dockerstatic.yml
@@ -44,6 +44,8 @@ jobs:
        include:
          - os: centos8
            dockerfile: "Dockerfile.cent8"
+         - os: centos-stream-9
+           dockerfile: "Dockerfile.centstream9"
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Test Dockerfile on ${{ matrix.os }}

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.centstream9
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.centstream9
@@ -1,0 +1,44 @@
+FROM quay.io/centos/centos:stream9
+
+ARG ant_version="1.10.15"
+ARG ant_512checksum="1de7facbc9874fa4e5a2f045d5c659f64e0b89318c1dbc8acc6aae4595c4ffaf90a7b1ffb57f958dd08d6e086d3fff07aa90e50c77342a0aa5c9b4c36bff03a9"
+
+RUN dnf -y update && dnf install -y perl openssh-server unzip zip wget epel-release
+RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -P ""
+
+# Download JDK
+RUN wget -q 'https://api.adoptium.net/v3/binary/latest/17/ga/linux/aarch64/jdk/hotspot/normal/eclipse?project=jdk' -O /tmp/jdk17.tar.gz
+RUN gpg --keyserver keyserver.ubuntu.com --recv-keys 3B04D753C9050D9A5D343F39843C48A565F8F04B
+# Get sig file for latest jdk17 ga
+RUN wget -q `curl -s 'https://api.adoptium.net/v3/assets/feature_releases/17/ga?architecture=aarch64&heap_size=normal&image_type=jdk&jvm_impl=hotspot&os=linux&page=0&page_size=1&project=jdk&vendor=eclipse' | grep signature_link | awk '{split($0,a,"\""); print a[4]}'` -O /tmp/jdk17.sig
+RUN gpg --verify /tmp/jdk17.sig /tmp/jdk17.tar.gz
+RUN mkdir -p /usr/lib/jvm/jdk17 && tar -xpzf /tmp/jdk17.tar.gz -C /usr/lib/jvm/jdk17 --strip-components=1
+
+# Install Ant
+RUN wget -q -O /tmp/ant.zip "https://archive.apache.org/dist/ant/binaries/apache-ant-$ant_version-bin.zip"
+RUN wget -q -O /tmp/ant-contrib.tgz  https://sourceforge.net/projects/ant-contrib/files/ant-contrib/ant-contrib-1.0b2/ant-contrib-1.0b2-bin.tar.gz
+RUN echo "$ant_512checksum  /tmp/ant.zip" > /tmp/ant.sha512
+RUN echo "0fd2771dca2b8b014a4cb3246715b32e20ad5d26754186d82eee781507a183d5e63064890b95eb27c091c93c1209528a0b18a6d7e6901899319492a7610e74ad  /tmp/ant-contrib.tgz" >> /tmp/ant.sha512
+RUN sha512sum --check --strict /tmp/ant.sha512
+RUN ln -s /usr/local/apache-ant-$ant_version/bin/ant /usr/bin/ant
+RUN unzip -q -d /usr/local /tmp/ant.zip
+RUN tar xpfz /tmp/ant-contrib.tgz -C /usr/local/apache-ant-$ant_version/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
+# Clear up space
+RUN rm /tmp/jdk17.tar.gz /tmp/ant.zip /tmp/ant-contrib.tgz /tmp/jdk17.sig /tmp/ant.sha512
+
+# Set up jenkins user
+RUN useradd -m -d /home/jenkins jenkins
+RUN mkdir /home/jenkins/.ssh
+RUN echo "Jenkins_User_SSHKey" > /home/jenkins/.ssh/authorized_keys
+RUN chown -R jenkins /home/jenkins/.ssh
+RUN chmod -R og-rwx /home/jenkins/.ssh
+# RUN service ssh start
+CMD ["/usr/sbin/sshd","-D"]
+
+RUN dnf install -y git make gcc xorg-x11-server-Xvfb libXrender libXi libXtst fontconfig fakeroot procps-ng hostname diffutils shared-mime-info
+RUN dnf install -y coreutils --allowerasing curl
+# Install SSL Test packages
+RUN dnf install -y gnutls gnutls-utils nss nss-tools
+# ENTRYPOINT /usr/lib/jvm/jdk17/bin/java
+EXPOSE 22
+# Start with docker run -p 2222:22 UUID


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/2478

Centos stream 9 has support for 2 more years, https://endoflife.date/centos-stream