### PR TITLE
unixPB: add rpm2cpio/rpm to for creating devkits on Ubuntu

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
@@ -49,6 +49,8 @@ Build_Tool_Packages:
   - patch                         # For Devkit creation which runs "patch"
   - pigz
   - pkg-config
+  - rpm                           # For Fedora/CentOS devkit creation on Ubuntu hosts
+  - rpm2cpio                      # For Fedora/CentOS devkit creation on Ubuntu hosts
   - strace                        # For SBOM dependency analysis
   - systemtap-sdt-dev
   - texinfo                       # For Devkit creation (binutils build)


### PR DESCRIPTION
I was a bit too quick with my [last PR](https://github.com/adoptium/infrastructure/pull/3896) and missed a couple of critical packages that are not already there. It's still not working 100% with these changes but it's close -the failure I'm seeing looks like it's related to the devkit code and not the machine setup (There is some hard coding of Centos in our scripts - unfortunately it doesn't show up until the job has been running for 14 hours)

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
