### PR TITLE
Inventory: Remove old jenkins-worker

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -27,9 +27,6 @@ hosts:
       - ibmcloud:
           vagrant-x64-1: {ip: 150.239.60.120, cloudloc: oj9, description: Bare metal machine to run vagrantPlaybookCheck and qemuPlaybookCheck}
 
-      - osuosl:
-          ubuntu2204-aarch64-1: {ip: 140.211.169.21, description: jenkins-worker}
-
   - build:
 
       - azure:


### PR DESCRIPTION
Fixes #4235 

Removed osuosl inventory entry for old jenkins-worker. Replaced with hetzner x64 jenkins worker

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR
- [X] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
