### PR TITLE
inventory: add windows dockerhosts and IBMcloud EL8/9/10 systems

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -102,6 +102,7 @@ hosts:
 
       - azure:
           ubuntu2404-x64-1: {ip: 20.115.98.159, user: azureuser}
+          rhel10-x64-1: {ip: 20.117.121.109, user: azureuser}
           win2022-x64-1: {ip: 51.132.234.42, user: adoptopenjdk}
           win2022-x64-2: {ip: 20.77.53.16, user: adoptopenjdk}
           win2022-x64-3: {ip: 20.68.165.213, user: adoptopenjdk}


### PR DESCRIPTION
Systems overdue for being added ...
Ref:
- https://github.com/adoptium/infrastructure/issues/3286 (There is a fourth windows dockerhost but it's offline and I plan to decommission it so not adding it here
- https://github.com/adoptium/infrastructure/issues/3868


##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
