### PR TITLE
tools: pin x64 ghcr build image jobs to a specific dockerhost node

### DIFF
--- a/ansible/docker/Jenkinsfile
+++ b/ansible/docker/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
             parallel {
                 stage('CentOS6 x64') {
                     agent {
-                        label "dockerBuild&&linux&&x64"
+                        label "dockerBuild&&linux&&x64&&containerBuilder"
                     }
                     steps {
                         dockerBuild('amd64', 'centos6', 'Dockerfile.CentOS6')
@@ -13,7 +13,7 @@ pipeline {
                 }
                 stage('CentOS7 x64') {
                     agent {
-                        label "dockerBuild&&linux&&x64"
+                        label "dockerBuild&&linux&&x64&&containerBuilder"
                     }
                     steps {
                         dockerBuild('amd64', 'centos7', 'Dockerfile.CentOS7')
@@ -53,7 +53,7 @@ pipeline {
                 }
                 stage('Alpine3 x64') {
                     agent {
-                        label "dockerBuild&&linux&&x64"
+                        label "dockerBuild&&linux&&x64&&containerBuilder"
                     }
                     steps {
                         dockerBuild('amd64', 'alpine3', 'Dockerfile.Alpine3')


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Same as the fix in https://github.com/adoptium/infrastructure/pull/4187/files but for the ghcr build image job. Should solve https://github.com/adoptium/infrastructure/issues/4207