### PR TITLE
unixPB: add skytap-5 to jckservices firewall

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/jckservices_iptables/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/jckservices_iptables/tasks/main.yml
@@ -77,6 +77,7 @@
     - 62.210.163.131 # jck-rise-ubuntu2404-risc64-1
     - 62.210.163.164 # jck-rise-ubuntu2404-risc64-2
     - 62.210.163.34 # jck-rise-ubuntu2404-risc64-3
+    - 20.61.136.213 # jck-skytap-aix72-ppc64-5
 
 - name: Setup iptables
   iptables:


### PR DESCRIPTION
Seems this machine was missing. It's been added to the machine already now so this PR just needs to go in to store the configuration

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
