### PR TITLE
UnixPB: Add Weston support to RHEL/CentOS 10

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
@@ -273,14 +273,23 @@
     - ansible_architecture == "x86_64"
   tags: expat
 
-#####################
-# Configure Weston #
-#####################
-- name: Install weston related packages(CentOS 10)
+#################
+# xorg Packages #
+#################
+- name: Install xorg-x11-server-Xvfb (< CentOS10)
+  package:
+    name: xorg-x11-server-Xvfb
+    state: latest
+  when: ansible_distribution_major_version < "10"
+
+#############################
+# Configure Wayland(Weston) #
+#############################
+- name: Install Wayland related packages (>= CentOS10)
   package:
     name: "{{ item }}"
     state: latest
-  with_items: "{{ Additional_Test_Tool_Packages_CentOS10 }}"
+  with_items: "{{ Additional_Test_Tool_Packages_Wayland }}"
   when: ansible_distribution_major_version > "9"
   tags: test_tools
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
@@ -280,7 +280,7 @@
   package:
     name: xorg-x11-server-Xvfb
     state: latest
-  when: ansible_distribution_major_version < "10"
+  when: ansible_distribution_major_version | int < 10
   tags: test_tools
 
 #############################
@@ -291,7 +291,7 @@
     name: "{{ item }}"
     state: latest
   with_items: "{{ Additional_Test_Tool_Packages_Wayland }}"
-  when: ansible_distribution_major_version > "9"
+  when: ansible_distribution_major_version | int > 9
   tags: test_tools
 
 ####################

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
@@ -281,6 +281,7 @@
     name: xorg-x11-server-Xvfb
     state: latest
   when: ansible_distribution_major_version < "10"
+  tags: test_tools
 
 #############################
 # Configure Wayland(Weston) #

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
@@ -273,6 +273,17 @@
     - ansible_architecture == "x86_64"
   tags: expat
 
+#####################
+# Configure Weston #
+#####################
+- name: Install weston related packages(CentOS 10)
+  package:
+    name: "{{ item }}"
+    state: latest
+  with_items: "{{ Additional_Test_Tool_Packages_CentOS10 }}"
+  when: ansible_distribution_major_version > "9"
+  tags: test_tools
+
 ####################
 # Set Default Java #
 ####################

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -118,25 +118,22 @@
 #################
 # xorg Packages #
 #################
-- name: Install xorg-x11-server-Xvfb (< RHEL10)
-  package:
-    name: xorg-x11-server-Xvfb
-    state: latest
+- name: Install x11 packages (< RHEL10)
+  tags: test_tools
   when: ansible_distribution_major_version < "10"
+  block:
+    - name: Install xorg-x11-server-Xvfb (< RHEL10)
+      package:
+        name: xorg-x11-server-Xvfb
+        state: latest
 
-- name: Install xorg-x11-server-Xorg if host is x86_64 and < RHEL10
-  yum: name=xorg-x11-server-Xorg state=installed
-  when:
-    - ansible_architecture == "x86_64"
-    - ansible_distribution_major_version < "10"
-  tags: test_tools
+    - name: Install xorg-x11-server-Xorg if host is x86_64 and < RHEL10
+      yum: name=xorg-x11-server-Xorg state=installed
+      when: ansible_architecture == "x86_64"
 
-- name: Install xorg-x11-server-common if host is s390x and < RHEL10
-  yum: name=xorg-x11-server-common state=installed
-  when:
-    - ansible_architecture == "s390x"
-    - ansible_distribution_major_version < "10"
-  tags: test_tools
+    - name: Install xorg-x11-server-common if host is s390x and < RHEL10
+      yum: name=xorg-x11-server-common state=installed
+      when: ansible_architecture == "s390x"
 
 #############################
 # Configure Wayland(Weston) #

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -16,12 +16,11 @@
     - ansible_architecture == "x86_64"
   tags: patch_update
 
-- name: Enable EPEL release for RHEL8 or RHEL6 or RHEL7
+- name: Enable EPEL release for RHEL
   yum: name=https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
   failed_when: false
-  when:
-    - ansible_architecture != "s390x"
-    - (ansible_distribution_major_version == "8") or (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
+  when: (ansible_distribution_major_version == "7" and ansible_architecture != "s390x") or
+        (ansible_distribution_major_version == "6" and (ansible_architecture != "s390x" or ansible_architecture != "ppc64le")
   tags: patch_update
 
 - name: YUM upgrade all packages

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -128,6 +128,17 @@
   when: (ansible_architecture == "s390x")
   tags: test_tools
 
+#####################
+# Configure Weston #
+#####################
+- name: Install weston related packages(RedHat 10)
+  package:
+    name: "{{ item }}"
+    state: latest
+  with_items: "{{ Additional_Test_Tool_Packages_RHEL10 }}"
+  when: ansible_distribution_major_version > "9"
+  tags: test_tools
+
 ################
 # Install Java #
 ################

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -128,14 +128,14 @@
   when: (ansible_architecture == "s390x")
   tags: test_tools
 
-#####################
-# Configure Weston #
-#####################
-- name: Install weston related packages(RedHat 10)
+#############################
+# Configure Wayland(Weston) #
+#############################
+- name: Install Wayland related packages(RedHat 10)
   package:
     name: "{{ item }}"
     state: latest
-  with_items: "{{ Additional_Test_Tool_Packages_RHEL10 }}"
+  with_items: "{{ Additional_Test_Tool_Packages_Wayland }}"
   when: ansible_distribution_major_version > "9"
   tags: test_tools
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -19,8 +19,8 @@
 - name: Enable EPEL release for RHEL
   yum: name=https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
   failed_when: false
-  when: (ansible_distribution_major_version == "7" and ansible_architecture != "s390x") or
-        (ansible_distribution_major_version == "6" and (ansible_architecture != "s390x" or ansible_architecture != "ppc64le")
+  when: not ((ansible_distribution_major_version == "7" and ansible_architecture == "s390x") or
+        (ansible_distribution_major_version == "6" and (ansible_architecture == "s390x" or ansible_architecture == "ppc64le")))
   tags: patch_update
 
 - name: YUM upgrade all packages

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -119,7 +119,7 @@
 #################
 - name: Install x11 packages (< RHEL10)
   tags: test_tools
-  when: ansible_distribution_major_version < "10"
+  when: ansible_distribution_major_version | int < 10
   block:
     - name: Install xorg-x11-server-Xvfb (< RHEL10)
       package:
@@ -142,7 +142,7 @@
     name: "{{ item }}"
     state: latest
   with_items: "{{ Additional_Test_Tool_Packages_Wayland }}"
-  when: ansible_distribution_major_version > "9"
+  when: ansible_distribution_major_version | int > 9
   tags: test_tools
 
 ################

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -118,20 +118,30 @@
 #################
 # xorg Packages #
 #################
-- name: Install xorg-x11-server-Xorg if host is x86_64
+- name: Install xorg-x11-server-Xvfb (< RHEL10)
+  package:
+    name: xorg-x11-server-Xvfb
+    state: latest
+  when: ansible_distribution_major_version < "10"
+
+- name: Install xorg-x11-server-Xorg if host is x86_64 and < RHEL10
   yum: name=xorg-x11-server-Xorg state=installed
-  when: (ansible_architecture == "x86_64")
+  when:
+    - ansible_architecture == "x86_64"
+    - ansible_distribution_major_version < "10"
   tags: test_tools
 
-- name: Install xorg-x11-server-common if host is s390x
+- name: Install xorg-x11-server-common if host is s390x and < RHEL10
   yum: name=xorg-x11-server-common state=installed
-  when: (ansible_architecture == "s390x")
+  when:
+    - ansible_architecture == "s390x"
+    - ansible_distribution_major_version < "10"
   tags: test_tools
 
 #############################
 # Configure Wayland(Weston) #
 #############################
-- name: Install Wayland related packages(RedHat 10)
+- name: Install Wayland related packages (>= RHEL10)
   package:
     name: "{{ item }}"
     state: latest

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -119,3 +119,8 @@ Test_Tool_Packages:
   - shared-mime-info
   - nss-devel
   - nss-tools
+
+Additional_Test_Tool_Packages_CentOS10:
+  - weston
+  - wayland-utils
+  - xorg-x11-server-Xwayland

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -112,7 +112,6 @@ Test_Tool_Packages:
   - perl
   - perl-Test-Simple
   - xorg-x11-xauth
-  - xorg-x11-server-Xvfb
   - fakeroot
   - gnutls
   - gnutls-utils
@@ -120,7 +119,7 @@ Test_Tool_Packages:
   - nss-devel
   - nss-tools
 
-Additional_Test_Tool_Packages_CentOS10:
+Additional_Test_Tool_Packages_Wayland:
   - weston
   - wayland-utils
   - xorg-x11-server-Xwayland

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -121,3 +121,8 @@ Test_Tool_Packages:
   - shared-mime-info
   - nss-devel
   - nss-tools
+
+Additional_Test_Tool_Packages_RHEL10:
+  - weston
+  - wayland-utils
+  - xorg-x11-server-Xwayland

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -110,7 +110,6 @@ Test_Tool_Packages:
   - perl-Time-HiRes
   - perl-Test-Simple
   - xorg-x11-xauth
-  - xorg-x11-server-Xvfb
   - zlib-devel
   - perl-devel
   - expat-devel
@@ -122,7 +121,9 @@ Test_Tool_Packages:
   - nss-devel
   - nss-tools
 
-Additional_Test_Tool_Packages_RHEL10:
+Additional_Test_Tool
+
+Additional_Test_Tool_Packages_Wayland:
   - weston
   - wayland-utils
   - xorg-x11-server-Xwayland

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -121,8 +121,6 @@ Test_Tool_Packages:
   - nss-devel
   - nss-tools
 
-Additional_Test_Tool
-
 Additional_Test_Tool_Packages_Wayland:
   - weston
   - wayland-utils


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->
rel: https://github.com/adoptium/infrastructure/issues/3851

The task installs weston related packages in RedHat/CentOS 10

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/2076/
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
