### PR TITLE
unixPB: increase swap file space to 4GiB (was 2GiB)

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Swap_File/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Swap_File/tasks/main.yml
@@ -80,8 +80,8 @@
     - (btrfs_fs_found == True) and not (swap_exists.stat.exists)
   tags: swap_file
 
-- name: Create/Populate swap file - via DD
-  command: "dd if=/dev/zero of=/{{ swap_path }} bs=250M count=8"
+- name: Create/Populate 4GiB swap file - via DD
+  command: "dd if=/dev/zero of=/{{ swap_path }} bs=250M count=16"
   when:
     not (swap_exists.stat.exists)
   tags: swap_file


### PR DESCRIPTION
Fixes https://github.com/adoptium/aqa-tests/issues/6526 (or will once it is redeployed)
To deploy on an existing machine (Needs to be done on all of the test-*-s390x ones as a minimum) here is a cut and pastable list of commands:
```
swapoff /swapfile
dd if=/dev/zero of=/swapfile bs=65536 count=65536
chmod 600 /swapfile
mkswap /swapfile
swapon /swapfile
```
This should be safe unless we get machines were there is less than 4GiB free to create the swapfile in `/`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/2205/
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
