### PR TITLE
unixPB: ensure JDK version is visible when downloading

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
@@ -163,7 +163,7 @@
         - not (jdk_version == 11 and ansible_architecture == "riscv64")
       register: sig_output
 
-    - name: Download latest release (Linux/Alpine-Linux)
+    - name: Download latest Temurin {{ jdk_version }} release (Linux/Alpine-Linux)
       get_url:
         url: "{{ api_url }}/v3/binary/latest/{{ jdk_version }}/ga/{{ platformLinux }}/{{ api_architecture }}/jdk/{{ bootjdk }}/normal/{{ api_vendor }}?project=jdk"
         dest: /tmp/jdk{{ jdk_version }}.tar.gz


### PR DESCRIPTION
During the adoptopenjdk role the longest part is typically the download. If you're watching the progress the JDK version number has typically scrolled off the screen so you don't know which one it is downloading. This trivial fix will ensure it is on the screen during the download. Similarly verbose `name` entriues are used on mac etc.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) https://ci.adoptium.net/job/VagrantPlaybookCheck/2156/
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
