### PR TITLE
unixPB: Update cmake to 3.15.0 for jdk25u devkit

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/cmake/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/cmake/tasks/main.yml
@@ -3,8 +3,11 @@
 # cmake  - required by OpenJ9 and OpenJFX builds - requires C++11 compiler #
 ############################################################################
 
+# 3.15.0 is required to be able to build the ccache version from the jdk25u devkit
+# The newer 4.1.0 would be more consistent with the version OpenJ9 uses on macos
+# But 3.15.0 will mean it can use the system on on Ubuntu 20+ without rebuilding here
 - name: Set cmake version
-  set_fact: cmakeVersion=3.11.4
+  set_fact: cmakeVersion=3.15.0
   tags: cmake
 
 - name: Test if cmake is installed on path
@@ -25,7 +28,7 @@
 
 - name: Download cmake
   get_url:
-    url: https://github.com/Kitware/CMake/releases/download/v3.11.4/cmake-{{ cmakeVersion }}.tar.gz
+    url: https://github.com/Kitware/CMake/releases/download/v{{ cmakeVersion }}/cmake-{{ cmakeVersion }}.tar.gz
     dest: /tmp/cmake-{{ cmakeVersion }}.tar.gz
     mode: 0440
     force: no
@@ -39,7 +42,7 @@
 
 # The checksum file of the download is checked, not the binary itself. The checksum in the download step is equal to the one in the file
 - name: GPG Signature verification
-  script: ../Supporting_Scripts/package_signature_verification.sh -fl "https://github.com/Kitware/CMake/releases/download/v3.11.4/cmake-3.11.4-SHA-256.txt" -sl "https://github.com/Kitware/CMake/releases/download/v3.11.4/cmake-3.11.4-SHA-256.txt.asc" -k {{ key.cmake }}
+  script: ../Supporting_Scripts/package_signature_verification.sh -fl "https://github.com/Kitware/CMake/releases/download/v{{ cmake_version }}/cmake-{{ cmake_version }}-SHA-256.txt" -sl "https://github.com/Kitware/CMake/releases/download/v{{ cmake_version }}/cmake-{{ cmake_version }}-SHA-256.txt.asc" -k {{ key.cmake }}
   when:
     - (cmake_installed.rc != 0 ) or (cmake_installed.rc == 0 and cmake_version.stdout is version_compare(cmakeVersion, operator='lt'))
     - ansible_architecture != "armv7l"


### PR DESCRIPTION
Ref: jdk25u devkit requirements for ccache build: https://github.com/adoptium/temurin-build/issues/4110#issuecomment-3175331257

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
