### PR TITLE
tools: Build arm32 build images on aarch64

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,10 +86,12 @@ pipeline {
 def dockerBuildArm32(architecture, distro, dockerfile) {
     git poll: false, url: 'https://github.com/adoptium/infrastructure.git'
     def git_sha = "${env.GIT_COMMIT.trim()}"
+    def ansible_arch = "armv7l"
     docker.withRegistry('https://index.docker.io/v1/', 'dockerhub') {
         sh """
             docker buildx build --platform linux/arm/v7 \
-            --build-arg git_sha=$git_sha -f ansible/docker/$dockerfile \
+            --build-arg git_sha=$git_sha --build-arg ansible_arch=$ansible_arch \
+            -f ansible/docker/$dockerfile \
             -t adoptopenjdk/${distro}_build_image:linux-$architecture \ 
             --push .
         """

--- a/ansible/docker/Dockerfile.Ubuntu1604
+++ b/ansible/docker/Dockerfile.Ubuntu1604
@@ -1,6 +1,7 @@
 FROM ubuntu:16.04
 
 ARG git_sha
+ARG ansible_arch
 ARG user=jenkins
 
 RUN apt-get update
@@ -22,7 +23,7 @@ RUN echo "localhost ansible_connection=local" > /ansible/hosts
 
 RUN set -eux; \
  cd /ansible; \
- ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml -e "git_sha=$git_sha" --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit,ntp_time"
+ ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml -e "git_sha=$git_sha ansible_architecture=$ansible_arch" --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit,ntp_time"
 
 RUN rm -rf /ansible
 


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/4088