### PR TITLE
WinPB: Pin Cygwin Packages

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/defaults/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/defaults/main.yml
@@ -1,0 +1,16 @@
+---
+# Default Variables For Installing Build Related Cygwin packages
+# At Pinned Versions
+
+## This Cygwin Site URL installs on old version of the cygwin packages, due to
+## An Upstream Bug When Building JDK11 with the most recent versions of make etc
+## https://bugs.openjdk.org/browse/JDK-8357657?focusedId=14792554&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel
+## Once The Upstream Bug Is Resolved, This Line Can Be Reverted To And The --no-verify switch on the installation removed.
+## The Current Cygwin Cache Has Been Created From A Snapshot Of The Cygwin Site Repo:
+## Cygwin_SITE_URL: "http://ctm.crouchingtigerhiddenfruitbat.org/pub/cygwin/circa/64bit/2024/08/25/171201"
+## The Original Site Repo Which Would Install The Latest Of All Cygwin Packages Is:
+## Cygwin_SITE_URL: "https://mirrors.kernel.org/sourceware/cygwin/"
+Cygwin_PACKAGE_DIR: "C:\\cygwin_packages"
+Cygwin_CACHE_DIR: "C:\\cygwin_cache"
+Cygwin_INST_DIR: "C:\\cygwin64"
+Cygwin_CACHE_DIR_POSIX: "C://cygwin_cache"

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
@@ -2,28 +2,73 @@
 ##########
 # cygwin #
 ##########
-- name: Test if Cygwin is already installed
+- name: Test if Cygwin is already installed (jq.exe as marker)
   win_stat:
-    path: 'C:\cygwin64\bin\jq.exe'
+    path: "{{ Cygwin_INST_DIR }}\\bin\\jq.exe"
   register: cygwin_installed
+  tags: cygwin
+
+- name: Ensure temp and package directories exist
+  win_file:
+    path: "{{ item }}"
+    state: directory
+  loop:
+    - "C:\\temp"
+    - "{{ Cygwin_PACKAGE_DIR }}"
+    - "{{ Cygwin_CACHE_DIR }}"
   tags: cygwin
 
 - name: Retrieve Cygwin setup
   win_get_url:
-    url: https://cygwin.com/setup-x86_64.exe
-    dest: C:\temp\cygwin.exe
+    url: "https://cygwin.com/setup-x86_64.exe"
+    dest: "C:\\temp\\cygwin.exe"
     force: no
-    checksum: 46993d76d756bde18564f72a4ee07384cd82b447527ca406c8bfc034cb05c664
+    checksum: "46993d76d756bde18564f72a4ee07384cd82b447527ca406c8bfc034cb05c664"
     checksum_algorithm: sha256
   when: not cygwin_installed.stat.exists
   register: cygwin_download
   tags: cygwin
 
-# If you update this with a new package, modify the "Test
-# if installed" to look for something in the new package
-- name: Install Cygwin
+- name: Retrieve Cygwin Package Cache
+  win_get_url:
+    url: "https://ci.adoptium.net/userContent/cygwin/cygwin_cache_20240825.zip"
+    dest: "C:\\temp\\cygwin_cache.zip"
+    force: no
+    checksum: "a2ec4dfbc67272312817228afb2bbff6f4ffc44df6088169ac11f191af00ec21"
+    checksum_algorithm: sha256
+  when: not cygwin_installed.stat.exists
+  register: cygwin_cache_download
+  tags: cygwin
+
+# Unzip Cygwin Cache
+- name: Unzip Cygwin Cache
+  win_unzip:
+    src: C:\TEMP\cygwin_cache.zip
+    dest: "{{ Cygwin_CACHE_DIR }}"
+  when: not cygwin_installed.stat.exists
+  tags: cygwin
+
+# Install strictly from the local cache (NO internet)
+# Change How The Args Are Parsed To Improve PS Interpretation
+- name: Install Cygwin From The Package Cache
   win_shell: |
-    Start-Process -Wait -FilePath 'C:\temp\cygwin.exe' -ArgumentList '--packages autoconf,automake,bsdtar,cmake,cpio,curl,gcc-core,git,gnupg,grep,jq,libtool,make,mingw64-x86_64-gcc-core,perl,rsync,unzip,wget,zip --quiet-mode --download --local-install --delete-orphans --site https://mirrors.kernel.org/sourceware/cygwin/ --local-package-dir C:\cygwin_packages --root C:\cygwin64'
+    $setup = 'C:\temp\cygwin.exe'
+    $list  = @(
+      '--quiet-mode',
+      '--local-install',
+      '--delete-orphans',
+      '--only-site',
+      '--no-verify',
+      '--no-version-check',
+      '--root', '{{ Cygwin_INST_DIR }}',
+      '--local-package-dir', '{{ Cygwin_CACHE_DIR }}',
+      '--site', 'file:///{{ Cygwin_CACHE_DIR_POSIX }}',
+      '--packages', 'autoconf,automake,bsdtar,cmake,cpio,curl,gcc-core,git,gnupg,gnupg2,grep,jq,libtool,make,mingw64-x86_64-gcc-core,perl,rsync,unzip,wget,zip'
+    ) | ForEach-Object { if ($_ -match '\s') { '"{0}"' -f $_ } else { $_ } }
+
+    $argString = $list -join ' '
+    $p = Start-Process -FilePath $setup -ArgumentList $argString -NoNewWindow -Wait -PassThru
+    if ($p.ExitCode -ne 0) { throw "Cygwin install from cache failed (exit $($p.ExitCode))" }
   args:
     executable: powershell
   when: not cygwin_installed.stat.exists


### PR DESCRIPTION
Fixes #4068 

Due to issues with the most recent version of Cygwin, being unable to build JDK11, due to an upstream JDK bug, we need to temporarily pin the cygwin installation to install specific versions of packages.

This bug : https://bugs.openjdk.org/browse/JDK-8357657?focusedId=14792554&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel

Should be fixed in time for January 2026 release, once this bug is fixed and tested, we can revert this change, and test with the current package versions again.

Have built all JDK versions locally on vms using this version of cygwin...

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)

:x:  JDK8 VPC :  [FAIL](https://ci.adoptium.net/job/VagrantPlaybookCheck/2178/OS=Win2022,label=vagrant/) [KNOWN ISSUE](https://github.com/adoptium/temurin-build/issues/4259)
:heavy_check_mark: : JDK11 VPC : https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Win2022,label=vagrant/2181/console
:heavy_check_mark: JDK17 VPC : https://ci.adoptium.net/job/VagrantPlaybookCheck/2187/
:heavy_check_mark: JDK21 VPC : https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Win2022,label=vagrant/2185/