### PR TITLE
Docker: Pin alpine x64 build to physical host

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ pipeline {
                 }
                 stage('Alpine3 x64') {
                     agent {
-                        label "dockerBuild&&linux&&x64"
+                        label "dockerBuild&&linux&&x64&&containerBuilder"
                     }
                     steps {
                         dockerBuild('amd64', 'alpine3', 'Dockerfile.Alpine3')


### PR DESCRIPTION
As seen in https://github.com/adoptium/infrastructure/pull/4169

Container builds do not work on dynamic linux hosts. Issue https://github.com/adoptium/infrastructure/issues/4168 has been raised and updated for a longer term fix, in the short term however, we need to pin the x64 container builds to a physical host

Issue 

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR

