### PR TITLE
Inventory: Update IP address For Risc Test Box

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -128,7 +128,7 @@ hosts:
       # Rise machines are hosted in Scaleway
       - rise:
           ubuntu2404-riscv64-1: {ip: 62.210.163.198, user: ubuntu}
-          ubuntu2404-riscv64-2: {ip: 62.210.163.196, user: ubuntu}
+          ubuntu2404-riscv64-2: {ip: 62.210.163.10, user: ubuntu}
           ubuntu2404-riscv64-3: {ip: 62.210.163.99, user: ubuntu}
           ubuntu2404-riscv64-4: {ip: 62.210.163.103, user: ubuntu}
           ubuntu2404-riscv64-5: {ip: 62.210.163.45, user: ubuntu}


### PR DESCRIPTION
Fixes #4307 

One of the riscv test boxes (test-rise-ubuntu2404-riscv64-2) became unreachable, and unrecoverable, it has been reprovisioned , this updates the IP address accordingly.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR
- [X] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
