### PR TITLE
Inventory: Update Windows IP Address

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -99,10 +99,8 @@ hosts:
 
       - azure:
           ubuntu2404-x64-1: {ip: 20.115.98.159, user: azureuser}
-          win2016-x64-1: {ip: 172.172.147.29, user: adoptopenjdk}
-          win2019-x64-1: {ip: 13.92.177.186, user: adoptopenjdk}
           win2022-x64-1: {ip: 51.132.234.42, user: adoptopenjdk}
-          win2022-x64-2: {ip: 20.26.116.218, user: adoptopenjdk}
+          win2022-x64-2: {ip: 20.77.53.16, user: adoptopenjdk}
           win2022-x64-3: {ip: 20.68.165.213, user: adoptopenjdk}
           win2022-x64-4: {ip: 20.77.112.43, user: adoptopenjdk}
           win11-aarch64-1: {ip: 20.4.31.184, user: adoptopenjdk}


### PR DESCRIPTION
Update the IP address for test-azure-windows-x64-2

Remove defunct windows 2016 & 2019 hosts ( machines no longer in azure )

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR
- [X] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
