### PR TITLE
docker: Update mulitarch linux arm platform option

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
@@ -8,10 +8,10 @@
 
 - name: Set docker buildx command if building arm32 container
   set_fact:
-    docker_build_command: "docker buildx build --platform linux/v7/arm"
+    docker_build_command: "docker buildx build --platform linux/arm/v7"
     arm32_suffix: ".arm32"
     ansible_architecture: arm
-    docker_run_command: "docker run --platform linux/v7/arm"
+    docker_run_command: "docker run --platform linux/arm/v7"
   when: build_arm32 is defined and build_arm32 == "yes"
 
 # Dockerfiles are transferred from the controller node onto the dockerhost to be used to build and run docker containers


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Not sure if this option changed recently, or with a docker upgrade, but linux/v7/arm no longer works and linux/arm/v7 works 👍🏻 