### PR TITLE
inventory: Add build-osuosl-aix72-ppc64-4 to inventory.yml

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -48,6 +48,7 @@ hosts:
           aix72-ppc64-1: {ip: 140.211.9.166, description: p8-java1-adopt10.osuosl.org, 7200-02-04-1914}
           aix72-ppc64-2: {ip: 140.211.9.12, description: p8-aix1-adopt02.osuosl.org, 7200-02-04-1914}
           aix72-ppc64-3: {ip: 140.211.9.163, description: p8-java1-adopt09.osuosl.org, 7200-05-03-2135}
+          aix72-ppc64-4: {ip: 140.211.9.137, description: p10-aix-adopt05.osuosl.org, 7200-02-06-2016}
           centos74-ppc64le-1: {ip: 140.211.168.138}
           centos74-ppc64le-2: {ip: 140.211.168.117}
           ubuntu2204-aarch64-1: {ip: 140.211.169.57}


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Ref https://github.com/adoptium/infrastructure/issues/4179. Adding https://ci.adoptium.net/computer/build-osuosl-aix72-ppc64-4/ to the inventory file. 
