### PR TITLE
unixPB: switch temporarily to using mirrorservice.org instead of ftp.gnu.org

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/autoconf/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/autoconf/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: Download Autoconf v2.69
   get_url:
-    url: https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz
+    url: https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz
     dest: /tmp/autoconf-2.69.tar.gz
     force: no
     mode: 0755
@@ -28,7 +28,7 @@
   tags: autoconf-2.69
 
 - name: GPG Signature verification
-  script: ../Supporting_Scripts/package_signature_verification.sh -f /tmp/autoconf-2.69.tar.gz -sl "https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz.sig" -k {{ key.autoconf }}
+  script: ../Supporting_Scripts/package_signature_verification.sh -f /tmp/autoconf-2.69.tar.gz -sl "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz.sig" -k {{ key.autoconf }}
   when:
     - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS")
     - ansible_distribution_major_version == "6"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_48/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_48/tasks/main.yml
@@ -15,7 +15,7 @@
 # gcc
 - name: Download gcc-4.8.5 source
   get_url:
-    url: https://ftp.gnu.org/gnu/gcc/gcc-4.8.5/gcc-4.8.5.tar.gz
+    url: https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/gcc/gcc-4.8.5/gcc-4.8.5.tar.gz
     dest: '/tmp/gcc-4.8.5.tar.gz'
     force: no
     mode: 0755

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gmake/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gmake/tasks/main.yml
@@ -33,7 +33,7 @@
 
 - name: Download make {{ makeVersion }} source
   get_url:
-    url: https://ftp.gnu.org/gnu/make/make-{{ makeVersion }}.tar.gz
+    url: https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/make/make-{{ makeVersion }}.tar.gz
     dest: /tmp/make-{{ makeVersion }}.tar.gz
     mode: 0440
     checksum: sha256:{{ makeVersionSHA }}
@@ -46,7 +46,7 @@
   tags: goodmake_source
 
 - name: GPG Signature verification
-  script: ../Supporting_Scripts/package_signature_verification.sh -f /tmp/make-{{ makeVersion }}.tar.gz -sl "https://ftp.gnu.org/gnu/make/make-4.1.tar.gz.sig" -k {{ key.gmake }}
+  script: ../Supporting_Scripts/package_signature_verification.sh -f /tmp/make-{{ makeVersion }}.tar.gz -sl "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/make/make-4.1.tar.gz.sig" -k {{ key.gmake }}
   when:
     - ((((ansible_distribution == "SLES" or ansible_distribution == "openSUSE") and ansible_distribution_major_version == "12") or
       (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "14")) and


### PR DESCRIPTION
Avoiding a full VPC run because we need this working urgently and I have been testing it locally.

Fixes (Well works around) https://github.com/adoptium/infrastructure/issues/4021
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
