### PR TITLE
unixPB: fix conditionals for nasm role

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/nasm/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/nasm/tasks/main.yml
@@ -87,7 +87,7 @@
     dest: /tmp/
     copy: False
   when:
-    - (nasm_installed.rc is defined) and ((nasm_installed.rc != 0 ) or (nasm_installed.rc == 0 and nasm.stdout is version_compare('2.13.03', operator='ne')) )
+    - (nasm_installed.rc is defined) and ((nasm_installed.rc != 0 ) or (nasm_installed.rc == 0 and nasm.stdout is version_compare(nasm_version, operator='ne')) )
   tags: nasm
 
 - name: Running ./configure & make for nasm ( Not Ubuntu 22+ and not Fedora 35+ )
@@ -98,7 +98,7 @@
     - (ansible_distribution != "Ubuntu" or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int < 22 ))
     - (ansible_distribution != "Fedora" or (ansible_distribution == "Fedora" and ansible_distribution_major_version | int < 35 ))
     - (nasm_installed.rc is defined)
-    - (nasm_installed.rc != 0 or (nasm_installed.rc == 0 and nasm.stdout is version_compare('2.13.03', operator='ne')))
+    - (nasm_installed.rc != 0 or (nasm_installed.rc == 0 and nasm.stdout is version_compare(nasm_version, operator='ne')))
   tags: nasm
 
 - name: Running ./configure & make for nasm ( Ubuntu 22 x64 )


### PR DESCRIPTION
Spotted while testing the playbooks on RHEL9.
The changes in https://github.com/adoptium/infrastructure/pull/3732/files abstracted out the `nasm_version` variable as well as updating it to a later version, however some of the conditionals were left with the original hard coded number. This means that different operations within the role were checking for different things. Specifically the download was triggered if it was anything other than the target version, but the extract of the downloaded tarball checked for the older one, so always fails.

I've no idea how this hasn't been spotted as a problem before, but this PR should fixing it ;-)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/2110/
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
