### PR TITLE
unixPB: Fixup cmakeVersion check for GPG signature

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/cmake/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/cmake/tasks/main.yml
@@ -42,7 +42,7 @@
 
 # The checksum file of the download is checked, not the binary itself. The checksum in the download step is equal to the one in the file
 - name: GPG Signature verification
-  script: ../Supporting_Scripts/package_signature_verification.sh -fl "https://github.com/Kitware/CMake/releases/download/v{{ cmake_version }}/cmake-{{ cmake_version }}-SHA-256.txt" -sl "https://github.com/Kitware/CMake/releases/download/v{{ cmake_version }}/cmake-{{ cmake_version }}-SHA-256.txt.asc" -k {{ key.cmake }}
+  script: ../Supporting_Scripts/package_signature_verification.sh -fl "https://github.com/Kitware/CMake/releases/download/v{{ cmakeVersion }}/cmake-{{ cmakeVersion }}-SHA-256.txt" -sl "https://github.com/Kitware/CMake/releases/download/v{{ cmakeVersion }}/cmake-{{ cmakeVersion }}-SHA-256.txt.asc" -k {{ key.cmake }}
   when:
     - (cmake_installed.rc != 0 ) or (cmake_installed.rc == 0 and cmake_version.stdout is version_compare(cmakeVersion, operator='lt'))
     - ansible_architecture != "armv7l"


### PR DESCRIPTION
Incorrect variable used for cmake's GPG signature check in [the previous PR](https://github.com/adoptium/infrastructure/pull/4019/files) (Not sure why I didn't hit this in my local testing though)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
