### PR TITLE
Fix Failing Windows 2022 Github Action

### DIFF
--- a/.github/workflows/build_wsl.yml
+++ b/.github/workflows/build_wsl.yml
@@ -36,7 +36,7 @@ jobs:
         New-NetFirewallRule -DisplayName "ALLOW TCP PORT 5986" -Direction inbound -Profile Any -Action Allow -LocalPort 5986 -Protocol TCP
         Invoke-WebRequest https://raw.githubusercontent.com/ansible/ansible-documentation/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile .\ConfigureRemotingForAnsible.ps1
         $expectedChecksum = "EBA72DF06E3E77709595F75D1D5B4D95B06602429DD2A3F7867406DF875B0C70"
-        $actualChecksum = Get-FileHash -Path ".\ConfigureRemotingForAnsible.ps1" -Algorithm SHA256 | Select-Object -ExpandProperty Hash        
+        $actualChecksum = Get-FileHash -Path ".\ConfigureRemotingForAnsible.ps1" -Algorithm SHA256 | Select-Object -ExpandProperty Hash
         if ($actualChecksum -ne $expectedChecksum) {
             Write-Output "Checksum mismatch"
             Write-Output "Actual Checksum: $actualChecksum"
@@ -46,12 +46,14 @@ jobs:
             .\ConfigureRemotingForAnsible.ps1 -CertValidityDays 9999
             .\ConfigureRemotingForAnsible.ps1 -EnableCredSSP
             .\ConfigureRemotingForAnsible.ps1 -ForceNewSSLCert
-            .\ConfigureRemotingForAnsible.ps1 -SkipNetworkProfileCheck       
+            .\ConfigureRemotingForAnsible.ps1 -SkipNetworkProfileCheck
         }
 
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - uses: Vampire/setup-wsl@23f94bc31caaddc08bd1230a00b89f872633d8d7 # v3.1.3
+    - uses: Vampire/setup-wsl@5ff2c045a05fd477a71b5419d50c5a228a52468e # v4.1
+      with:
+        wsl-version: 1
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Fixes #3873 

Add wsl version param to wsl setup, to ensure wsl v1 compatible with both windows 2019 & windows 2022.

This should also allow #3854 to be merged.


##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR

