### PR TITLE
unix: Install curl on macos14 intel via brew to get libcurl.4.dylib library

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/curl/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/curl/tasks/main.yml
@@ -31,11 +31,13 @@
   set_fact:
     homebrew_path: /usr/local/bin
   when: ansible_distribution == "MacOSX" and ansible_architecture == "x86_64"
+  tags: curl
 
 - name: Set Mac homebrew path (Arm64)
   set_fact:
     homebrew_path: /opt/homebrew/bin
   when: ansible_distribution == "MacOSX" and ansible_architecture == "arm64"
+  tags: curl
 
 - name: Download curl {{ curl_latest }}
   get_url:
@@ -151,4 +153,17 @@
     - ansible_distribution == "MacOSX"
     - "macos_version_number is version('10.13', '>')"
     - ((not curl_version.stdout) or ((curl_version.stdout) and (curl_version.stdout is version_compare(curl_oldest, operator='lt', strict=True))))
+  tags: curl
+
+- name: Install curl via brew on MacOS 14 x64 (regardless if curl is already installed)
+  become: yes
+  become_user: "{{ ansible_user }}"
+  homebrew:
+    name: curl
+    state: latest
+    path: "{{ homebrew_path }}"
+  when:
+    - ansible_distribution == "MacOSX"
+    - ansible_distribution_major_version == "14"
+    - ansible_architecture == "x86_64"
   tags: curl


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/4141#issuecomment-3552831824

We are seeing an error on macos14 intel in which git-remote-https is failing to call a libcurl.4.dylib library. This solution is to instal this library with curl via brew and then add DYLD_LIBRARY_PATH=/usr/local/Cellar/curl/8.17.0/lib/:$DYLD_LIBRARY_PATH to the macos14 intel node config in jenkins.

Ive tested this pr on a macos14 intel node in orka