### PR TITLE
WinPB: Add Installation of VS2022 Redists

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -76,6 +76,8 @@
       tags: MSVS_2019
     - role: MSVS_2022
       tags: MSVS_2022
+    - role: MSVS_2022_REDIST
+      tags: MSVS_2022_REDIST
     - NVidia_Cuda_Toolkit         # OpenJ9
     - NTP_TIME
     - Clang_64bit                 # OpenJ9

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2022_REDIST/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2022_REDIST/tasks/main.yml
@@ -1,0 +1,56 @@
+---
+###########################################
+# Visual Studio 2022 Redists Installation #
+###########################################
+- name: Set Windows SDK version
+  set_fact:
+    wsdk_version: "14.40.33807_10.0.26100.0"
+  tags: MSVS_2022_REDIST
+
+- name: Set Windows SDK checksum
+  set_fact:
+    wsdk_checksum: "a29ada15d941a7b2065e9a4273fd6b97df44d089ed2b9f860ded442f7fe69767"
+  tags: MSVS_2022_REDIST
+
+- name: Test if VS 2022 Redists Are installed
+  win_stat:
+    path: 'c:\openjdk\devkit\vs2022_redist_{{ wsdk_version }}'
+  register: vs2022sdk_installed
+  tags: MSVS_2022_REDIST
+
+- name: Check if C:\openjdk\devkit exists
+  ansible.windows.win_stat:
+    path: 'c:\openjdk\devkit'
+  register: directory_status
+  tags: MSVS_2022_REDIST
+
+- name: Create  C:\openjdk\devkit if it does not exist
+  ansible.windows.win_file:
+    path: 'c:\openjdk\devkit\'
+    state: directory
+  when: not directory_status.stat.exists
+  tags: MSVS_2022_REDIST
+
+# Download & Install VS2022 Redists From Github
+
+- name: Download Visual Studio 2022 Redists
+  win_get_url:
+    url: 'https://github.com/adoptium/devkit-binaries/releases/download/vs2022_redist_14.40.33807_10.0.26100.0/vs2022_redist_14.40.33807_10.0.26100.0.zip'
+    checksum: "{{ wsdk_checksum }}"
+    checksum_algorithm: sha256
+    dest: 'c:\openjdk\devkit\vs2022_redist_{{ wsdk_version }}.zip'
+    force: no
+  tags: MSVS_2022_REDIST
+
+- name: Unzip Visual Studio 2022 Redists
+  win_unzip:
+    src: 'c:\openjdk\devkit\vs2022_redist_{{ wsdk_version }}.zip'
+    dest: 'c:\openjdk\devkit\vs2022_redist_{{ wsdk_version }}'
+  when: not vs2022sdk_installed.stat.exists
+  tags: MSVS_2022_REDIST
+
+- name: Remove VS2022 redists Download
+  win_file:
+    path: 'c:\openjdk\devkit\vs2022_redist_{{ wsdk_version }}.zip'
+    state: absent
+  tags: MSVS_2022_REDIST


### PR DESCRIPTION
Fixes #3772 

Required as part of https://github.com/adoptium/temurin-build/pull/3981/files 

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)

VPC Successful : https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Win2022,label=vagrant/1982/console
