### PR TITLE
DockerStatic: Install weston on Ubuntu 24 in lieu of xvfb

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.u2404
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.u2404
@@ -39,7 +39,7 @@ CMD ["/usr/sbin/sshd","-D"]
 
 RUN apt-get update && apt-get install -qq -y git curl make gcc xvfb libxrender1 libxi6 libxtst6 locales fontconfig fakeroot
 # Install SSL Test packages
-RUN apt-get install -qq -y gnutls-bin libnss3 libnss3-tools libnss3-dev pkg-config
+RUN apt-get install -qq -y gnutls-bin libnss3 libnss3-tools libnss3-dev pkg-config weston
 
 RUN locale-gen en_US.utf8
 


### PR DESCRIPTION
Fixes #4165 

Add Weston packages to Ubuntu24 static docker container images.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR

