### PR TITLE
Add pipeline code for test_image_updater job

### DIFF
--- a/ansible/docker/Jenkinsfile.test
+++ b/ansible/docker/Jenkinsfile.test
@@ -5,7 +5,7 @@ pipeline {
             parallel {
                 stage('Ubuntu24.04 x64') {
                     agent {
-                        label "dockerBuild&&linux&&x64&&dockerhost-azure-ubuntu2204-x64-1"
+                        label "dockerBuild&&linux&&x64"
                     } 
                     steps {
                         dockerBuild('amd64', 'ubuntu2404', 'Dockerfile.u2404')
@@ -21,7 +21,7 @@ pipeline {
                 }
                 stage('UBI10 x64') {
                     agent {
-                        label "dockerBuild&&linux&&x64&&dockerhost-azure-ubuntu2204-x64-1"
+                        label "dockerBuild&&linux&&x64"
                     } 
                     steps {
                         dockerBuild('amd64', 'ubi10', 'Dockerfile.ubi10')


### PR DESCRIPTION
This is the code that is being used by the [test_image_updater job](https://ci.adoptium.net/job/test_image_updater) in support of https://github.com/adoptium/aqa-tests/issues/5684

At the moment the job is running from my branch but the code is now in a reasonable state (it just doesn't have a full set of architectures) so I'm upstreaming this so that the job can be pointed at the upstream repository.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
