### PR TITLE
unixPB: remove curl from CentOS Common role

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -12,7 +12,6 @@ Build_Tool_Packages:
   - bzip2
   - ca-certificates
   - cpio
-  - curl
   - cups-devel
   - elfutils-libelf-devel
   - file


### PR DESCRIPTION
This seems like an odd thing to do, but the comment at https://github.com/adoptium/infrastructure/issues/3871#issuecomment-2883322700 is the best explanation. CS9 provides `curl-minimal` by default for `curl` whereas earlier versions and CS10 provide it via `curl`. Since they're all in the default package, it's less messy to just remove it unelss we find a deployment where it is not on the system by default.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)  https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/2088/
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
