### PR TITLE
unixPB: Update Ubuntu build images (arm32/riscv64) with patch and texinfo for devkit creation

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
@@ -46,10 +46,12 @@ Build_Tool_Packages:
   - libxtst-dev
   - make
   - ntp
+  - patch                         # For Devkit creation which runs "patch"
   - pigz
   - pkg-config
   - strace                        # For SBOM dependency analysis
   - systemtap-sdt-dev
+  - texinfo                       # For Devkit creation (binutils build)
   - wget
   - zip
 


### PR DESCRIPTION
Follow-on to https://github.com/adoptium/infrastructure/pull/3293 for other platforms.
Blocker for https://ci.adoptium.net/job/build-scripts/job/utils/job/devkit/job/devkit-gcc-linux-riscv64/ to be able to work within the docker build container (without the container it produces a compiler which will not work on Ubuntu 20.04)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/2073/ Passed on Ubuntu 18.04 so I'm confident this is safe - VPC having "issues" elsewhere
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
