### PR TITLE
unixPB: improves `common > macos` task by using module for brew

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
@@ -108,9 +108,9 @@
 
 # Skipping linting as no situation where this can't run (lint error 301)
 - name: Update Casks
-  become: yes
-  become_user: "{{ ansible_user }}"
-  command: "{{ homebrew_path }}/brew cu -y"
+  homebrew_cask:
+    upgrade_all: yes
+    path: "{{ homebrew_path }}/brew"
   tags:
     - brew_cu
     - skip_ansible_lint


### PR DESCRIPTION
It replaces `command` with `homebrew_cask` module for Update Casks task in common > macos.

Signed-off-by: mahdi@ibm.com

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
