### PR TITLE
unixPB: exclude cmake on solaris and alpine (Not OpenJ9 there)

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -91,7 +91,7 @@
       when: ansible_distribution == "MacOSX" and ansible_architecture == "arm64"
       tags: [xcode15] # JDK 17+
     - role: cmake                 # OpenJ9 / OpenJFX
-      when: ansible_distribution != "Solaris" # Compile fails on Solaris
+      when: ansible_distribution != "Solaris" and ansible_distribution != "Alpine"
       tags: [build_tools, build_tools_openj9, build_tools_openjfx]
     - role: capstone
       tags: [build_tools]


### PR DESCRIPTION
Fixes https://github.com/adoptium/infrastructure/issues/3904
cmake role is there for OpenJ9 and OpenJ9 does not support Alpine, so this is superfluous.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/2081/
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
