### PR TITLE
WinPB: Remove package cache from VS2022 installation options

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2022/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2022/tasks/main.yml
@@ -122,7 +122,7 @@
 
 - name: Run Visual Studio 2022 Installer From Download
   win_shell: |
-      Start-Process -Wait -FilePath 'C:\temp\vs_BuildTools22.exe' -ArgumentList '--wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --includeOptional --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.ATL.ARM64 --add Microsoft.VisualStudio.Component.VC.MFC.ARM64 --quiet --norestart'
+      Start-Process -Wait -FilePath 'C:\temp\vs_BuildTools22.exe' -ArgumentList '--nocache --wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --includeOptional --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.ATL.ARM64 --add Microsoft.VisualStudio.Component.VC.MFC.ARM64 --quiet --norestart'
   args:
     executable: powershell
   when: (not vs2022_installed.stat.exists) and (windows_version.stdout_lines[0] | regex_search('^(10\.|11\.|2016|2019|2022)'))


### PR DESCRIPTION
Identified as part of #4125 

The installation of VS2022 from the download ( rather than our cached installation layout ), does not remove the package caches, which utilises around 6.7Gb of space that could be freed.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)

VPC in progress: https://ci.adoptium.net/job/VagrantPlaybookCheck/2209/