### PR TITLE
unixPB: add linux-libc-dev to Ubuntu for jdk25u devkit build

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Debian.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Debian.yml
@@ -42,6 +42,7 @@ Build_Tool_Packages:
   - libxrender-dev
   - libxt-dev
   - libxtst-dev
+  - linux-libc-dev                # Required for binutils 2.43 build in jdk25u devkit
   - make
   - ntp
   - pigz

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
@@ -45,6 +45,7 @@ Build_Tool_Packages:
   - libxrender-dev
   - libxt-dev
   - libxtst-dev
+  - linux-libc-dev                # Required for binutils 2.43 build in jdk25u devkit
   - make
   - ntp
   - patch                         # For Devkit creation which runs "patch"


### PR DESCRIPTION
Required for the binutils 2.43 build in the jdk25u devkit to provide `asm/hwprobe.h` when building on Ubuntu (e.g. riscv64)
Ref: https://github.com/adoptium/temurin-build/issues/4110#issuecomment-3189100530
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) https://ci.adoptium.net/job/VagrantPlaybookCheck/2144/
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
