### PR TITLE
github: update jenkins template due to unquoted colon character in title

### DIFF
--- a/.github/ISSUE_TEMPLATE/jenkinsupdate.md
+++ b/.github/ISSUE_TEMPLATE/jenkinsupdate.md
@@ -1,7 +1,7 @@
 ---
 name: Regular jenkins maintenance update
 about: Template for a jenkins server update - usually first Tuesday of each month
-title: 202x/MM/DD: Jenkins regular patching cycle - update to X.YYY.Z
+title: '202x/MM/DD: Jenkins regular patching cycle - update to X.YYY.Z'
 labels: 'jenkins'
 assignees: ''
 


### PR DESCRIPTION
yaml was considered invalid due to the use of a colon in the description which wasn't enclosed in quotes. This was causing the jenkins template to not get shown correctly

<img width="1157" height="91" alt="image" src="https://github.com/user-attachments/assets/ceb5ab06-a908-46b9-
b91b-d229af88df86" />

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
