### PR TITLE
unixPB: Updates for Centos Stream 10

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
@@ -79,9 +79,9 @@
 
 - name: Install additional build tools when NOT CentOS8+
   package: "name={{ item }} state=latest"
-  with_items: "{{ Additional_Build_Tools_NOT_CentOS8_CentOS9Stream }}"
+  with_items: "{{ Additional_Build_Tools_NOT_CentOS8plus }}"
   when:
-    - ansible_distribution_major_version|int < 8
+    - ansible_distribution_major_version | int < 8
   tags: build_tools
 
 - name: Install additional test tools for CentOS 10+ e.g. weston
@@ -207,11 +207,12 @@
     - ansible_architecture == "x86_64" and ansible_distribution_major_version == "7"
   tags: build_tools
 
-- name: Install additional build tools for CentOS on x86
+- name: Install additional build tools for CentOS on x86 for EL<10 (Not 32-bit support)
   package: "name={{ item }} state=latest"
   with_items: "{{ Additional_Build_Tools_CentOS_x86 }}"
   when:
     - ansible_architecture == "x86_64"
+    - ansible_distribution_major_version | int < 10
   tags: build_tools
 
 - name: Create symlink for /opt/rh/devtoolset-2/root/usr/bin/gcc to gcc

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
@@ -157,8 +157,7 @@
   package: "name=centos-release-scl state=latest"
   when:
     - ansible_architecture == "x86_64"
-    - ansible_distribution_major_version != "8"
-    - ansible_distribution_major_version != "9"
+    - ansible_distribution_major_version | int < 8
   tags: build_tools
 
 - name: Sed change the baseurl for CentOS SCL (CentOS6)

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -82,7 +82,7 @@ Additional_Build_Tools_CentOS8_Plus:
   - ccache
   - procps-ng
 
-Additional_Build_Tools_NOT_CentOS8_CentOS9Stream:
+Additional_Build_Tools_NOT_CentOS8plus:
   - lbzip2
   - java-1.7.0-openjdk-devel
   - java-1.8.0-openjdk-devel

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/nasm/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/nasm/tasks/main.yml
@@ -90,7 +90,7 @@
     - (nasm_installed.rc is defined) and ((nasm_installed.rc != 0 ) or (nasm_installed.rc == 0 and nasm.stdout is version_compare(nasm_version, operator='ne')))
   tags: nasm
 
-- name: Running ./configure & make for nasm ( Not Ubuntu 22+ and not Fedora 35+ )
+- name: Running ./configure & make for nasm ( Not Ubuntu 22+ and not Fedora 35+ based distros )
   shell: cd /tmp/nasm-{{ nasm_version }} && CC={{ CC }} && ./configure -prefix=/usr/local && make install
   environment:
     CC: "{{ CC }}"
@@ -98,6 +98,7 @@
     - (ansible_distribution != "Ubuntu") or (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int < 22)
     - (ansible_distribution != "Fedora") or (ansible_distribution == "Fedora" and ansible_distribution_major_version | int < 35)
     - (ansible_distribution != "RedHat") or (ansible_distribution == "RedHat" and ansible_distribution_major_version | int < 10)
+    - (ansible_distribution != "CentOS") or (ansible_distribution == "CentOS" and ansible_distribution_major_version | int < 10)
     - nasm_installed.rc is defined
     - (nasm_installed.rc != 0 or (nasm_installed.rc == 0 and nasm.stdout is version_compare(nasm_version, operator='ne')))
   tags: nasm


### PR DESCRIPTION
Updates to allow CentOS Stream 10 to be provisioned using the playbooks.
Note: Does not currently include the EPEL install (`dnf install -y epel-release` seems to work in CS10 containers, but on a real machine it seems to need it installed by `dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm`

Final step in https://github.com/adoptium/infrastructure/issues/3868 assuming the testing completes as expected

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) https://ci.adoptium.net/job/VagrantPlaybookCheck/2155/
- [ ] VPC/QPC not applicable for this PR 
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
