### PR TITLE
aixPb: A few updates to the AIX playbook

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
@@ -53,9 +53,6 @@
     # Likewise, the xlc files may also need the Ansible unarchive and
     # need to be evaluated after the CORE OSS software has been installed.
     - X11
-    ## verify/install licensed IBM compilers
-    - xlc_v13
-    - xlc_v16
 
     # 4. Core OSS installation
 
@@ -68,6 +65,10 @@
     - aixfs
     - role: dnf
       tags: dnf
+
+    ## verify/install licensed IBM compilers
+    - xlc_v13
+    - xlc_v16
 
     ## additional OSS packages
     - ant

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/ant_contrib/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/ant_contrib/tasks/main.yml
@@ -11,7 +11,7 @@
   block:
     - name: Checking for ant-contrib availability
       stat:
-        path: /opt/apache-ant-1.9.9/lib/ant-contrib.jar
+        path: /opt/apache-ant-{{ ant_version }}/lib/ant-contrib.jar
       register: antcontrib
 
     - name: "Debug ant-contrib.jar installed, skipping download"
@@ -27,7 +27,7 @@
       when: not antcontrib.stat.exists
 
     - name: Move ant-contrib.jar to lib folder
-      command: mv /tmp/ant-contrib/lib/ant-contrib.jar /opt/apache-ant-1.9.9/lib/
+      command: mv /tmp/ant-contrib/lib/ant-contrib.jar /opt/apache-ant-{{ ant_version }}/lib/
       when: not antcontrib.stat.exists
 
     - name: Clean ant-contrib tmp files

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/dnf/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/dnf/tasks/main.yml
@@ -53,9 +53,9 @@
         path: /tmp/dnf_aixtoolbox.sh
 
 # See https://github.com/adoptium/infrastructure/pull/3271#issuecomment-1836343656
-- name: Dnf module needs /opt/freeware/libexec/python3 as its ansible_python_interpreter
+- name: Dnf module needs /opt/freeware/bin/python3 as its ansible_python_interpreter
   vars:
-    ansible_python_interpreter: /opt/freeware/libexec/python3
+    ansible_python_interpreter: /opt/freeware/bin/python3
   block:
     # See https://github.com/adoptium/infrastructure/pull/3271#issuecomment-1836227877
     - name: Remove yum-utils before dnf update

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/dnf/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/dnf/tasks/main.yml
@@ -53,25 +53,28 @@
         path: /tmp/dnf_aixtoolbox.sh
 
 # See https://github.com/adoptium/infrastructure/pull/3271#issuecomment-1836343656
-- name: Dnf module needs /opt/freeware/bin/python3 as its ansible_python_interpreter
+- name: Dnf module needs /opt/freeware/libexec/python3 as its ansible_python_interpreter
   vars:
-    ansible_python_interpreter: /opt/freeware/bin/python3
+    ansible_python_interpreter: /opt/freeware/libexec/python3
   block:
     # See https://github.com/adoptium/infrastructure/pull/3271#issuecomment-1836227877
     - name: Remove yum-utils before dnf update
       dnf:
         name: yum-utils
         state: absent
+        use_backend: dnf
 
     - name: Update dnf
       dnf:
         update_cache: true
         name: '*'
         state: latest
+        use_backend: dnf
 
     - name: Install packages
       dnf:
         state: present
+        use_backend: dnf
         update_cache: yes
         disable_excludes: all
         name:
@@ -129,6 +132,7 @@
         state: present
         update_cache: yes
         disable_excludes: all
+        use_backend: dnf
       tags:
         - rpm_install
         - cmake
@@ -147,6 +151,7 @@
     - name: Remove packages - in case installed historically, or by accident
       dnf:
         state: absent
+        use_backend: dnf
         name:
           - libXrender-devel
           - libXrender

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/xlc_v13/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/xlc_v13/tasks/main.yml
@@ -17,7 +17,6 @@
         src: /Vendor_Files/aix/XLC/IBM_XL_C_C___FOR_AIX_V13.1.3_EMG.tar.gz
         dest: /tmp
         remote_src: false
-      failed_when: false
       register: _vendor_copied
 
     - name: Install IBM XLC13 - installp

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/xlc_v16/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/xlc_v16/tasks/main.yml
@@ -18,7 +18,6 @@
         dest: /tmp
         remote_src: false
       register: _vendor_copied
-      failed_when: false
 
     - name: Install IBM XLC16 - installp
       command: installp -aXYg -e /tmp/xlc16_install.log -d /tmp/usr/sys/inst.images all


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Updates:
- Move compiler installs after dnf role. If unzip and tar are not installed, ansible cant unarchive the compiler files
- Ant contrib should use the up to date ant_version
- Update the python interpreter used by the dnf module
- Remove `failed_when: false` on the transfer tasks in the compiler roles. If the transfer fails for whatever reason I want the playbook execution to stop
