### PR TITLE
UnixPB: Create .X11-unix directory for wayland

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
@@ -302,13 +302,21 @@
 #############################
 # Configure Wayland(Weston) #
 #############################
-- name: Install Wayland related packages (>= CentOS10)
-  package:
-    name: "{{ item }}"
-    state: latest
-  with_items: "{{ Additional_Test_Tool_Packages_Wayland }}"
-  when: ansible_distribution_major_version | int > 9
+- name: Configure Wayland (>= CentOS10)
   tags: test_tools
+  when: ansible_distribution_major_version | int > 9
+  block:
+    - name: Install Wayland related packages (>= CentOS10)
+      package:
+        name: "{{ item }}"
+        state: latest
+      with_items: "{{ Additional_Test_Tool_Packages_Wayland }}"
+
+    - name: Configure .X11-Unix folder
+      file:
+        path: /tmp/.X11-unix
+        state: directory
+        mode: "0777"
 
 ####################
 # Set Default Java #

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
@@ -316,7 +316,7 @@
       file:
         path: /tmp/.X11-unix
         state: directory
-        mode: "0777"
+        mode: "1777"
 
 ####################
 # Set Default Java #

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -159,11 +159,11 @@
 #############################
 # Configure Wayland(Weston) #
 #############################
-- name: Configure Wayland (>= Rhel10)
+- name: Configure Wayland (>= RHEL10)
   tags: test_tools
   when: ansible_distribution_major_version | int > 9
   block:
-    - name: Install Wayland related packages (>= Rhel10)
+    - name: Install Wayland related packages (>= RHEL10)
       package:
         name: "{{ item }}"
         state: latest
@@ -173,7 +173,7 @@
       file:
         path: /tmp/.X11-unix
         state: directory
-        mode: "0777"
+        mode: "1777"
 
 ################
 # Install Java #

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -159,13 +159,21 @@
 #############################
 # Configure Wayland(Weston) #
 #############################
-- name: Install Wayland related packages (>= RHEL10)
-  package:
-    name: "{{ item }}"
-    state: latest
-  with_items: "{{ Additional_Test_Tool_Packages_Wayland }}"
-  when: ansible_distribution_major_version | int > 9
+- name: Configure Wayland (>= Rhel10)
   tags: test_tools
+  when: ansible_distribution_major_version | int > 9
+  block:
+    - name: Install Wayland related packages (>= Rhel10)
+      package:
+        name: "{{ item }}"
+        state: latest
+      with_items: "{{ Additional_Test_Tool_Packages_Wayland }}"
+
+    - name: Configure .X11-Unix folder
+      file:
+        path: /tmp/.X11-unix
+        state: directory
+        mode: "0777"
 
 ################
 # Install Java #


### PR DESCRIPTION
 - add task to create .X11-unix directory for wayland
 - ref: https://github.com/adoptium/infrastructure/issues/3851#issuecomment-3244828331
 
Signed-off-by: Aswin K R <aswinkr77@gmail.com>

We're(IBM) seeing test failures on RedHat 10 machines which doesn't have this particular directory. Seems like sometimes Weston is not properly creating this directory. This task will ensure the directory exists.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
