### PR TITLE
unixPB: Add perl-Time-Piece to common RedHat/CentOS

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -52,6 +52,7 @@ Build_Tool_Packages:
   - perl-IPC-Cmd                  # required for openssl v3 compiles
   - perl-libwww-perl
   - perl-Time-HiRes
+  - perl-Time-Piece               # required for openssl v3.5.3+ compiles
   - pigz
   - strace                        # For SBOM dependency analysis
   - systemtap-sdt-devel

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -47,6 +47,7 @@ Build_Tool_Packages:
   - patch                         # For DevKit creation that runs "patch"
   - perl-devel
   - perl-IPC-Cmd                  # required for openssl v3 compiles
+  - perl-Time-Piece               # required for openssl v3.5.3+ compiles
   - pkgconfig
   - strace                        # For SBOM dependency analysis
   - systemtap-sdt-devel


### PR DESCRIPTION
Required by OpenJ9 when compiling OpenSSL version 3.5.3+

Related eclipse-openj9/openj9#22631

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) https://ci.adoptium.net/job/VagrantPlaybookCheck/2190/
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
