### PR TITLE
doc: add backup of plugins into jenkins upgrade doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ to do an out-of-bound patch if a sufficientl sever issue is identified.
 1. Ensure off-machine backups are working!
 1. Ensure that no non-pipeline jobs are running on the server as they
    will often hold up restarts
+1. Create a tarball backup of the main config.xml and plugins.xml so they
+   can be quickly restored in the event of upgrade problems: `tar czf /home/jenkins/jenkinsbackup.$(date +%Y%m%d).tar.gz -C ~jenkins config.xml plugins`
 1. Check for plugin updates that will apply to the current version of
    jenkins (Each plugin should be checked for potential issues in the readme)
 1. Repeat step 1 if necessary until jenkins does not offer any more plugins

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ to do an out-of-bound patch if a sufficientl sever issue is identified.
    back and create an issue to deal with them in the next cycle.
 1. Backup the main war in /usr/share/jenkins to a name with a version suffix
    in case of corruption to the main jar.
+1. Once the upgrade is done, restart agents which do not auto-restart such as the windows ones not running as s service
 
 ### Backups
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ to do an out-of-bound patch if a sufficientl sever issue is identified.
    back and create an issue to deal with them in the next cycle.
 1. Backup the main war in /usr/share/jenkins to a name with a version suffix
    in case of corruption to the main jar.
-1. Once the upgrade is done, restart agents which do not auto-restart such as the windows ones not running as s service
+1. Once the upgrade is done, restart agents which do not auto-restart such as the Windows ones not running as a service
 
 ### Backups
 


### PR DESCRIPTION
It's a good idea and saved us a lot of time during the [latest upgrade cycle](https://github.com/adoptium/infrastructure/issues/3925).

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [x] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
