### PR TITLE
WinPB: Update MSVS2022 Installation To Version 19.42.34444

### DIFF
--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -138,21 +138,21 @@ checkVars()
 		skipFullSetup=",nvidia_cuda_toolkit"
 		case "$jdkToBuild" in
 			"jdk8" )
-				skipFullSetup="$skipFullSetup,MSVS_2017,MSVS_2019,MSVS_2022";
+				skipFullSetup="$skipFullSetup,MSVS_2013,MSVS_2019";
 				if [ "$buildHotspot" != "" ]; then
-					skipFullSetup="$skipFullSetup,MSVS_2010,VS2010_SP1,MSVS_2017,MSVS_2019,MSVS_2022"
+					skipFullSetup="$skipFullSetup,MSVS_2010,VS2010_SP1,MSVS_2013,MSVS_2019"
 				fi
 				;;
 			"jdk11" )
-				skipFullSetup="$skipFullSetup,MSVS_2013,MSVS_2019,MSVS_2022";
+				skipFullSetup="$skipFullSetup,MSVS_2013,MSVS_2019";
 				if [ "$buildHotspot" != "" ]; then
-					skipFullSetup="$skipFullSetup,MSVS_2010,VS2010_SP1,MSVS_2013,MSVS_2019,MSVS_2022"
+					skipFullSetup="$skipFullSetup,MSVS_2010,VS2010_SP1,MSVS_2013,MSVS_2019"
 				fi
 				;;
 			"jdk17" )
-				skipFullSetup="$skipFullSetup,MSVS_2013,MSVS_2017,MSVS_2022";
+				skipFullSetup="$skipFullSetup,MSVS_2013,MSVS_2017";
 				if [ "$buildHotspot" != "" ]; then
-					skipFullSetup="$skipFullSetup,MSVS_2010,VS2010_SP1,MSVS_2013,MSVS_2017,MSVS_2022"
+					skipFullSetup="$skipFullSetup,MSVS_2010,VS2010_SP1,MSVS_2013,MSVS_2017"
 				fi
 				;;
 			"jdk21" )

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2022/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2022/tasks/main.yml
@@ -10,17 +10,20 @@
 
 - name: Test if VS 2022 is installed
   win_stat:
-    path: 'C:\Program Files\Microsoft Visual Studio\2022'
+    path: 'C:\Program Files (x86)\Microsoft Visual Studio\2022'
   register: vs2022_installed
   tags: adoptopenjdk
 
-- name: Install VS2022
+# Update MSVS 2022 Installation For JDK25 ZGC Errors
+# https://github.com/adoptium/infrastructure/issues/4064
+# https://github.com/adoptium/aqa-tests/issues/6592
+- name: Install VS2022 From Adoptium Layout
   when: (not vs2022_installed.stat.exists) and (windows_version.stdout_lines[0] | regex_search('^(10\.|11\.|2016|2019|2022)'))
   tags: adoptopenjdk
   block:
     - name: Transfer VS2022 Layout File
       win_copy:
-        src: /Vendor_Files/windows/vs_layout_2022.zip
+        src: /Vendor_Files/windows/vs_layout_2022_17092025.zip
         dest: C:\TEMP\VS2022_Layout.zip
         remote_src: no
       failed_when: false
@@ -34,7 +37,7 @@
     - name: Get SHA256 checksum of the file
       win_shell: |
         $filePath = "C:\TEMP\VS2022_Layout.zip"
-        $expectedChecksum = "29567E33B5361E4BAD36DFDFF83FEB3DDFDF0518122237E8273F0FA4E11E8B74"
+        $expectedChecksum = "C22C8E30E5D6EB84EC0C226E5459507BD5B015A1CC075AD324C2B66BB63B5B74"
         $actualChecksum = Get-FileHash -Path $filePath -Algorithm SHA256 | Select-Object -ExpandProperty Hash
 
         if ($actualChecksum -ne $expectedChecksum) {
@@ -62,17 +65,25 @@
       when: (vs2022_layout_ready.stat.exists)
 
     # When Installing From The Layout, We Need To Ensure the x86 installer is not detected.
+    - name: Check if x86 Installer folder exists
+      win_stat:
+        path: "C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer"
+      register: vs2022_installer_folder
+      when: (vs2022_layout_ready.stat.exists)
+
     - name: Rename x86 Installer When Installing VS2022 from the Adoptium Layout
       win_shell: |
         Rename-Item -Path "C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer" -NewName "Installer.old"
       args:
         executable: powershell
         creates: "C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer.old"
-      when: (vs2022_layout_ready.stat.exists)
+      when:
+        - vs2022_layout_ready.stat.exists
+        - vs2022_installer_folder.stat.exists
 
     - name: Run Visual Studio 2022 Installer From Layout
       win_shell: |
-          Start-Process -Wait -FilePath 'C:\temp\VSLayout2022\vs_community.exe' -ArgumentList '--nocache --quiet --norestart --wait --noweb --add Microsoft.VisualStudio.Workload.NativeDesktop --includeRecommended --includeOptional --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.ATL.ARM64 --add Microsoft.VisualStudio.Component.VC.MFC.ARM64'
+          Start-Process -Wait -FilePath 'C:\temp\VSLayout2022\vs_setup.exe' -ArgumentList '--nocache --quiet --norestart --wait --noweb --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --includeOptional --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.ATL.ARM64 --add Microsoft.VisualStudio.Component.VC.MFC.ARM64'
       args:
         executable: powershell
       when: (vs2022_layout_ready.stat.exists)
@@ -80,8 +91,8 @@
     - name: Register Visual Studio Community 2022 DIA SDK shared libraries
       win_command: 'regsvr32 /s "{{ item }}"'
       with_items:
-        - C:\Program Files\Microsoft Visual Studio\2022\Community\DIA SDK\bin\msdia140.dll
-        - C:\Program Files\Microsoft Visual Studio\2022\Community\DIA SDK\bin\amd64\msdia140.dll
+        - C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\DIA SDK\bin\msdia140.dll
+        - C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\DIA SDK\bin\amd64\msdia140.dll
 
     - name: Remove VS2022 Zip File
       win_file:
@@ -95,17 +106,15 @@
 
 - name: Test if VS 2022 is installed(non adopt)
   win_stat:
-    path: 'C:\Program Files\Microsoft Visual Studio\2022'
+    path: 'C:\Program Files (x86)\Microsoft Visual Studio\2022'
   register: vs2022_installed
 
 # Download & Install VS2022 When No Layout & Not AdoptOpenJDK
-# This is the target that you're redirected to when you go to https://aka.ms/vs/17/release/vs_community.exe
-- name: Download Visual Studio Community 2022
+# This is the download to install the same payloads as the adoptium layout above
+- name: Download VS Build Tools install for 17.12.12
   win_get_url:
-# https://learn.microsoft.com/en-us/visualstudio/releases/2022/release-history
-# 17.7.34302.85    url: 'https://download.visualstudio.microsoft.com/download/pr/47b236ad-5505-4752-9d2b-5cf9795528bc/87684889f46dec53d1452f4a0ff9fec1ac202a97ebed866718d7c0269e814b28/vs_BuildTools.exe'
-    url: 'https://download.visualstudio.microsoft.com/download/pr/1d66edfe-3c83-476b-bf05-e8901c62ba7f/bac71effb5a23d7cd1a81e5f628a0c8dcb7e8a07e0aa7077c853ed84a862dceb/vs_BuildTools.exe' # 17.7.3 = 17.7.34024.191
-    checksum: bac71effb5a23d7cd1a81e5f628a0c8dcb7e8a07e0aa7077c853ed84a862dceb
+    url: 'https://download.visualstudio.microsoft.com/download/pr/8eb6bd5d-4ec9-4328-a0e7-f59e7e51fdca/9b748c66ba6a2b22f346cc113f354ded3b202b53a109fff93111167741acb6c1/vs_BuildTools.exe' # 17.12.12
+    checksum: 9b748c66ba6a2b22f346cc113f354ded3b202b53a109fff93111167741acb6c1
     checksum_algorithm: sha256
     dest: 'C:\temp\vs_BuildTools22.exe'
     force: no
@@ -113,7 +122,7 @@
 
 - name: Run Visual Studio 2022 Installer From Download
   win_shell: |
-      Start-Process -Wait -FilePath 'C:\temp\vs_BuildTools22.exe' -ArgumentList '--wait --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Workload.NativeDesktop --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.ATL.ARM64 --add Microsoft.VisualStudio.Component.VC.MFC.ARM64 --includeRecommended --includeOptional --quiet --norestart'
+      Start-Process -Wait -FilePath 'C:\temp\vs_BuildTools22.exe' -ArgumentList '--wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --includeOptional --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.ATL.ARM64 --add Microsoft.VisualStudio.Component.VC.MFC.ARM64 --quiet --norestart'
   args:
     executable: powershell
   when: (not vs2022_installed.stat.exists) and (windows_version.stdout_lines[0] | regex_search('^(10\.|11\.|2016|2019|2022)'))
@@ -128,10 +137,11 @@
     - C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\DIA SDK\bin\amd64\msdia140.dll
   when: (not vs2022_installed.stat.exists) and (windows_version.stdout_lines[0] | regex_search('^(10\.|11\.|2016|2019|2022)'))
 
+# Reboot The Machine After VS Installation
 - name: Reboot machine after Visual Studio installation
   win_reboot:
     reboot_timeout: 1800
     shutdown_timeout: 1800
-  when: (not vs2022_installed.stat.exists) and (windows_version.stdout_lines[0] | regex_search('^(10\.|11\.|2016|2019|2022)'))
+  when: (not vs2022_installed.stat.exists)
   tags:
     - reboot


### PR DESCRIPTION
Fixes #4064 

Update the installation of MSVS_2022 to a new preferred versions which resolves issues identified in the JDK25 build as seen in https://github.com/adoptium/aqa-tests/issues/6592

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)

VPC Completed OK: https://ci.adoptium.net/job/VagrantPlaybookCheck/2159