### PR TITLE
tools: Build arm32 ghcr build images on aarch64 nodes

### DIFF
--- a/ansible/docker/Jenkinsfile
+++ b/ansible/docker/Jenkinsfile
@@ -109,6 +109,7 @@ def dockerBuildArm32(architecture, distro, dockerfile) {
             -t ghcr.io/adoptium/adoptium_build_image:${distro}_linux-$architecture --push .
             docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/adoptium/adoptium_build_image:${distro}_linux-${architecture} > ${distro}_linux-${architecture}.sha256
         """
+        archiveArtifacts artifacts: '*linux*.sha256', fingerprint: true
     }
 }
 


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

ref https://github.com/adoptium/infrastructure/issues/4088#issuecomment-3521523403