### PR TITLE
UnixPB: Fix Problematic Centos6 Downloads

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -42,7 +42,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Set up Python 3.x
-      uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: '3.x'
 

--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -169,11 +169,11 @@ fi
 # Don't build the debug-images as it takes too much space, and doesn't benefit VPC
 # See: https://github.com/adoptium/infrastructure/issues/2033
 export CONFIGURE_ARGS="--with-native-debug-symbols=none"
-export BUILD_ARGS="--custom-cacerts false"
+export BUILD_ARGS="--custom-cacerts false --create-sbom"
 
 # For Ubuntu24.04 Support - Don't Use gcc-7
 if grep 'noble' /etc/*-release >/dev/null 2>&1; then
-        export BUILD_ARGS="--custom-cacerts false --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03"
+        export BUILD_ARGS="${BUILD_ARGS} --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03"
 fi
 
 echo "buildJDK.sh DEBUG:
@@ -191,5 +191,4 @@ echo "buildJDK.sh DEBUG:
 cloneRepo
 
 cd $WORKSPACE/openjdk-build
-export BUILD_ARGS+=" --create-sbom"
 build-farm/make-adopt-build-farm.sh

--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -191,5 +191,5 @@ echo "buildJDK.sh DEBUG:
 cloneRepo
 
 cd $WORKSPACE/openjdk-build
-export BUILD_ARGS=--create-sbom
+export BUILD_ARGS+=" --create-sbom"
 build-farm/make-adopt-build-farm.sh

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/GIT_Source/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/GIT_Source/tasks/main.yml
@@ -42,6 +42,7 @@
     - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.15', operator='lt'))
     - ansible_distribution != "FreeBSD"
     - ansible_distribution != "CentOS" or ansible_distribution_major_version | int != 6
+    - ansible_distribution != "RedHat" or ansible_distribution_major_version | int != 6
   tags: git_source
 
 - name: Download git source for CentOS 6
@@ -50,7 +51,8 @@
     warn: false
   when:
     - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.15', operator='lt'))
-    - ansible_distribution == "CentOS" and ansible_distribution_major_version | int == 6
+    - (ansible_distribution == "CentOS" or ansible_distribution == "RedHat")
+    - ansible_distribution_major_version | int == 6
   tags: git_source
 
 - name: Verify checksum for CentOS 6 Git Source download ...
@@ -59,7 +61,8 @@
   failed_when: "'107116489f10b758b51af1c5dbdb9a274917b0fb67dc8eaefcdabc7bc3eb3e6a' not in checksum_result.stdout"
   when:
     - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.15', operator='lt'))
-    - ansible_distribution == "CentOS" and ansible_distribution_major_version | int == 6
+    - (ansible_distribution == "CentOS" or ansible_distribution == "RedHat")
+    - ansible_distribution_major_version | int == 6
   tags: git_source
 
 - name: Extract git source

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/GIT_Source/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/GIT_Source/tasks/main.yml
@@ -41,6 +41,25 @@
   when:
     - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.15', operator='lt'))
     - ansible_distribution != "FreeBSD"
+    - ansible_distribution != "CentOS" or ansible_distribution_major_version | int != 6
+  tags: git_source
+
+- name: Download git source for CentOS 6
+  shell: "wget -q -O /tmp/git-2.15.0.tar.xz https://www.kernel.org/pub/software/scm/git/git-2.15.0.tar.xz"
+  args:
+    warn: false
+  when:
+    - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.15', operator='lt'))
+    - ansible_distribution == "CentOS" and ansible_distribution_major_version | int == 6
+  tags: git_source
+
+- name: Verify checksum for CentOS 6 Git Source  download ...
+  shell: sha256sum /tmp/git-2.15.0.tar.xz
+  register: checksum_result
+  failed_when: "'107116489f10b758b51af1c5dbdb9a274917b0fb67dc8eaefcdabc7bc3eb3e6a' not in checksum_result.stdout"
+  when:
+    - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.15', operator='lt'))
+    - ansible_distribution == "CentOS" and ansible_distribution_major_version | int == 6
   tags: git_source
 
 - name: Extract git source

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NVidia_Cuda_Toolkit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NVidia_Cuda_Toolkit/tasks/main.yml
@@ -2,6 +2,7 @@
 #######################
 # NVidia_Cuda_Toolkit #
 #######################
+
 - name: Check if NVidia CUDA toolkit is already installed
   stat:
     path: /usr/local/cuda-9.0
@@ -21,6 +22,29 @@
     - cuda_installed.stat.isdir is not defined
     - (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or (ansible_distribution == "RedHat" and (ansible_distribution_major_version == "6" or ansible_distribution_major_version == "7")) or (ansible_distribution == "CentOS" and (ansible_distribution_major_version == "6" or ansible_distribution_major_version == "7"))
     - (ansible_architecture == "x86_64" or ansible_architecture == "ppc64le")
+    - ansible_distribution != "CentOS" or ansible_distribution_major_version | int != 6
+  tags: nvidia_cuda_toolkit
+
+- name: Download Nvidia Cuda for CentOS 6
+  shell: "wget -q -O /tmp/cuda9_linux-run https://developer.nvidia.com/compute/cuda/9.0/Prod/local_installers/cuda_9.0.176_384.81_linux-run"
+  args:
+    warn: false
+  when:
+    - cuda_installed.stat.isdir is not defined
+    - (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or (ansible_distribution == "RedHat" and (ansible_distribution_major_version == "6" or ansible_distribution_major_version == "7")) or (ansible_distribution == "CentOS" and (ansible_distribution_major_version == "6" or ansible_distribution_major_version == "7"))
+    - (ansible_architecture == "x86_64" or ansible_architecture == "ppc64le")
+    - ansible_distribution == "CentOS" and ansible_distribution_major_version | int == 6
+  tags: nvidia_cuda_toolkit
+
+- name: Verify checksum for CentOS 6 Nvdia Cuda download ...
+  shell: sha256sum /tmp/cuda9_linux-run
+  register: checksum_result
+  failed_when: "'96863423feaa50b5c1c5e1b9ec537ef7ba77576a3986652351ae43e66bcd080c' not in checksum_result.stdout"
+  when:
+    - cuda_installed.stat.isdir is not defined
+    - (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or (ansible_distribution == "RedHat" and (ansible_distribution_major_version == "6" or ansible_distribution_major_version == "7")) or (ansible_distribution == "CentOS" and (ansible_distribution_major_version == "6" or ansible_distribution_major_version == "7"))
+    - (ansible_architecture == "x86_64" or ansible_architecture == "ppc64le")
+    - ansible_distribution == "CentOS" and ansible_distribution_major_version | int == 6
   tags: nvidia_cuda_toolkit
 
 - name: Install NVidia CUDA toolkit


### PR DESCRIPTION
Fixes #3839 

Downloads for Git Source and Nvidia Cuda toolkit are failing on CentOS6 due to the certificate errors, and the lack of support of SNI enabled validation, due to the age of the O/S.

This PR adds an alternative, but still secure download mechanism for CentOS6 only, to allow the playbook to be backwards compatible.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)

VPC In Progress : https://ci.adoptium.net/job/VagrantPlaybookCheck/2061/