### PR TITLE
inventory: Add 2 new OSUOSL aarch64 dockerhost machines

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -81,6 +81,8 @@ hosts:
       - osuosl:
           ubuntu2404-ppc64le-1: {ip: 140.211.168.214}
           ubuntu2404-aarch64-1: {ip: 140.211.167.67}
+          ubuntu2404-aarch64-2: {ip: 140.211.167.73}
+          ubuntu2404-aarch64-3: {ip: 140.211.167.88}
 
       - marist:
           ubuntu2404-s390x-1: {ip: 148.100.74.237, user: linux1}


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
