### PR TITLE
inventory: Update test-rise riscv names and IPs after upgrades

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -144,15 +144,15 @@ hosts:
 
       # Rise machines are hosted in Scaleway
       - rise:
-          ubuntu2310-riscv64-1: {ip: 62.210.163.38, user: ubuntu}
-          ubuntu2310-riscv64-2: {ip: 62.210.163.36, user: ubuntu}
-          ubuntu2404-riscv64-1: {ip: 62.210.163.41, user: ubuntu}
+          ubuntu2404-riscv64-1: {ip: 62.210.163.198, user: ubuntu}
           ubuntu2404-riscv64-2: {ip: 62.210.163.196, user: ubuntu}
           ubuntu2404-riscv64-3: {ip: 62.210.163.99, user: ubuntu}
           ubuntu2404-riscv64-4: {ip: 62.210.163.103, user: ubuntu}
           ubuntu2404-riscv64-5: {ip: 62.210.163.45, user: ubuntu}
           ubuntu2404-riscv64-6: {ip: 62.210.163.135, user: ubuntu}
           ubuntu2404-riscv64-7: {ip: 62.210.163.137, user: ubuntu}
+          ubuntu2404-riscv64-8: {ip: 62.210.163.38, user: ubuntu}
+          ubuntu2404-riscv64-9: {ip: 62.210.163.36, user: ubuntu}
 
       - siteox:
           solaris10u11-sparcv9-1: {ip: cloud.siteox.com, port: 53322}


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/3719

All of the test-rise boxes were given a reinstall to ensure a kernel upgrade to `5.10.113-scw1`. More specifically, test-rise-ubuntu2404-riscv64-1's ip changed because I deleted the old box and made a new one. The ubuntu 2310 boxes were reinstalled to ubuntu2404. Their entries in jenkins have been updated