### PR TITLE
Vagrant: Improve Test Coverage & Align Tests In VPC process.

### DIFF
--- a/ansible/pbTestScripts/testJDK.sh
+++ b/ansible/pbTestScripts/testJDK.sh
@@ -17,28 +17,25 @@ if [[ "$(uname)" == "SunOS" ]]; then
 	export PATH="/usr/local/bin:/opt/csw/bin:${PATH}"
 fi
 
+## Run The Smoke Tests To Ensure The JDK Build OK
 mkdir -p $HOME/testLocation
 [ ! -d $HOME/testLocation/aqa-tests ] && git clone https://github.com/adoptium/aqa-tests.git $HOME/testLocation/aqa-tests
 # cd to aqa-tests as required by https://github.com/adoptium/aqa-tests/issues/2691#issue-932959102
 cd $HOME/testLocation/aqa-tests
-$HOME/testLocation/aqa-tests/get.sh
+$HOME/testLocation/aqa-tests/get.sh --vendor_repos https://github.com/adoptium/temurin-build --vendor_branches master --vendor_dirs /test/functional
 cd $HOME/testLocation/aqa-tests/TKG || exit 1
+export BUILD_LIST=functional/buildAndPackage
+$MAKE_COMMAND compile
+$MAKE_COMMAND _extended.functional
 
-# Solaris runs a different test to Linux.
-# See: https://adoptium.slack.com/archives/C53GHCXL4/p1641311568115100?thread_ts=1641296204.114900&cid=C53GHCXL4
-if [[ "$(uname)" == "SunOS" ]]; then
-	export BUILD_LIST=system
-	$MAKE_COMMAND compile
-	$MAKE_COMMAND _MachineInfo
-else
-	# Runs this test to check for prerequisite perl modules
-	export BUILD_LIST=functional
-	$MAKE_COMMAND compile
-	$MAKE_COMMAND _MBCS_Tests_pref_ja_JP_linux_0
-fi
+# Run a few subsets of OpenJDK Tests as a shakedown of the built JDK.
+export BUILD_LIST=openjdk
+$MAKE_COMMAND compile
+$MAKE_COMMAND _hotspot_sanity_0
+$MAKE_COMMAND _jdk_math_0
 
 # Run SSL Client Tests Linux Only ( Not Solaris / FreeBSD )
-if [[ "$(uname)" == "FreeBSD" ]] || [["$(uname)" == "SunOS"]]; then
+if [[ "$(uname)" == "FreeBSD" ]] || [[ "$(uname)" == "SunOS" ]]; then
 	echo "Skipping SSL Tests As Not Supported"
 else
 	export TESTJAVA=$TEST_JDK_HOME

--- a/ansible/pbTestScripts/testJDKWin.sh
+++ b/ansible/pbTestScripts/testJDKWin.sh
@@ -30,13 +30,17 @@ pwd
 ls -tr
 cd aqa-tests
 ./get.sh --vendor_repos https://github.com/adoptium/temurin-build --vendor_branches master --vendor_dirs /test/functional
-cd aqa-tests/TKG || exit 1
+pwd
+ls -ltr
+cd TKG || exit 1
+
+## Run The Smoke Tests To Ensure The JDK Build OK
 export BUILD_LIST=functional/buildAndPackage
-$MAKE_COMMAND compile
-$MAKE_COMMAND _extended.functional
+make compile
+make _extended.functional
 
 # Run a few subsets of OpenJDK Tests as a shakedown of the built JDK.
-# export BUILD_LIST=openjdk
-# $MAKE_COMMAND compile
-# $MAKE_COMMAND _hotspot_sanity_0
-# $MAKE_COMMAND _jdk_math_0
+export BUILD_LIST=openjdk
+make compile
+make _hotspot_sanity_0
+make _jdk_math_0

--- a/ansible/pbTestScripts/testJDKWin.sh
+++ b/ansible/pbTestScripts/testJDKWin.sh
@@ -15,6 +15,9 @@ rm -rf /cygdrive/c/tmp/*-test-image
 export TEST_JDK_HOME=`ls -d c:/tmp/jdk*|grep -v "static"|grep -v "debug"|grep -v "jre"|grep -v "test-image"`
 echo TEST_JDK_HOME=$TEST_JDK_HOME
 
+## Run The Same Tests As Test JDK for Linux
+## Run The Smoke Tests To Ensure The JDK Build OK
+
 cd /cygdrive/c/tmp
 if [ ! -d "testLocation" ];
 then
@@ -22,15 +25,18 @@ then
 	mkdir testLocation
 fi
 cd testLocation
-if [ ! -d "openjdk-tests" ];
-then
-	echo "Git cloning openjdk-tests"
-	git clone https://github.com/adoptopenjdk/openjdk-tests
-fi
-cd openjdk-tests
+git clone https://github.com/adoptium/aqa-tests.git
+pwd
+ls -tr
+cd aqa-tests
+./get.sh --vendor_repos https://github.com/adoptium/temurin-build --vendor_branches master --vendor_dirs /test/functional
+cd aqa-tests/TKG || exit 1
+export BUILD_LIST=functional/buildAndPackage
+$MAKE_COMMAND compile
+$MAKE_COMMAND _extended.functional
 
-./get.sh -T $HOME/testLocation/openjdk-tests -p x64_windows
-cd TKG
-export BUILD_LIST=system
-make compile
-make _extended.system 
+# Run a few subsets of OpenJDK Tests as a shakedown of the built JDK.
+# export BUILD_LIST=openjdk
+# $MAKE_COMMAND compile
+# $MAKE_COMMAND _hotspot_sanity_0
+# $MAKE_COMMAND _jdk_math_0

--- a/ansible/vagrant/Vagrantfile.Fedora40
+++ b/ansible/vagrant/Vagrantfile.Fedora40
@@ -6,6 +6,9 @@ $script = <<SCRIPT
 if [ -r /vagrant/id_rsa.pub ]; then
         mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys
 fi
+sudo dnf install -y cloud-utils-growpart xfsprogs
+sudo growpart /dev/sda 2
+sudo xfs_growfs /
 SCRIPT
 
 # 2 = version of configuration file for Vagrant 1.1+ leading up to 2.0.x
@@ -18,6 +21,7 @@ Vagrant.configure("2") do |config|
     adoptopenjdkF40.vm.network :private_network, type: "dhcp"
     adoptopenjdkF40.vm.provision "shell", inline: $script, privileged: false
   end
+  config.disksize.size ="75GB"
   config.vm.provider "virtualbox" do |v|
     v.gui = false
     v.memory = 4196


### PR DESCRIPTION
Update the vagrant playbook check tests of the built JDK, this will now run the standard smoke tests after each build, plus 2 sets of tests ( jdk_math and hotspot_sanity ). These tests are now identical across linux & windows.



##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)

VPC Run : https://ci.adoptium.net/job/VagrantPlaybookCheck/2025/ 