### PR TITLE
inventory: remove equinix awx systems

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -19,10 +19,6 @@ hosts:
       - digitalocean:
           ubuntu2004-x64-1: {ip: 178.62.115.224, description: bastillion.adoptopenjdk.net}
 
-      - equinix:
-          ubuntu1604-x64-1: {ip: 147.75.80.219, description: ansible.adoptopenjdk.net}
-          ubuntu2004-x64-1: {ip: 147.75.80.235, description: awx.adoptopenjdk.net}
-
       - hetzner:
           ubuntu1604-x64-1: {ip: 78.47.239.96, description: nagios.adoptopenjdk.net}
           ubuntu2004-x64-1: {ip: 78.47.239.97, description: ci.adoptium.net}


### PR DESCRIPTION
These disappeared as part of https://github.com/adoptium/infrastructure/issues/3292 earlier this year but didn't get removed from the inventory.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
