### PR TITLE
unixPB: Add AlmaLinux10 static dockerfile

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alma10
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alma10
@@ -1,4 +1,5 @@
-FROM quay.io/almalinuxorg/10-base:10
+FROM ghcr.io/almalinux/10-base:10.0-20250825@sha256:b59938ea3b263a747fa989622dd8bcba59f7cad9878be108c1de21e7db08daef
+# Using SHA because quay.io/almalinuxorg/10-base:10 might pull the x86-64-v3 version
 
 ARG ant_version="1.10.15"
 ARG ant_512checksum="1de7facbc9874fa4e5a2f045d5c659f64e0b89318c1dbc8acc6aae4595c4ffaf90a7b1ffb57f958dd08d6e086d3fff07aa90e50c77342a0aa5c9b4c36bff03a9"


### PR DESCRIPTION
While we may not have use of these in the Adoptium set, I want to add this for my own purposes as Alma has an x86-64-v2 version (unlike most of the other EL10 distributions, including CentOS Stream 10), and I have two such systems with `i5-2520` CPUs that don't support x86-64-v3. It's also simpler than the UBI10 one :-)

Ref: https://fosstodon.org/@sxa/115129852235496249 - I was tempted to explicitly pull the x86-64-v2 image but that doesn't seem easy without hard coding a SHA (and therefore not getting updates)

Related: https://github.com/adoptium/infrastructure/issues/3868

Original [JDK21 sanity.openjdk](https://ci.adoptium.net/job/Grinder/14248/testReport/), [Grinder with various problematic testList](https://ci.adoptium.net/job/Grinder/14265/) 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
