### PR TITLE
UnixPB: Fix package installations for RHEL8+ 

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -36,10 +36,21 @@
     - (ansible_distribution == "RedHat" and (ansible_distribution_major_version | int >= 8))
   tags: patch_update
 
-- name: YUM upgrade all packages
+- name: YUM upgrade all packages ( Prior To RHEL8 )
   yum:
     name: '*'
     state: latest
+  when:
+    - (ansible_distribution == "RedHat" and (ansible_distribution_major_version | int < 8))
+  tags: patch_update
+
+# For RHEL8 plus to avoid conflicts with system python and ansible
+# Fall back to the shell to do the package upgrade
+- name: YUM upgrade all packages ( RHEL8+ )
+  command: dnf -y upgrade
+  changed_when: true
+  when:
+    - (ansible_distribution == "RedHat" and (ansible_distribution_major_version | int >= 8))
   tags: patch_update
 
 # TODO: We should find a better way of doing this in the future, for some reason these deps aren't in the aarch64 rhel 7 repos.
@@ -89,6 +100,14 @@
 - name: Install numactl-devel excluding RHEL 7 on s390x
   package: "name=numactl-devel state=latest"
   when:
+    - ansible_distribution_major_version | int < 8
+    - not (ansible_distribution_major_version == "7" and ansible_architecture == "s390x")
+  tags: build_tools
+
+- name: Install numactl-devel (RHEL 8+)
+  command: dnf -y install numactl-devel
+  when:
+    - ansible_distribution_major_version | int >= 8
     - not (ansible_distribution_major_version == "7" and ansible_architecture == "s390x")
   tags: build_tools
 
@@ -97,7 +116,15 @@
   with_items: "{{ Additional_Build_Tools_RHEL_x86 }}"
   when:
     - ansible_architecture == "x86_64"
-    - ansible_distribution_major_version | int < 10
+    - ansible_distribution_major_version | int < 8
+  tags: build_tools
+
+- name: Install additional build tools for RHEL8+ on x86
+  command: dnf -y install {{ item }}
+  with_items: "{{ Additional_Build_Tools_RHEL_x86 }}"
+  when:
+    - ansible_architecture == "x86_64"
+    - ansible_distribution_major_version | int >= 8
   tags: build_tools
 
 - name: Install additional build tools for RHEL10+ on x86
@@ -124,14 +151,14 @@
   tags: build_tools
 
 - name: Install additional build tools for RHEL8 and above
-  package: "name={{ item }} state=latest"
+  command: dnf -y install {{ item }}
   with_items: "{{ Additional_Build_Tools_RHEL8Plus }}"
   when:
     - (ansible_distribution_major_version | int >= 8)
   tags: build_tools
 
 - name: Install jq for SBoM parsing for build reproducibility testing
-  package: "name=jq state=latest"
+  command: dnf -y install jq
   when:
     - ansible_distribution_major_version > "7"
   tags: test_tools
@@ -143,18 +170,47 @@
   tags: test_tools
   when: ansible_distribution_major_version | int < 10
   block:
-    - name: Install xorg-x11-server-Xvfb (< RHEL10)
+      # RHEL 8 and 9 — use cli
+
+    - name: Install xorg-x11-server-Xvfb (RHEL 8/9)
+      command: dnf -y install xorg-x11-server-Xvfb
+      when: ansible_distribution_major_version | int >= 8
+
+    - name: Install xorg-x11-server-Xorg on x86_64 (RHEL 8/9)
+      command: dnf -y install xorg-x11-server-Xorg
+      when:
+        - ansible_distribution_major_version | int >= 8
+        - ansible_architecture == "x86_64"
+
+    - name: Install xorg-x11-server-common on s390x (RHEL 8/9)
+      command: dnf -y install xorg-x11-server-common
+      when:
+        - ansible_distribution_major_version | int >= 8
+        - ansible_architecture == "s390x"
+
+    # RHEL 7 and earlier — keep modules
+
+    - name: Install xorg-x11-server-Xvfb (RHEL ≤ 7)
       package:
         name: xorg-x11-server-Xvfb
         state: latest
+      when: ansible_distribution_major_version | int < 8
 
-    - name: Install xorg-x11-server-Xorg if host is x86_64 and < RHEL10
-      yum: name=xorg-x11-server-Xorg state=installed
-      when: ansible_architecture == "x86_64"
+    - name: Install xorg-x11-server-Xorg on x86_64 (RHEL ≤ 7)
+      yum:
+        name: xorg-x11-server-Xorg
+        state: installed
+      when:
+        - ansible_distribution_major_version | int < 8
+        - ansible_architecture == "x86_64"
 
-    - name: Install xorg-x11-server-common if host is s390x and < RHEL10
-      yum: name=xorg-x11-server-common state=installed
-      when: ansible_architecture == "s390x"
+    - name: Install xorg-x11-server-common on s390x (RHEL ≤ 7)
+      yum:
+        name: xorg-x11-server-common
+        state: installed
+      when:
+        - ansible_distribution_major_version | int < 8
+        - ansible_architecture == "s390x"
 
 #############################
 # Configure Wayland(Weston) #
@@ -239,10 +295,16 @@
 # Locales #
 ###########
 
-- name: Install 'glibc-common' package
+- name: Install glibc-common (Prior to RHEL 8)
   package:
     name: glibc-common
     state: present
+  when: ansible_distribution_major_version | int < 8
+  tags: locales
+
+- name: Install glibc-common (RHEL 8+)
+  command: dnf -y install glibc-common
+  when: ansible_distribution_major_version | int >= 8
   tags: locales
 
 # Skipping linting as no alternative to shell can be used (lint error 305)

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/build_packages_and_tools.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/build_packages_and_tools.yml
@@ -12,9 +12,25 @@
   when:
     - ansible_distribution == "FreeBSD"
 
-- name: Install Build Tool Packages
+- name: Install Build Tool Packages (None RHEL)
   package: "name={{ item }} state={{ package_var }}"
   with_items: "{{ Build_Tool_Packages }}"
+  when:
+    - ansible_distribution != "RedHat"
+  tags: build_tools
+
+- name: Install Build Tool Packages (Prior To RHEL8)
+  package: "name={{ item }} state={{ package_var }}"
+  with_items: "{{ Build_Tool_Packages }}"
+  when:
+    - (ansible_distribution == "RedHat" and (ansible_distribution_major_version | int < 8))
+  tags: build_tools
+
+- name: Install Build Tool Packages (RHEL8+)
+  command: dnf -y install {{ item }}
+  with_items: "{{ Build_Tool_Packages }}"
+  when:
+    - (ansible_distribution == "RedHat" and (ansible_distribution_major_version | int >= 8))
   tags: build_tools
 
 - name: Create symlink for gmake to make
@@ -31,7 +47,23 @@
     - ansible_distribution != "Fedora"
   tags: build_tools
 
-- name: Install Test Tool Packages
+- name: Install Test Tool Packages (None-RHEL)
   package: "name={{ item }} state={{ package_var }}"
   with_items: "{{ Test_Tool_Packages }}"
+  when:
+    - ansible_distribution != "RedHat"
+  tags: test_tools
+
+- name: Install Test Tool Packages ( Prior To RHEL8 )
+  package: "name={{ item }} state={{ package_var }}"
+  with_items: "{{ Test_Tool_Packages }}"
+  when:
+    - (ansible_distribution == "RedHat" and (ansible_distribution_major_version | int < 8))
+  tags: test_tools
+
+- name: Install Test Tool Packages ( RHEL8+ )
+  command: dnf -y install {{ item }}
+  with_items: "{{ Test_Tool_Packages }}"
+  when:
+    - (ansible_distribution == "RedHat" and (ansible_distribution_major_version | int >= 8))
   tags: test_tools

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
@@ -39,13 +39,35 @@
     ##################
     # Install Docker #
     ##################
-    - name: Install docker based on OS (Ubuntu, RHEL/CentOS 7/8/9, Debian)
+
+    # CentOS (all), RHEL < 8, Ubuntu < 20, Debian
+
+    - name: Install docker (CentOS, RHEL < 8, Ubuntu < 20, Debian)
       package:
         name:
           - docker-ce
         state: latest   # TODO: Package installs should not use latest
-        use: auto       # automatic select package manager to use yum, apt and so on
-      when: ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version >= "7")) or ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int < 20) or ansible_distribution == "Debian")
+        use: auto
+      when: >
+        (
+          ansible_distribution == "CentOS"
+          or
+          (ansible_distribution == "RedHat" and ansible_distribution_major_version | int < 8)
+        )
+        or
+        (
+          (ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int < 20)
+          or ansible_distribution == "Debian"
+        )
+
+      # RHEL 8+
+
+    - name: Install docker (RHEL 8+)
+      command: dnf -y install docker-ce
+      when:
+        - ansible_distribution == "RedHat"
+        - ansible_distribution_major_version | int >= 8
+      tags: docker
 
     - name: Install default docker on Ubuntu 22+
       package:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_RedHat.yml
@@ -26,12 +26,12 @@
     - not (ansible_distribution_major_version >= "10")
   tags: nagios_plugins
 
-- name: Install nagios-plugins (RHEL8/x64)
-  yum:
-    name: nagios-plugins
-    state: latest
+- name: Install nagios-plugins (RHEL 8 / x86_64)
+  command: dnf -y install nagios-plugins
   when:
-    - ansible_distribution_major_version == "8" and ansible_architecture == "x86_64"
+    - ansible_distribution == "RedHat"
+    - ansible_distribution_major_version == "8"
+    - ansible_architecture == "x86_64"
   tags: nagios_plugins
 
 ##########

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ant/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ant/tasks/main.yml
@@ -92,12 +92,21 @@
   failed_when: false
   tags: ant
 
-- name: Remove the older Ant package via yum
+- name: Remove ant package (CentOS or RHEL prior to 8)
   yum:
     name: ant
     state: absent
   when:
-    - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS")
+    - ansible_os_family == "RedHat"
+    - ansible_distribution == "CentOS"
+      or ansible_distribution_major_version | int < 8
+  tags: ant
+
+- name: Remove ant package (RHEL 8+)
+  command: dnf -y remove ant
+  when:
+    - ansible_distribution == "RedHat"
+    - ansible_distribution_major_version | int >= 8
   tags: ant
 
 - name: Remove the older Ant package via apt


### PR DESCRIPTION
Fixes #4118 

Amend DNF/yum installation processes to run via command line rather than via ansible builtin modules.

RHEL8 has a system python of 3.6.8 which dictates how dnf and yum behave.
When running via Ansible with a version of 2.18 or later, the system python and ansible on the controller are incompatible, and this error occurs.

```
TASK [Common : YUM upgrade all packages] ***************************************
fatal: [169.63.185.12]: FAILED! => {"changed": false, "msg": "Could not import the dnf python module using /usr/bin/python3.9 (3.9.20 (main, Aug 23 2025, 13:51:39) [GCC 8.5.0 20210514 (Red Hat 8.5.0-28)]). Please install `python3-dnf` package or ensure you have specified the correct ansible_python_interpreter. (attempted ['/usr/libexec/platform-python', '/usr/bin/python3', '/usr/bin/python'])", "results": []}

PLAY RECAP *********************************************************************

```

This may impact RHEL9+ in the future as ansible and python versions progress.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)

VPC In Progress: https://ci.adoptium.net/job/VagrantPlaybookCheck/2239/

05:58:02.674 [VagrantPlaybookCheck » Ubuntu2204,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Ubuntu2204,label=vagrant/) completed with result SUCCESS
07:52:50.293 [VagrantPlaybookCheck » CentOS7,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=CentOS7,label=vagrant/) completed with result SUCCESS
07:52:50.295 [VagrantPlaybookCheck » CentOS8,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=CentOS8,label=vagrant/) completed with result SUCCESS
07:52:50.295 [VagrantPlaybookCheck » Fedora40,vagrant](https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Fedora40,label=vagrant/) completed with result SUCCESS

Rerun Failed Due To Node Issue: https://ci.adoptium.net/job/VagrantPlaybookCheck/2240/