### PR TITLE
tools: Add Ubuntu 2404 ppc64le and s390x aqa test images

### DIFF
--- a/ansible/docker/Jenkinsfile.test
+++ b/ansible/docker/Jenkinsfile.test
@@ -35,14 +35,22 @@ pipeline {
                        dockerBuild('arm64', 'ubi10', 'Dockerfile.ubi10')
                    }
                }
-//               stage('UBI10 ppc64le') {
-//                   agent {
-//                       label "dockerBuild&&linux&&ppc64le"
-//                   }
-//                   steps {
-//                       dockerBuild('ppc64le', 'ubi10', 'Dockerfile.ubi10')
-//                   }
-//               }
+              stage('Ubuntu24.04 s390x') {
+                  agent {
+                      label "dockerBuild&&linux&&s390x"
+                  }
+                  steps {
+                      dockerBuild('s390x', 'ubuntu2404', 'Dockerfile.u2404')
+                  }
+              }
+              stage('Ubuntu24.04 ppc64le') {
+                  agent {
+                      label "dockerBuild&&linux&&ppc64le"
+                  }
+                  steps {
+                      dockerBuild('ppc64le', 'ubuntu2404', 'Dockerfile.u2404')
+                  }
+              }
             }
         }
         stage('Docker Manifest') {
@@ -97,13 +105,19 @@ def dockerManifest() {
             export TARGET="ghcr.io/adoptium/test-containers:ubuntu2404"
             AMD64=${TARGET}-amd64
             ARM64=${TARGET}-arm64
+            S390X=${TARGET}-s390x
+            PPC64LE=${TARGET}-ppc64le
             echo "Debug SF01"
             docker manifest inspect $AMD64 2>/dev/null | grep mediaType
             docker manifest inspect $ARM64 2>/dev/null | grep mediaType
+            docker manifest inspect $S390X 2>/dev/null | grep mediaType
+            docker manifest inspect $PPC64LE 2>/dev/null | grep mediaType
             echo "Debug SF01"
-            docker manifest create $TARGET $AMD64 $ARM64
+            docker manifest create $TARGET $AMD64 $ARM64 $S390X $PPC64LE
             docker manifest annotate $TARGET $AMD64 --arch amd64 --os linux
             docker manifest annotate $TARGET $ARM64 --arch arm64 --os linux
+            docker manifest annotate $TARGET $S390X --arch s390x --os linux
+            docker manifest annotate $TARGET $PPC64LE --arch ppc64le --os linux
             docker manifest push $TARGET
 
             # UBI10


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Ref https://github.com/adoptium/infrastructure/issues/4217

Ive chosen Ubuntu 2404 on s390x and ppc64le because im familiar with its stability in our static docker containers
