### PR TITLE
unix: Change the path where git-remote-http looks for libcurl.4.dylib

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/curl/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/curl/tasks/main.yml
@@ -178,5 +178,5 @@
       shell: ls -ld /usr/local/Cellar/git/2.*/libexec/git-core/git-remote-http | awk '{print $9}'
       register: git_remote_http_path
 
-    - name: Change the path of the libcurl library in the git-remote-http
+    - name: Change the path of the libcurl library in the git-remote-http executable
       shell: "install_name_tool -change /usr/lib/libcurl.4.dylib {{ libcurl_path.stdout }} {{ git_remote_http_path.stdout }}"


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Repeating my comment https://github.com/adoptium/infrastructure/issues/4141#issuecomment-3563966438:

Found another solution (went a bit deep on this one). Using `otool` and `install_tool_name` I changed the path where `git-remote-http` looks for `libcurl.4.dylib`

```
admin@ventura-vm ~ % install_name_tool -change /usr/lib/libcurl.4.dylib /usr/local/Cellar/curl/8.17.0/lib/libcurl.4.dylib /usr/local/Cellar/git/2.52.0/libexec/git-core/git-remote-http
admin@ventura-vm ~ % otool -L /usr/local/Cellar/git/2.52.0/libexec/git-core/git-remote-http
/usr/local/Cellar/git/2.52.0/libexec/git-core/git-remote-http:
	/System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices (compatibility version 1.0.0, current version 1226.0.0)
Changed location ----> /usr/local/Cellar/curl/8.17.0/lib/libcurl.4.dylib (compatibility version 7.0.0, current version 9.0.0)
```
I thought this would mess up the signing on the `git-remote-http` executable since ive tampered with it but I guess not, a simple `git clone` command worked.

Ive tested this on an intel macos14 box, works 👍🏻 , solves:

```
23:15:51  git clone -q https://github.com/adoptium/TKG.git
23:15:51  dyld[2180]: Symbol not found: _curl_global_trace
23:15:51    Referenced from: <6EADC463-B41C-365C-8590-F3AE3D6E9106> /usr/local/Cellar/git/2.51.2/libexec/git-core/git-remote-http
23:15:51    Expected in:     <F8F6C7FA-6ED7-3B16-9E60-4AF09985DC3C> /usr/lib/libcurl.4.dylib
23:15:51  error: git-remote-https died of signal 6
```