### PR TITLE
unixPB: Add non-Temurin jdk25 build for arm32 as trestle boot JDK

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -166,6 +166,54 @@
     - ansible_architecture == "armv7l"
   tags: default_java
 
+- name: Check if JDK25/arm32 is already installed in the target location
+  stat: path=/usr/lib/jvm/jdk25/bin/java
+  register: jdk25_installed
+  when:
+    - ansible_architecture == "armv7l"
+  tags: build_tools
+
+- name: Download JDK25/arm32 build
+  get_url:
+    url: https://ci.adoptium.net/userContent/arm32/OpenJDK25U.arm32_linux.25+36.tar.gz
+    dest: /tmp/OpenJDK25U.arm32_linux.25+36.tar.gz
+    force: no
+    mode: 0755
+    checksum: sha256:de160d44d5dbcb37c47cc1bd983e21fcb5dedd5ae16be21048e9a5c80f114502
+  when:
+    - ansible_architecture == "armv7l"
+    - not jdk25_installed.stat.exists
+  tags: build_tools
+
+- name: Decompress jdk25/arm32
+  unarchive:
+    src: /tmp/OpenJDK25U.arm32_linux.25+36.tar.gz
+    dest: /usr/lib/jvm
+    remote_src: yes
+  when:
+    - ansible_architecture == "armv7l"
+    - not jdk25_installed.stat.exists
+  tags: build_tools
+
+- name: Remove jdk25/arm32 tarball
+  file:
+    path: /tmp/OpenJDK25U.arm32_linux.25+36.tar.gz
+    state: absent
+  when:
+    - ansible_architecture == "armv7l"
+    - not jdk25_installed.stat.exists
+  tags: build_tools
+
+- name: Create jdk25 symlink on arm32
+  file:
+    src: /usr/lib/jvm/jdk-25+36
+    dest: /usr/lib/jvm/jdk25
+    state: link
+  when:
+    - ansible_architecture == "armv7l"
+    - not jdk25_installed.stat.exists
+  tags: adoptopenjdk_install
+
 - name: Set default java version for ppc64le
   alternatives:
     name: java


### PR DESCRIPTION
Ref: https://github.com/adoptium/adoptium/issues/265#issuecomment-3586342945

This allows us to have a jdk25 that can be used as a bootstrap for a jdk26/jdk build:
```
 Version string: 26-beta+26-202511271822 (26-beta)
* Source date:    1764267722 (2025-11-27T18:22:02Z)

Tools summary:
* Boot JDK:       openjdk version "25-beta" 2025-09-16 OpenJDK Runtime Environment (build 25-beta+36-202511252229) OpenJDK Server VM (build 25-beta+36-202511252229, mixed mode, sharing) (at /usr/lib/jvm/jdk25)
* Toolchain:      gcc (GNU Compiler Collection)
* C Compiler:     Version 11.2.0 (at /usr/local/gcc11/bin/gcc-11.2)
* C++ Compiler:   Version 11.2.0 (at /usr/local/gcc11/bin/g++-11.2)
```
```
=JAVA VERSION OUTPUT=
openjdk version "26-beta" 2026-03-17
OpenJDK Runtime Environment (build 26-beta+26-202511281556)
OpenJDK Server VM (build 26-beta+26-202511281556, mixed mode, sharing)
=/JAVA VERSION OUTPUT=
```
Noting that it's running with
```
* Build jobs:     1
```
which should probably be fixed at some point (Noted in https://github.com/adoptium/temurin-build/pull/4323#issuecomment-3590052830)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) https://ci.adoptium.net/job/VagrantPlaybookCheck/2224/ Additional standalone testig has taken place and confirmed that the jdk25 boot jdk is in place and usable as a bootstrap for jdk26
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

_Note: The JDK tarball that this is pulling was built locally by me (including the chain of 22->23->24) in the `ubuntu1604_build_image` container with GCC11.2.0._