### PR TITLE
winPB: Stop using ansible.windows as prefix to tasks

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Incredibuild/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Incredibuild/tasks/main.yml
@@ -4,12 +4,12 @@
 #######################################
 
 - name: Check if the ibxbuild service exists
-  ansible.windows.win_service_info:
+  win_service_info:
     name: IBXDashboard
   register: service_info
 
 - name: Stop the IBX Dashboard service if it exists
-  ansible.windows.win_service:
+  win_service:
     name: IBXDashboard
     state: stopped
   when: service_info.exists
@@ -28,7 +28,7 @@
   when: incredibuild_conf_file.stat.exists
 
 - name: Start the IBX Dashboard service if it exists
-  ansible.windows.win_service:
+  win_service:
     name: IBXDashboard
     state: started
   when: service_info.exists

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2022_REDIST/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2022_REDIST/tasks/main.yml
@@ -19,13 +19,13 @@
   tags: MSVS_2022_REDIST
 
 - name: Check if C:\openjdk\devkit exists
-  ansible.windows.win_stat:
+  win_stat:
     path: 'c:\openjdk\devkit'
   register: directory_status
   tags: MSVS_2022_REDIST
 
 - name: Create  C:\openjdk\devkit if it does not exist
-  ansible.windows.win_file:
+  win_file:
     path: 'c:\openjdk\devkit\'
     state: directory
   when: not directory_status.stat.exists


### PR DESCRIPTION
The Windows playbooks are not currently able to run using the setup process for running our windows docker containers as they fail with a "no task" or similar message when we try to run them using the `ansible` supplied with a default cygwin install. The implementatino of fully qualifications were done under:
- https://github.com/adoptium/infrastructure/pull/3726
- https://github.com/adoptium/infrastructure/pull/3774

I've got a feeling there was a reason we did this but I'm not sure what it is and it's currently causing me a problem, so I'd like to remove the full qualification for now, unless there is another simple solution.

NOTE: Up til now we've been using a fixed version of the playbooks as specified in https://github.com/adoptium/infrastructure/blob/e23e780a20b920e576291283d6229e11bb0d5603/ansible/docker/Dockerfile.win2022#L49 to create the containers. This branch (which has now been merged) did not have the above two PRs so hasn't been causing a problem. This error was found while attempting to bring that up to date so we can use the master branch going forward. Also noting that there is one other issue relating to the ant-contrib download being unreliable that will also need to be addressed - I've worked around that in another branch for now.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/2014/
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
