### PR TITLE
unixPB: update IP addresses for SkyTap AIX VMs

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/jckservices_iptables/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/jckservices_iptables/tasks/main.yml
@@ -62,8 +62,9 @@
     - 140.211.168.163 # jck-osuol-ubuntu2004-ppc64le-1
     - 140.211.168.2 # jck-osuol-ubuntu2004-ppc64le-2
     - 213.146.141.66 # jck-linaro-ubuntu2004-aarch64-2
-    - 20.61.222.79 # jck-skytap-aix72-ppc64-3
-    - 20.61.222.106 # jck-skytap-aix72-ppc64-4
+    - 76.191.119.116 # jck-skytap-aix72-ppc64-3
+    - 76.191.119.200 # jck-skytap-aix72-ppc64-4
+    - 76.191.119.132 # jck-skytap-aix72-ppc64-5
     - 12.202.69.3 # jck-siteox-solaris10u11-sparcv9-1
     - 178.62.54.114 # jck-digitalocean-ubuntu2004-x64-1
     - 188.166.144.71 # jck-digitalocean-ubuntu2004-x64-2
@@ -77,7 +78,6 @@
     - 62.210.163.131 # jck-rise-ubuntu2404-risc64-1
     - 62.210.163.164 # jck-rise-ubuntu2404-risc64-2
     - 62.210.163.34 # jck-rise-ubuntu2404-risc64-3
-    - 20.61.136.213 # jck-skytap-aix72-ppc64-5
 
 - name: Setup iptables
   iptables:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/ubuntu-jckservices.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/ubuntu-jckservices.yml
@@ -4,7 +4,7 @@
 # -------- Ubuntu 20 (tested on x64) -------- #
 ###############################################
 
-- name: Ansibl JCK Services Playbook
+- name: Ansible JCK Services Playbook
   hosts: all
   gather_facts: yes
   tasks:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

These VMs were migrated to a new DC which means they have new IP addresses.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
