### PR TITLE
unixPb: Correct the condition on JDK17 alpine aarch64 install

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -126,7 +126,7 @@
       jdk_version: 17
       when:
         - ansible_distribution != "Solaris"
-        - (ansible_distribution != "Alpine" and ansible_architecture != "aarch64")
+        - not (ansible_distribution == "Alpine" and ansible_architecture == "aarch64")
       tags: build_tools
     - role: adoptopenjdk_install  # JDK21 Build Bootstrap
       jdk_version: 20


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Mistakenly put the wrong condition in https://github.com/adoptium/infrastructure/pull/3805 causing the JDK17 install to skip x64 alpine

https://ci.adoptium.net/job/centos7_docker_image_updater/576/execution/node/116/log/

```
#9 807.4 TASK [adoptopenjdk_install : Install latest Adopt JDK17 if one not already installed (Linux/Alpine-Linux)] ***
#9 807.4 skipping: [localhost]
#9 807.4 
```

This should skip the JDK17 install only on aarch64 alpine. Its equivalent to `(ansible_distribution != "Alpine" or ansible_architecture != "aarch64")` which is also used in the playbook to prevent JDK11 and JDK8 from installing on alpine aarch64.

The Alpine3 aarch64 build image will still have its JDK17 bootjdk as mentioned here https://github.com/adoptium/infrastructure/pull/3805#issuecomment-2463452475

To clarify: we install a GA boot jdk17 on alpine x64 and a ea jdk17 on alpine aarch64