### PR TITLE
pbTests: Include SBOM creation in the build tests

### DIFF
--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -191,4 +191,5 @@ echo "buildJDK.sh DEBUG:
 cloneRepo
 
 cd $WORKSPACE/openjdk-build
+export BUILD_ARGS=--create-sbom
 build-farm/make-adopt-build-farm.sh

--- a/ansible/pbTestScripts/buildJDKWin.sh
+++ b/ansible/pbTestScripts/buildJDKWin.sh
@@ -131,4 +131,5 @@ echo "buildJDKWin.sh DEBUG:
 	FILENAME=${FILENAME:-}"
 
 echo "Running $WORKSPACE/openjdk-build/build-farm/make-adopt-build-farm.sh"
+export BUILD_ARGS=--create-sbom
 $WORKSPACE/openjdk-build/build-farm/make-adopt-build-farm.sh


### PR DESCRIPTION
Self-explanatory. The current build checks do run run through the SBoM generation process, so we are not validating that those parts of the process work after any changes. This will also help to verify https://github.com/adoptium/infrastructure/issues/3806 when it is implemented.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/2032/ (Although I'm not sure it works for a change to these files - we shall see...)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
