### PR TITLE
unixPb: Install Curl via brew on macos14 arm64

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/curl/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/curl/tasks/main.yml
@@ -155,7 +155,20 @@
     - ((not curl_version.stdout) or ((curl_version.stdout) and (curl_version.stdout is version_compare(curl_oldest, operator='lt', strict=True))))
   tags: curl
 
-- name: Install curl via brew in MacOS14 (regardless if curl is already installed)
+- name: Install curl via brew on MacOS14 arm64 (upgrade to latest if curl is already installed)
+  become: yes
+  become_user: "{{ ansible_user }}"
+  homebrew:
+    name: curl
+    state: latest
+    path: "{{ homebrew_path }}"
+  when:
+    - ansible_distribution == "MacOSX"
+    - ansible_distribution_major_version == "14"
+    - ansible_architecture == "arm64"
+  tags: curl
+
+- name: Install curl via brew on MacOS14 x64 (upgrade to latest if curl is already installed)
   become: yes
   become_user: "{{ ansible_user }}"
   when:


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Installs latest curl on macos14 arm64. This platform comes with curl out of the box, but it does not come with the /usr/lib/libcurl.4.dylib library. This comes with curl via brew. This should fix https://github.com/adoptium/infrastructure/issues/4209

I then need to add `DYLD_LIBRARY_PATH=/opt/homebrew/Cellar/curl/8.18.0/lib/:$DYLD_LIBRARY_PATH` to the jenkins config of the build arm64 macos orka nodes once this pr is merged