### PR TITLE
Inventory: Remove Win2012 machines

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -44,8 +44,6 @@ hosts:
           ubuntu1804-armv8-2: {ip: 159.138.100.163}
 
       - azure:
-          win2012r2-x64-1: {ip: 20.108.178.21, user: adoptopenjdk}
-          win2012r2-x64-2: {ip: 20.108.176.36, user: adoptopenjdk}
           win2022-x64-1: {ip: 172.187.129.163, user: adoptopenjdk}
           win2022-x64-2: {ip: 172.187.176.15, user: adoptopenjdk}
           win2022-x64-3: {ip: 51.142.8.47, user: adoptopenjdk}


### PR DESCRIPTION
Part of #3238 

Remove decomissioned Windows 2012 azure machines.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR
- [X] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
