### PR TITLE
Inventory: Update IBM Cloud Nodes

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -58,7 +58,7 @@ hosts:
           solaris10u11-sparcv9-1: {ip: cloud.siteox.com, port: 24322}
 
       - ibmcloud:
-          win2022-x64-1: {ip: 52.118.206.11, user: Administrator, cloudloc: oj9 }
+          win2022-x64-1: {ip: 52.118.206.11, user: Administrator, cloudloc: oj9}
 
   - dockerhost:
 


### PR DESCRIPTION
Update IBM cloud hosted nodes, as these machines have been migrated, and updated. 

Full pipeline : https://ci.adoptium.net/job/AQA_Test_Pipeline/624/

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR
- [X] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
