### PR TITLE
unixPb: Set corefile size on MacOS to unlimited

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
@@ -235,10 +235,10 @@
     group: wheel
     mode: 0644
     content: |
-      <?xml version="1.0" encoding="UTF-8"?> 
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" 
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
       "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0"> 
+      <plist version="1.0">
       <dict>
       <key>Label</key>
       <string>limit.core</string>

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
@@ -247,8 +247,8 @@
       <string>launchctl</string>
       <string>limit</string>
       <string>core</string>
-      <string>unlimited</string>
-      <string>unlimited</string>
+      <string>8388608</string>
+      <string>8388608</string>
       </array>
       <key>RunAtLoad</key>
       <true/>

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
@@ -228,11 +228,42 @@
   tags:
     - core_dumps
 
+- name: Create limit.core.plist file in /Library/LaunchDaemons
+  copy:
+    dest: /Library/LaunchDaemons/limit.core.plist
+    owner: root
+    group: wheel
+    mode: 0644
+    content: |
+      <?xml version="1.0" encoding="UTF-8"?> 
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" 
+      "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0"> 
+      <dict>
+      <key>Label</key>
+      <string>limit.core</string>
+      <key>ProgramArguments</key>
+      <array>
+      <string>launchctl</string>
+      <string>limit</string>
+      <string>core</string>
+      <string>unlimited</string>
+      <string>unlimited</string>
+      </array>
+      <key>RunAtLoad</key>
+      <true/>
+      <key>ServiceIPC</key>
+      <false/>
+      </dict>
+      </plist>
+  register: core
+  tags: kernel_tuning
+
 # Skipping linting as not to introduce handlers into task-only playbooks (lint error 503)
 - name: Reboot macOS after tweaking kernel tuning parameters
   reboot:
     reboot_timeout: 3600
-  when: kernel.changed
+  when: kernel.changed or core.changed
   tags:
     - kernel_tuning
     - skip_ansible_lint

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
@@ -256,18 +256,15 @@
       <false/>
       </dict>
       </plist>
-  tags: kernel_tuning
 
 - name: Load limit.core.plist file with launchctl
   command: sudo launchctl load -w /Library/LaunchDaemons/limit.core.plist
-  register: core
-  tags: kernel_tuning
 
 # Skipping linting as not to introduce handlers into task-only playbooks (lint error 503)
 - name: Reboot macOS after tweaking kernel tuning parameters
   reboot:
     reboot_timeout: 3600
-  when: kernel.changed or core.changed
+  when: kernel.changed
   tags:
     - kernel_tuning
     - skip_ansible_lint

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
@@ -256,6 +256,7 @@
       <false/>
       </dict>
       </plist>
+  become: true
 
 - name: Load limit.core.plist file with launchctl
   command: sudo launchctl load -w /Library/LaunchDaemons/limit.core.plist

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
@@ -256,6 +256,10 @@
       <false/>
       </dict>
       </plist>
+  tags: kernel_tuning
+
+- name: Load limit.core.plist file with launchctl
+  command: sudo launchctl load -w /Library/LaunchDaemons/limit.core.plist
   register: core
   tags: kernel_tuning
 


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/aqa-tests/issues/6596#issuecomment-3311995980