### PR TITLE
GHA: Added checksum validation

### DIFF
--- a/.github/workflows/build_wsl.yml
+++ b/.github/workflows/build_wsl.yml
@@ -29,17 +29,26 @@ jobs:
     name: Windows
     runs-on: ${{ matrix.os }}
     steps:
-
-    - name: Setup WinRM and Password
+    
+    - name: Setup WinRM and Password (checksum verified)
       shell: powershell
       run: |
         Set-LocalUser -Name "runneradmin" -Password (ConvertTo-SecureString -AsPlainText "Ansible_password123!" -Force)
         New-NetFirewallRule -DisplayName "ALLOW TCP PORT 5986" -Direction inbound -Profile Any -Action Allow -LocalPort 5986 -Protocol TCP
         Invoke-WebRequest https://raw.githubusercontent.com/ansible/ansible-documentation/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile .\ConfigureRemotingForAnsible.ps1
-        .\ConfigureRemotingForAnsible.ps1 -CertValidityDays 9999
-        .\ConfigureRemotingForAnsible.ps1 -EnableCredSSP
-        .\ConfigureRemotingForAnsible.ps1 -ForceNewSSLCert
-        .\ConfigureRemotingForAnsible.ps1 -SkipNetworkProfileCheck
+        $expectedChecksum = "EBA72DF06E3E77709595F75D1D5B4D95B06602429DD2A3F7867406DF875B0C70"
+        $actualChecksum = Get-FileHash -Path ".\ConfigureRemotingForAnsible.ps1" -Algorithm SHA256 | Select-Object -ExpandProperty Hash        
+        if ($actualChecksum -ne $expectedChecksum) {
+            Write-Output "Checksum mismatch"
+            Write-Output "Actual Checksum: $actualChecksum"
+            Write-Output "Expect Checksum: $expectedChecksum"
+            exit 1
+        } else {
+            .\ConfigureRemotingForAnsible.ps1 -CertValidityDays 9999
+            .\ConfigureRemotingForAnsible.ps1 -EnableCredSSP
+            .\ConfigureRemotingForAnsible.ps1 -ForceNewSSLCert
+            .\ConfigureRemotingForAnsible.ps1 -SkipNetworkProfileCheck       
+        }
 
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 

--- a/.github/workflows/build_wsl.yml
+++ b/.github/workflows/build_wsl.yml
@@ -29,7 +29,6 @@ jobs:
     name: Windows
     runs-on: ${{ matrix.os }}
     steps:
-    
     - name: Setup WinRM and Password (checksum verified)
       shell: powershell
       run: |


### PR DESCRIPTION
Fixes #3157

Added checksum validation for WinRE Ansible file 

##### Checklist
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] VPC/QPC not applicable for this PR