### PR TITLE
UnixPB: Add Cron For Ubuntu / riscv64

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
@@ -106,6 +106,7 @@ Additional_Build_Tools_riscv64:
   - g++-10
   - openjdk-11-jdk
   - libatomic1
+  - cron
 
 Additional_Build_Tools_Ubuntu20:
   - cmake


### PR DESCRIPTION
Ensure cron is installed on Ubuntu for Riscv64 systems.

Fixes #4010 

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR

Tested locally, and as part of reprovisioning [test-rise-ubuntu2404-riscv64-[137]](https://github.com/adoptium/infrastructure/issues/3977)
