### PR TITLE
tools: Fix typo in jenkinsfile from pr 4132

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,8 +92,7 @@ def dockerBuildArm32(architecture, distro, dockerfile) {
             docker buildx build --platform linux/arm/v7 \
             --build-arg git_sha=$git_sha --build-arg ansible_arch=$ansible_arch \
             -f ansible/docker/$dockerfile \
-            -t adoptopenjdk/${distro}_build_image:linux-$architecture \ 
-            --push .
+            -t adoptopenjdk/${distro}_build_image:linux-$architecture --push .
         """
     }
 }


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Fixes typo in https://github.com/adoptium/infrastructure/pull/4132