### PR TITLE
github: remove sxa as sole assignee of 'temporary access' issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/machineaccess.md
+++ b/.github/ISSUE_TEMPLATE/machineaccess.md
@@ -3,7 +3,6 @@ name: ⌨️  Request access to a machine
 about: Request access to an AdoptOpenJDK machine or set of machines
 title: Access request for <your username>
 labels: 'Temp Infra Access'
-assignees: 'sxa'
 
 ---
 **NOTE: THIS ISSUE SHOULD NOT BE CLOSED BY THE ORIGINATOR IF ACCESS IS GRANTED**.


### PR DESCRIPTION
Removing `sxa` as the exclusive owner of requests for temporary log in access to machines as this could prevent others from picking them up.

Other notes/options:
1. We could add all active infrastructure team members as assignees.
2. We could have the template link to https://github.com/adoptium/infrastructure/blob/master/FAQ.md#temporary-access-to-a-machine which describes how to grant access for whoever picks it up

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly


