### PR TITLE
UNIXPB: Update Playbooks For RHEL10 Support

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -97,6 +97,15 @@
   with_items: "{{ Additional_Build_Tools_RHEL_x86 }}"
   when:
     - ansible_architecture == "x86_64"
+    - ansible_distribution_major_version | int < 10
+  tags: build_tools
+
+- name: Install additional build tools for RHEL10+ on x86
+  package: "name={{ item }} state=latest"
+  with_items: "{{ Additional_Build_Tools_RHEL10plus_x86 }}"
+  when:
+    - ansible_architecture == "x86_64"
+    - ansible_distribution_major_version | int >= 10
   tags: build_tools
 
 - name: Install additional build tools for RHEL on ppc64

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -92,11 +92,20 @@
     - not (ansible_distribution_major_version == "7" and ansible_architecture == "s390x")
   tags: build_tools
 
-- name: Install additional build tools for RHEL on x86
+- name: Install additional build tools for RHEL on x86 pre RHEL10
   package: "name={{ item }} state=latest"
   with_items: "{{ Additional_Build_Tools_RHEL_x86 }}"
   when:
     - ansible_architecture == "x86_64"
+    - (ansible_distribution_major_version | int <= 9)
+  tags: build_tools
+
+- name: Install additional build tools for RHEL on x86 post RHEL10
+  package: "name={{ item }} state=latest"
+  with_items: "{{ Additional_Build_Tools_RHEL10_x86 }}"
+  when:
+    - ansible_architecture == "x86_64"
+    - (ansible_distribution_major_version | int >= 10)
   tags: build_tools
 
 - name: Install additional build tools for RHEL on ppc64
@@ -172,7 +181,10 @@
 - name: Install Java when RedHat 8 and above
   package: "name={{ item }} state=latest"
   with_items: "{{ Java_RHEL8Plus }}"
-  when: (ansible_distribution_major_version | int >= 8)
+  when:
+    - (ansible_distribution_major_version | int >= 8)
+    - (ansible_distribution_major_version | int < 10)
+
   tags: install_java
 
 ####################

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -92,20 +92,11 @@
     - not (ansible_distribution_major_version == "7" and ansible_architecture == "s390x")
   tags: build_tools
 
-- name: Install additional build tools for RHEL on x86 pre RHEL10
+- name: Install additional build tools for RHEL on x86
   package: "name={{ item }} state=latest"
   with_items: "{{ Additional_Build_Tools_RHEL_x86 }}"
   when:
     - ansible_architecture == "x86_64"
-    - (ansible_distribution_major_version | int <= 9)
-  tags: build_tools
-
-- name: Install additional build tools for RHEL on x86 post RHEL10
-  package: "name={{ item }} state=latest"
-  with_items: "{{ Additional_Build_Tools_RHEL10_x86 }}"
-  when:
-    - ansible_architecture == "x86_64"
-    - (ansible_distribution_major_version | int >= 10)
   tags: build_tools
 
 - name: Install additional build tools for RHEL on ppc64
@@ -182,8 +173,8 @@
   package: "name={{ item }} state=latest"
   with_items: "{{ Java_RHEL8Plus }}"
   when:
-    - (ansible_distribution_major_version | int >= 8)
-    - (ansible_distribution_major_version | int < 10)
+    - (ansible_distribution_major_version | int == 8)
+    - (ansible_distribution_major_version | int == 9)
 
   tags: install_java
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -82,11 +82,6 @@ Additional_Build_Tools_RHEL_x86:
   - glibc-devel.i686              # a dependency required for executing a 32-bit C binary
   - libstdc++.i686                # a dependency required for executing a 32-bit C binary
   - libnss3.so
-
-Additional_Build_Tools_RHEL10_x86:
-  - glibc                    # a dependency required for executing a 32-bit C binary
-  - glibc-devel              # a dependency required for executing a 32-bit C binary
-  - libstdc++                # a dependency required for executing a 32-bit C binary
   - nss
 
 Additional_Build_Tools_RHEL_ppc64:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -83,6 +83,12 @@ Additional_Build_Tools_RHEL_x86:
   - libstdc++.i686                # a dependency required for executing a 32-bit C binary
   - libnss3.so
 
+Additional_Build_Tools_RHEL10_x86:
+  - glibc                    # a dependency required for executing a 32-bit C binary
+  - glibc-devel              # a dependency required for executing a 32-bit C binary
+  - libstdc++                # a dependency required for executing a 32-bit C binary
+  - nss
+
 Additional_Build_Tools_RHEL_ppc64:
   - glibc.ppc                     # a dependency required for executing a 32-bit C binary
   - glibc-devel.ppc               # a dependency required for executing a 32-bit C binary

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -84,6 +84,9 @@ Additional_Build_Tools_RHEL_x86:
   - libnss3.so
   - nss
 
+Additional_Build_Tools_RHEL10plus_x86:
+  - nss
+
 Additional_Build_Tools_RHEL_ppc64:
   - glibc.ppc                     # a dependency required for executing a 32-bit C binary
   - glibc-devel.ppc               # a dependency required for executing a 32-bit C binary

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_RedHat.yml
@@ -68,75 +68,60 @@
     path: /usr/local/nagios
   register: folder_nagios
 
-- name: Download nagios-plugins
+- name: Set plugin version/checksum fact (RHEL < 10)
+  set_fact:
+    plugin_version: "2.2.1"
+    plugin_checksum: "sha256:647c0ba4583d891c965fc29b77c4ccfeccc21f409fdf259cb8af52cb39c21e18"
+  when: ansible_distribution_major_version | int < 10
+  tags: nagios_plugins
+
+- name: Set plugin version/checksum fact (RHEL >= 10)
+  set_fact:
+    plugin_version: "2.4.9"
+    plugin_checksum: "sha256:74da12037c0ab62ad34f9d9f00f475c472cef0913d2ffa9810c17fef101cd5cf"
+  when: ansible_distribution_major_version | int >= 10
+  tags: nagios_plugins
+
+- name: Download nagios-plugins source
   get_url:
-    url: https://nagios-plugins.org/download/nagios-plugins-2.2.1.tar.gz
+    url: "https://nagios-plugins.org/download/nagios-plugins-{{ plugin_version }}.tar.gz"
     dest: /tmp/
-    mode: 0440
+    mode: '0440'
     timeout: 25
-    checksum: sha256:647c0ba4583d891c965fc29b77c4ccfeccc21f409fdf259cb8af52cb39c21e18
-  when:
-    - not (ansible_distribution_major_version == "10")
-#      - ansible_distribution_major_version == "6"
-    - not folder_nagios.stat.exists
+    checksum: "{{ plugin_checksum }}"
+  when: not folder_nagios.stat.exists
+  tags: nagios_plugins
 
 - name: Extract nagios-plugins
   unarchive:
-    src: /tmp/nagios-plugins-2.2.1.tar.gz
+    src: "/tmp/nagios-plugins-{{ plugin_version }}.tar.gz"
     dest: /tmp/
-    copy: False
-  when:
-    - not (ansible_distribution_major_version == "10")
-#      - ansible_distribution_major_version == "6"
-    - not folder_nagios.stat.exists
+    remote_src: yes
+  when: not folder_nagios.stat.exists
+  tags: nagios_plugins
 
-- name: Configure, make and make install nagios-plugins
-  shell: cd /tmp/nagios-plugins-2.2.1/ && ./configure --prefix=/usr/local/nagios && make -j {{ ansible_processor_vcpus }} && make install
-  become: yes
-  when:
-    - not (ansible_distribution_major_version == "10")
-#      - ansible_distribution_major_version == "6"
-    - not folder_nagios.stat.exists
-
-# Download Nagios Plugins For RHEL10
-- name: Download nagios-plugins for RHEL10+
-  get_url:
-    url: https://nagios-plugins.org/download/nagios-plugins-2.4.9.tar.gz
-    dest: /tmp/
-    mode: 0440
-    timeout: 25
-    checksum: sha256:74da12037c0ab62ad34f9d9f00f475c472cef0913d2ffa9810c17fef101cd5cf
-  when:
-    - ansible_distribution_major_version >= "10"
-    - not folder_nagios.stat.exists
-
-- name: Extract nagios-plugins for RHEL10+
-  unarchive:
-    src: /tmp/nagios-plugins-2.4.9.tar.gz
-    dest: /tmp/
-    copy: False
-  when:
-    - ansible_distribution_major_version >= "10"
-    - not folder_nagios.stat.exists
-
-- name: Configure, make and make install nagios-plugins
-  shell: cd /tmp/nagios-plugins-2.4.9/ && ./configure --prefix=/usr/local/nagios && make -j {{ ansible_processor_vcpus }} && make install
-  become: yes
-  when:
-    - ansible_distribution_major_version >= "10"
-    - not folder_nagios.stat.exists
+- name: Compile and install nagios-plugins
+  shell: |
+    cd /tmp/nagios-plugins-{{ plugin_version }} && \
+    ./configure --prefix=/usr/local/nagios && \
+    make -j {{ ansible_processor_vcpus }} && \
+    make install
+  args:
+    chdir: "/tmp/nagios-plugins-{{ plugin_version }}"
+  become: true
+  when: not folder_nagios.stat.exists
+  tags: nagios_plugins
 
 ##############################
 # Install additional plugins #
 ##############################
-- name: Copy check_yum plugin
-  copy:
-    src: roles/Nagios_Plugins/tasks/additional_plugins/check_yum
-    dest: /usr/local/nagios/libexec/check_yum
-    mode: 0755
 
-- name: Copy check_ntp_timesync plugin
+- name: Install custom Nagios plugin scripts
   copy:
-    src: roles/Nagios_Plugins/tasks/additional_plugins/check_ntp_timesync
-    dest: /usr/local/nagios/libexec/check_ntp_timesync
-    mode: 0755
+    src: "roles/Nagios_Plugins/tasks/additional_plugins/{{ item }}"
+    dest: "/usr/local/nagios/libexec/{{ item }}"
+    mode: '0755'
+  loop:
+    - check_yum
+    - check_ntp_timesync
+  tags: nagios_plugins

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_RedHat.yml
@@ -23,7 +23,7 @@
     - ansible_distribution_major_version != "6"
     - not (ansible_distribution_major_version == "7" and ansible_architecture == "s390x")
     - not (ansible_distribution_major_version == "8" and ansible_architecture == "x86_64")
-    - not (ansible_distribution_major_version == "10")
+    - not (ansible_distribution_major_version >= "10")
   tags: nagios_plugins
 
 - name: Install nagios-plugins (RHEL8/x64)
@@ -42,7 +42,7 @@
   when:
     - ansible_distribution_major_version != "6"
     - not (ansible_distribution_major_version == "7" and ansible_architecture == "s390x")
-    - not (ansible_distribution_major_version == "10")
+    - not (ansible_distribution_major_version >= "10")
   tags: nagios_plugins
 
 - name: Check if plugins folder is where its expected
@@ -56,7 +56,7 @@
   when:
     - ansible_distribution_major_version != "6"
     - not (ansible_distribution_major_version == "7" and ansible_architecture == "s390x")
-    - not (ansible_distribution_major_version == "10")
+    - not (ansible_distribution_major_version >= "10")
     - not plugins_folder.stat.exists
   tags: nagios_plugins
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_RedHat.yml
@@ -23,6 +23,7 @@
     - ansible_distribution_major_version != "6"
     - not (ansible_distribution_major_version == "7" and ansible_architecture == "s390x")
     - not (ansible_distribution_major_version == "8" and ansible_architecture == "x86_64")
+    - not (ansible_distribution_major_version == "10")
   tags: nagios_plugins
 
 - name: Install nagios-plugins (RHEL8/x64)
@@ -41,6 +42,7 @@
   when:
     - ansible_distribution_major_version != "6"
     - not (ansible_distribution_major_version == "7" and ansible_architecture == "s390x")
+    - not (ansible_distribution_major_version == "10")
   tags: nagios_plugins
 
 - name: Check if plugins folder is where its expected
@@ -54,6 +56,7 @@
   when:
     - ansible_distribution_major_version != "6"
     - not (ansible_distribution_major_version == "7" and ansible_architecture == "s390x")
+    - not (ansible_distribution_major_version == "10")
     - not plugins_folder.stat.exists
   tags: nagios_plugins
 
@@ -73,6 +76,7 @@
     timeout: 25
     checksum: sha256:647c0ba4583d891c965fc29b77c4ccfeccc21f409fdf259cb8af52cb39c21e18
   when:
+    - not (ansible_distribution_major_version == "10")
 #      - ansible_distribution_major_version == "6"
     - not folder_nagios.stat.exists
 
@@ -82,6 +86,7 @@
     dest: /tmp/
     copy: False
   when:
+    - not (ansible_distribution_major_version == "10")
 #      - ansible_distribution_major_version == "6"
     - not folder_nagios.stat.exists
 
@@ -89,7 +94,36 @@
   shell: cd /tmp/nagios-plugins-2.2.1/ && ./configure --prefix=/usr/local/nagios && make -j {{ ansible_processor_vcpus }} && make install
   become: yes
   when:
+    - not (ansible_distribution_major_version == "10")
 #      - ansible_distribution_major_version == "6"
+    - not folder_nagios.stat.exists
+
+# Download Nagios Plugins For RHEL10
+- name: Download nagios-plugins for RHEL10+
+  get_url:
+    url: https://nagios-plugins.org/download/nagios-plugins-2.4.9.tar.gz
+    dest: /tmp/
+    mode: 0440
+    timeout: 25
+    checksum: sha256:74da12037c0ab62ad34f9d9f00f475c472cef0913d2ffa9810c17fef101cd5cf
+  when:
+    - ansible_distribution_major_version >= "10"
+    - not folder_nagios.stat.exists
+
+- name: Extract nagios-plugins for RHEL10+
+  unarchive:
+    src: /tmp/nagios-plugins-2.4.9.tar.gz
+    dest: /tmp/
+    copy: False
+  when:
+    - ansible_distribution_major_version >= "10"
+    - not folder_nagios.stat.exists
+
+- name: Configure, make and make install nagios-plugins
+  shell: cd /tmp/nagios-plugins-2.4.9/ && ./configure --prefix=/usr/local/nagios && make -j {{ ansible_processor_vcpus }} && make install
+  become: yes
+  when:
+    - ansible_distribution_major_version >= "10"
     - not folder_nagios.stat.exists
 
 ##############################

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/nasm/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/nasm/tasks/main.yml
@@ -87,7 +87,7 @@
     dest: /tmp/
     copy: False
   when:
-    - (nasm_installed.rc is defined) and ((nasm_installed.rc != 0 ) or (nasm_installed.rc == 0 and nasm.stdout is version_compare('2.13.03', operator='ne')) )
+    - (nasm_installed.rc is defined) and ((nasm_installed.rc != 0 ) or (nasm_installed.rc == 0 and nasm.stdout is version_compare('{{ nasm_version }}', operator='ne')) )
   tags: nasm
 
 - name: Running ./configure & make for nasm ( Not Ubuntu 22+ and not Fedora 35+ )
@@ -95,10 +95,11 @@
   environment:
     CC: "{{ CC }}"
   when:
-    - (ansible_distribution != "Ubuntu" or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int < 22 ))
-    - (ansible_distribution != "Fedora" or (ansible_distribution == "Fedora" and ansible_distribution_major_version | int < 35 ))
-    - (nasm_installed.rc is defined)
-    - (nasm_installed.rc != 0 or (nasm_installed.rc == 0 and nasm.stdout is version_compare('2.13.03', operator='ne')))
+    - (ansible_distribution != "Ubuntu") or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int < 22)
+    - (ansible_distribution != "Fedora") or (ansible_distribution == "Fedora" and ansible_distribution_major_version | int < 35)
+    - (ansible_distribution != "RedHat") or (ansible_distribution == "RedHat" and ansible_distribution_major_version | int < 10)
+    - nasm_installed.rc is defined
+    - (nasm_installed.rc != 0 or (nasm_installed.rc == 0 and nasm.stdout is version_compare('{{ nasm_version }}', operator='ne')))
   tags: nasm
 
 - name: Running ./configure & make for nasm ( Ubuntu 22 x64 )
@@ -120,6 +121,7 @@
     - (nasm_installed.rc != 0) or (nasm_installed.rc == 0 and nasm.stdout is version_compare(nasm_version, operator='ne'))
     - (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int >= 24)
       or (ansible_distribution == "Fedora" and ansible_distribution_major_version | int >= 35)
+      or (ansible_distribution == "RedHat" and ansible_distribution_major_version | int >= 10)
   tags: nasm
 
 - name: Remove downloaded packages for nasm

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/nasm/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/nasm/tasks/main.yml
@@ -87,7 +87,7 @@
     dest: /tmp/
     copy: False
   when:
-    - (nasm_installed.rc is defined) and ((nasm_installed.rc != 0 ) or (nasm_installed.rc == 0 and nasm.stdout is version_compare('{{ nasm_version }}', operator='ne')) )
+    - (nasm_installed.rc is defined) and ((nasm_installed.rc != 0 ) or (nasm_installed.rc == 0 and nasm.stdout is version_compare(nasm_version, operator='ne')))
   tags: nasm
 
 - name: Running ./configure & make for nasm ( Not Ubuntu 22+ and not Fedora 35+ )
@@ -99,7 +99,7 @@
     - (ansible_distribution != "Fedora") or (ansible_distribution == "Fedora" and ansible_distribution_major_version | int < 35)
     - (ansible_distribution != "RedHat") or (ansible_distribution == "RedHat" and ansible_distribution_major_version | int < 10)
     - nasm_installed.rc is defined
-    - (nasm_installed.rc != 0 or (nasm_installed.rc == 0 and nasm.stdout is version_compare('{{ nasm_version }}', operator='ne')))
+    - (nasm_installed.rc != 0 or (nasm_installed.rc == 0 and nasm.stdout is version_compare(nasm_version, operator='ne')))
   tags: nasm
 
 - name: Running ./configure & make for nasm ( Ubuntu 22 x64 )


### PR DESCRIPTION
Amend Unix Playbooks to run on RHEL10

Part of #3868 

:heavy_check_mark: JDK21 build successfully on RHEL10.

VPC In Progress : https://ci.adoptium.net/job/VagrantPlaybookCheck/2122/
13:31:07 [VagrantPlaybookCheck » Ubuntu1804,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Ubuntu1804,label=vagrant/) completed with result SUCCESS
13:31:07 [VagrantPlaybookCheck » CentOS8,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=CentOS8,label=vagrant/) completed with result SUCCESS
13:31:07 [VagrantPlaybookCheck » Ubuntu2204,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Ubuntu2204,label=vagrant/) completed with result SUCCESS
13:31:07 [VagrantPlaybookCheck » Ubuntu2404,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Ubuntu2404,label=vagrant/) completed with result FAILURE
14:24:10 [VagrantPlaybookCheck » Fedora40,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Fedora40,label=vagrant/) completed with result SUCCESS
15:51:24 [VagrantPlaybookCheck » Ubuntu2004,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Ubuntu2004,label=vagrant/) completed with result SUCCESS
16:30:22 [VagrantPlaybookCheck » Debian10,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Debian10,label=vagrant/) completed with result SUCCESS
16:30:22 [VagrantPlaybookCheck » CentOS7,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=CentOS7,label=vagrant/) completed with result FAILURE

Rerun Of Centos7 & Ubuntu24
13:29:45 [VagrantPlaybookCheck » Ubuntu2404,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Ubuntu2404,label=vagrant/) completed with result SUCCESS
14:34:04 [VagrantPlaybookCheck » CentOS7,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=CentOS7,label=vagrant/) completed with result SUCCESS

VPC with review changes:

https://ci.adoptium.net/job/VagrantPlaybookCheck/2125/

19:44:13 [VagrantPlaybookCheck » Ubuntu1804,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Ubuntu1804,label=vagrant/) completed with result SUCCESS
19:44:13 [VagrantPlaybookCheck » CentOS8,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=CentOS8,label=vagrant/) completed with result SUCCESS
19:44:13 [VagrantPlaybookCheck » Ubuntu2204,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Ubuntu2204,label=vagrant/) completed with result SUCCESS
20:21:40 [VagrantPlaybookCheck » Ubuntu2404,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Ubuntu2404,label=vagrant/) completed with result SUCCESS
23:06:57 [VagrantPlaybookCheck » Fedora40,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Fedora40,label=vagrant/) completed with result SUCCESS
23:12:14 [VagrantPlaybookCheck » Ubuntu2004,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Ubuntu2004,label=vagrant/) completed with result SUCCESS
23:44:56 [VagrantPlaybookCheck » Debian10,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Debian10,label=vagrant/) completed with result SUCCESS
01:46:46 [VagrantPlaybookCheck » CentOS7,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=CentOS7,label=vagrant/) completed with result SUCCESS19:44:13 [VagrantPlaybookCheck » Ubuntu1804,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Ubuntu1804,label=vagrant/) completed with result SUCCESS
19:44:13 [VagrantPlaybookCheck » CentOS8,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=CentOS8,label=vagrant/) completed with result SUCCESS
19:44:13 [VagrantPlaybookCheck » Ubuntu2204,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Ubuntu2204,label=vagrant/) completed with result SUCCESS
20:21:40 [VagrantPlaybookCheck » Ubuntu2404,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Ubuntu2404,label=vagrant/) completed with result SUCCESS
23:06:57 [VagrantPlaybookCheck » Fedora40,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Fedora40,label=vagrant/) completed with result SUCCESS
23:12:14 [VagrantPlaybookCheck » Ubuntu2004,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Ubuntu2004,label=vagrant/) completed with result SUCCESS
23:44:56 [VagrantPlaybookCheck » Debian10,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Debian10,label=vagrant/) completed with result SUCCESS
01:46:46 [VagrantPlaybookCheck » CentOS7,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=CentOS7,label=vagrant/) completed with result SUCCESS

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
