### PR TITLE
UnixPB: Override Default Pandoc Install Root For MacOS x64

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/pandoc/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/pandoc/tasks/main.yml
@@ -50,7 +50,7 @@
       changed_when: false
       tags: pandoc
 
-   - name: Override install root on macOS x64
+    - name: Override install root on macOS x64
       when:
         - supported
         - ansible_system == "Darwin"
@@ -59,7 +59,7 @@
         pandoc_install_root: "/usr/local"
       changed_when: false
       tags: pandoc
-      
+
     - name: Set Pandoc Base Directory Paths
       when: supported
       set_fact:


### PR DESCRIPTION
Fixes #4142 

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)

VPC In Progress: https://ci.adoptium.net/job/VagrantPlaybookCheck/2211/