### PR TITLE
unixPB: add diffutils and procps-ng to RH/Cent/Fedora

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -14,6 +14,7 @@ Build_Tool_Packages:
   - cpio
   - curl
   - cups-devel
+  - diffutils
   - elfutils-libelf-devel
   - file
   - flex                          # OpenJ9
@@ -71,6 +72,7 @@ gcc48_devtoolset_compiler:
 Additional_Build_Tools_CentOS7:
   - libstdc++-static
   - ccache
+  - procps-ng
 
 Additional_Build_Tools_CentOS8_CentOS9Stream:
   - glibc-locale-source
@@ -80,6 +82,7 @@ Additional_Build_Tools_CentOS8_CentOS9Stream:
   - git
   - cmake
   - ccache
+  - procps-ng
 
 Additional_Build_Tools_NOT_CentOS8_CentOS9Stream:
   - lbzip2

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -12,7 +12,6 @@ Build_Tool_Packages:
   - bzip2
   - ca-certificates
   - cpio
-  - curl
   - cups-devel
   - diffutils
   - elfutils-libelf-devel

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Fedora.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Fedora.yml
@@ -15,6 +15,7 @@ Build_Tool_Packages:
   - cpio
   - curl
   - cups-devel
+  - diffutils
   - elfutils-libelf-devel
   - flex                          # OpenJ9
   - fontconfig-devel
@@ -44,6 +45,7 @@ Build_Tool_Packages:
   - nss-devel
   - nss-tools
   - openssl-devel
+  - procps-ng
   - perl-devel
   - pkgconfig
   - strace                        # For SBOM dependency analysis

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Fedora.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Fedora.yml
@@ -13,7 +13,6 @@ Build_Tool_Packages:
   - ca-certificates
   - capstone-devel
   - cpio
-  - curl
   - cups-devel
   - diffutils
   - elfutils-libelf-devel

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -14,6 +14,7 @@ Build_Tool_Packages:
   - cpio
   - curl
   - cups-devel
+  - diffutils
   - elfutils-libelf-devel
   - file
   - flex                          # OpenJ9
@@ -68,9 +69,11 @@ Additional_Build_Tools_RHEL8:
   - glibc-langpack-zh             # required for creating Chinese locales
   - git
   - cmake
+  - procps-ng
 
 Additional_Build_Tools_RHEL7:
   - libstdc++-static
+  - procps-ng
 
 Additional_Build_Tools_RHEL7_PPC64LE:
   - libstdc++

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -12,7 +12,6 @@ Build_Tool_Packages:
   - bzip2
   - ca-certificates
   - cpio
-  - curl
   - cups-devel
   - diffutils
   - elfutils-libelf-devel


### PR DESCRIPTION
Fixes https://github.com/adoptium/infrastructure/issues/3869
Related: https://github.com/adoptium/infrastructure/pull/3802 (The RHEL8-RHEL8Plus change in that PR may mean this needs an update to go it to avoid a conflict).

Note that as per the notes in 3869 CentOS6 will generally already have procps installed so, for simplicity,  I have not explicitly listed it here.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) No due to https://github.com/adoptium/infrastructure/issues/3867 but I'm testing in containers New VPC run https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/2087/
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
