### PR TITLE
Vagrant: Remove jmods folder from Test JDK derivation in VPC tests

### DIFF
--- a/ansible/pbTestScripts/testJDK.sh
+++ b/ansible/pbTestScripts/testJDK.sh
@@ -7,7 +7,7 @@ if [[ "$(uname)" == "FreeBSD" ]]; then
 	export TEST_JDK_HOME=$HOME/jdk
 else
 	ls -ld $HOME/openjdk-build/workspace/build/src/build/*/images/jdk*
- 	export TEST_JDK_HOME=$(ls -1d $HOME/openjdk-build/workspace/build/src/build/*/images/jdk* |egrep -v 'jre|-image|static-libs|sbom')
+ 	export TEST_JDK_HOME=$(ls -1d $HOME/openjdk-build/workspace/build/src/build/*/images/jdk* |egrep -v 'jre|-image|static-libs|sbom|-jmods')
 fi
 
 echo DEBUG: TEST_JDK_HOME = $TEST_JDK_HOME

--- a/ansible/pbTestScripts/testJDKWin.sh
+++ b/ansible/pbTestScripts/testJDKWin.sh
@@ -12,7 +12,7 @@ rm -rf /cygdrive/c/tmp/*-test-image
 
 # Set Test JDK HOME To The Relocated JDK
 # export TEST_JDK_HOME=C:/cygwin64$(find ~ -maxdepth 1 -type d -name "*jdk*"|grep -v ".*jre"| grep -v ".*-image")
-export TEST_JDK_HOME=`ls -d c:/tmp/jdk*|grep -v "static"|grep -v "debug"|grep -v "jre"|grep -v "test-image"`
+export TEST_JDK_HOME=`ls -d c:/tmp/jdk*|grep -v "static"|grep -v "debug"|grep -v "jre"|grep -v "test-image"|grep -v "jmods"`
 echo TEST_JDK_HOME=$TEST_JDK_HOME
 
 ## Run The Same Tests As Test JDK for Linux

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
@@ -13,7 +13,7 @@
     url: https://cygwin.com/setup-x86_64.exe
     dest: C:\temp\cygwin.exe
     force: no
-    checksum: e7815d360ab098fdd1f03f10f43f363c73a632e8866e304c72573cf1e6a0dec8
+    checksum: 2e2e322b138f6337d1a9be71cc0d3b9bb05991c5ac72bd68cf3c1c5f309ecf30
     checksum_algorithm: sha256
   when: not cygwin_installed.stat.exists
   register: cygwin_download


### PR DESCRIPTION
Fixes #3952 

Fix a bug where the addition of a new folder into the JDK build folder structure is causing the VPC post build tests to fail, as the derivation of the JDK folder was finding 2 entries.

:heavy_check_mark: U24.04 - https://ci.adoptium.net/job/VagrantPlaybookCheck/2095/
:heavy_check_mark: U22.04 - https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Ubuntu2204,label=vagrant/2098/
:heavy_check_mark: U20.04 - https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Ubuntu2004,label=vagrant/2096/
:heavy_check_mark: Centos 8: https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=CentOS8,label=vagrant/2096/
:heavy_check_mark: Centos 7: https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=CentOS7,label=vagrant/2098/
:heavy_check_mark: Solaris 10: https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Solaris10,label=vagrant/
:heavy_check_mark: Fedora 40: https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Fedora40,label=vagrant/2096/
:heavy_check_mark: Debian 10: https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Debian10,label=vagrant/2098/
:heavy_check_mark: Win2022: https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Win2022,label=vagrant/2109/

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
