### PR TITLE
Add support for the GHCR build image pushes currently running from sxa's fork

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,11 +100,11 @@ def dockerManifest() {
         git poll: false, url: 'https://github.com/adoptium/infrastructure.git'
         sh '''
             # Centos6
-            #export TARGET="adoptopenjdk/centos6_build_image"
-            #AMD64=$TARGET:linux-amd64
-            #docker manifest create $TARGET $AMD64
-            #docker manifest annotate $TARGET $AMD64 --arch amd64 --os linux
-            #docker manifest push $TARGET
+            export TARGET="adoptopenjdk/centos6_build_image"
+            AMD64=$TARGET:linux-amd64
+            docker manifest create $TARGET $AMD64
+            docker manifest annotate $TARGET $AMD64 --arch amd64 --os linux
+            docker manifest push $TARGET
             # Centos7
             export TARGET="adoptopenjdk/centos7_build_image"
             AMD64=$TARGET:linux-amd64


### PR DESCRIPTION
Upstreaming the changes which are used by https://ci.adoptium.net/job/build_image_updater so it's not running off my branch.

Fixes https://github.com/adoptium/infrastructure/issues/4047
Part of https://github.com/adoptium/infrastructure/issues/3830
Helps progress https://github.com/adoptium/infrastructure/issues/4088 which needs to be on top of this.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
