### PR TITLE
inventory: Update dockerhost-skytap-ubuntu2004-ppc64le-1 name after OS upgrade

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -86,7 +86,7 @@ hosts:
           ubuntu2404-s390x-1: {ip: 148.100.74.237, user: linux1}
 
       - skytap:
-          ubuntu2004-ppc64le-1: {ip: 20.61.136.212, description: 32CPU, 400G}
+          ubuntu2204-ppc64le-1: {ip: 20.61.136.212, description: 32CPU, 400G}
           ubuntu2204-x64-1: {ip: 20.61.136.254, description: 24 core Intel X5650}
 
   - test:


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/3588
Upgraded the OS from 20.04 to 22.04. Its Jenkins config, and hw.dockerhost.dockerhost-skytap-ubuntu2004-ppc64le-1 label on its hosted containers have been updated