### PR TITLE
change distribution_release to 15.6

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/SLES.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/SLES.yml
@@ -23,7 +23,8 @@
 
 - name: Add Devel-Tools repository (SLES15)
   zypper_repository:
-    repo: https://download.opensuse.org/repositories/devel:/tools/15.6/devel:tools.repo
+    name: devel-tools
+    repo: 'https://download.opensuse.org/repositories/devel:/tools/15.{{ ansible_distribution_release }}/'
     auto_import_keys: yes
     state: present
   when:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/SLES.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/SLES.yml
@@ -23,7 +23,7 @@
 
 - name: Add Devel-Tools repository (SLES15)
   zypper_repository:
-    repo: https://download.opensuse.org/repositories/devel:/tools/15.5/devel:tools.repo
+    repo: https://download.opensuse.org/repositories/devel:/tools/15.6/devel:tools.repo
     auto_import_keys: yes
     state: present
   when:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

Need to change the distribution release version from 15.5 to 15.6 in the common role to add the devel-tools repo.

Can we make a change to make this dynamic?
Instead of using the hardcoded version , cant we make it dynamic?
For example instead  of `15.5` cant we make it `{{ ansible_distribution_major_version }}.{{ ansible_distribution_release }}`


##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
