### PR TITLE
unixPB: orka - always ensure that xcode path is reset to /

### DIFF
--- a/ansible/packer/orka.pkr.hcl
+++ b/ansible/packer/orka.pkr.hcl
@@ -77,4 +77,12 @@ build {
     ]
     command = "source /Users/admin/.zprofile; ansible-playbook"
   }
+
+  # Set xcode-select to / to ensure we're always resetting to the command line tools
+  provisioner "shell" {
+    only = ["macstadium-orka.sonoma-arm64"]
+    inline = [
+      "sudo xcode-select --switch /",
+    ]
+  }
 }

--- a/ansible/packer/orka.pkr.hcl
+++ b/ansible/packer/orka.pkr.hcl
@@ -50,14 +50,14 @@ build {
     # Only needed on arm64 as we rebuild intel base frequently
     only = ["macstadium-orka.sonoma-arm64"]
     inline = [
-      "source /Users/admin/.zprofile; brew upgrade ansible",
+      "source /Users/admin/.zprofile; brew upgrade ansible"
     ]
   }
 
   # Create /tmp/packer-provisioner-ansible-local
   provisioner "shell" {
     inline = [
-      "mkdir -p /tmp/packer-provisioner-ansible-local",
+      "mkdir -p /tmp/packer-provisioner-ansible-local"
     ]
   }
 
@@ -82,7 +82,7 @@ build {
   provisioner "shell" {
     only = ["macstadium-orka.sonoma-arm64"]
     inline = [
-      "sudo xcode-select --switch /",
+      "sudo xcode-select --switch /"
     ]
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
