### PR TITLE
UnixPB: Dont install jdk24 & jdk25 on arm32

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -163,12 +163,14 @@
       jdk_version: 24
       when:
         - ansible_distribution != "Solaris"
+        - ansible_architecture != "armv7l"
         - not (ansible_distribution == "Alpine" and ansible_architecture == "aarch64")
       tags: build_tools
     - role: adoptopenjdk_install  # Current LTS
       jdk_version: 25
       when:
         - ansible_distribution != "Solaris"
+        - ansible_architecture != "armv7l"
         - not (ansible_distribution == "Alpine" and ansible_architecture == "aarch64")
       tags: build_tools
     - role: Nagios_Plugins        # AdoptOpenJDK Infrastructure


### PR DESCRIPTION
Fixes #4254 

As we dont build JDK24 & JDK25 for arm32, these shouldnt be installed by the playbook.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR

