### PR TITLE
Inventory: Add New Hetzner Jenkins Worker Node

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -22,6 +22,7 @@ hosts:
       - hetzner:
           ubuntu1604-x64-1: {ip: 78.47.239.96, description: nagios.adoptopenjdk.net}
           ubuntu2004-x64-1: {ip: 78.47.239.97, description: ci.adoptium.net}
+          ubuntu2404-x64-1: {ip: 46.224.123.39, description: jenkins-hetzner-worker}
 
       - ibmcloud:
           vagrant-x64-1: {ip: 150.239.60.120, description: Bare metal machine to run vagrantPlaybookCheck and qemuPlaybookCheck}


### PR DESCRIPTION
Fixes #4126 

Add a new jenkins worker node hosted by hetzner, and hosted in the same geolocation as the jenkins server, this offers significant performance improvements.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR
- [X] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
