### PR TITLE
unixPB: Dont install GA JDK17 bootjdk on alpine aarch64

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -126,6 +126,7 @@
       jdk_version: 17
       when:
         - ansible_distribution != "Solaris"
+        - (ansible_distribution != "Alpine" and ansible_architecture != "aarch64")
       tags: build_tools
     - role: adoptopenjdk_install  # JDK21 Build Bootstrap
       jdk_version: 20

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Alpine.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Alpine.yml
@@ -193,7 +193,7 @@
         - not adoptopenjdk17_installed.stat.exists
 
     - name: Get Temurin jdk17 full path name
-      shell: set -o pipefail | ls -ld /usr/lib/jvm/jdk17.* 2>/dev/null | awk '{print $9}'
+      shell: set -o pipefail | ls -ld /usr/lib/jvm/jdk-17.* 2>/dev/null | awk '{print $9}'
       register: adoptopenjdk17_dir
       when:
         - not adoptopenjdk17_installed.stat.exists

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Alpine.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Alpine.yml
@@ -137,10 +137,10 @@
       when:
         - not adoptopenjdk8_installed.stat.exists
 
-# Temp: install a non temurin binary until GA or when the jdk-11 alpine aarch64 build job becomes more stable (whichever comes first)
+# Temp: install a non temurin binary until GA or when the jdk11 alpine aarch64 build job becomes more stable (whichever comes first)
 # https://github.com/adoptium/temurin-build/issues/2961
-    - name: Check if jdk-11 is already installed in the target location
-      stat: path=/usr/lib/jvm/jdk-11
+    - name: Check if jdk11 is already installed in the target location
+      stat: path=/usr/lib/jvm/jdk11
       register: adoptopenjdk11_installed
 
     - name: Install java 11 from Alpine repositories
@@ -150,7 +150,7 @@
     - name: Create symlink to point at openjdk11
       file:
         src: /usr/lib/jvm/java-11-openjdk
-        dest: /usr/lib/jvm/jdk-11
+        dest: /usr/lib/jvm/jdk11
         state: link
       when: ansible_architecture != "aarch64" and not adoptopenjdk11_installed.stat.exists
 
@@ -177,10 +177,10 @@
 # Temp. Change to GA binary once theyre available
     - name: Check if Temurin jdk17 is installed
       stat:
-        path: /usr/lib/jvm/jdk-17
+        path: /usr/lib/jvm/jdk17
       register: adoptopenjdk17_installed
 
-    - name: Install Temurin jdk-17 nightly
+    - name: Install Temurin jdk17 nightly
       unarchive:
         src: https://github.com/adoptium/temurin17-binaries/releases/download/jdk17u-2022-05-27-19-32-beta/OpenJDK17U-jdk_aarch64_alpine-linux_hotspot_2022-05-27-17-01.tar.gz
         dest: /usr/lib/jvm
@@ -192,8 +192,8 @@
       when:
         - not adoptopenjdk17_installed.stat.exists
 
-    - name: Get Temurin jdk-17 full path name
-      shell: set -o pipefail | ls -ld /usr/lib/jvm/jdk-17.* 2>/dev/null | awk '{print $9}'
+    - name: Get Temurin jdk17 full path name
+      shell: set -o pipefail | ls -ld /usr/lib/jvm/jdk17.* 2>/dev/null | awk '{print $9}'
       register: adoptopenjdk17_dir
       when:
         - not adoptopenjdk17_installed.stat.exists
@@ -201,7 +201,7 @@
     - name: Create symlink to major version
       file:
         src: '{{ adoptopenjdk17_dir.stdout }}'
-        dest: /usr/lib/jvm/jdk-17
+        dest: /usr/lib/jvm/jdk17
         state: link
       when:
         - not adoptopenjdk17_installed.stat.exists


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Installing GA JDK17 aarch64 alpine linux as a bootjdk (using the adoptopenjdk_install role) is causing an error since the GA doesnt exist. We install a [nightly version](https://github.com/adoptium/infrastructure/blob/master/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Alpine.yml) in the common role.

Theres an issue [here](https://github.com/adoptium/infrastructure/issues/3804) to discuss merging the bootjdk installs in the common role and the adoptopenjdk_install role, but until then this pr will stop errors such as https://ci.adoptium.net/job/centos7_docker_image_updater/574/execution/node/77/log/ in the build image updater job

```
 > [5/5] RUN set -eux;  cd /ansible;  ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml -e "git_sha=8803a16b196c127edb73c33b63ec9ace14008fd5" --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit";  rm -rf /ansible; apk del ansible:
671.6 
671.6 TASK [adoptopenjdk_install : Download latest release (Linux/Alpine-Linux)] *****
672.3 FAILED - RETRYING: Download latest release (Linux/Alpine-Linux) (3 retries left).
678.1 FAILED - RETRYING: Download latest release (Linux/Alpine-Linux) (2 retries left).
683.8 FAILED - RETRYING: Download latest release (Linux/Alpine-Linux) (1 retries left).
689.6 fatal: [localhost]: FAILED! => {"attempts": 3, "changed": false, "dest": "/tmp/jdk17.tar.gz", "elapsed": 0, "msg": "Request failed", "response": "HTTP Error 404: Not Found", "status_code": 404, "url": "https://api.adoptium.net/v3/binary/latest/17/ga/alpine-linux/aarch64/jdk/hotspot/normal/eclipse?project=jdk"}
```