### PR TITLE
github: add jenkins gha workflow

### DIFF
--- a/.github/workflows/jenkins-agent-macos15-intel.yml
+++ b/.github/workflows/jenkins-agent-macos15-intel.yml
@@ -1,0 +1,49 @@
+# ---------------------------------------------------------------
+# GitHub Actions workflow for Jenkins agent provisioning (macOS)
+# ---------------------------------------------------------------
+#
+# The GitHub Actions Cloud plugin triggers this workflow via
+# workflow_dispatch, passing the Jenkins URL, agent name, and
+# agent secret as inputs.
+# ---------------------------------------------------------------
+
+name: Jenkins Agent (macOS)
+
+on:
+  workflow_dispatch:
+    inputs:
+      jenkins_url:
+        description: 'Jenkins server URL (with trailing slash)'
+        required: true
+      agent_name:
+        description: 'Jenkins agent name'
+        required: true
+      agent_secret:
+        description: 'Jenkins agent secret'
+        required: true
+
+jobs:
+  agent:
+    runs-on: macos-15-intel
+    timeout-minutes: 360   # max 6 hours, adjust as needed
+
+    steps:
+      - name: Mask secret
+        run: echo "::add-mask::${{ inputs.agent_secret }}"
+
+      - name: Download Jenkins agent JAR
+        run: |
+          curl -sSfL --retry 3 --retry-delay 5 -o agent.jar \
+            "${{ inputs.jenkins_url }}jnlpJars/agent.jar"
+
+      - name: Connect to Jenkins
+        env:
+          AGENT_SECRET: ${{ inputs.agent_secret }}
+        run: |
+          java -jar agent.jar \
+            -url "${{ inputs.jenkins_url }}" \
+            -secret "$AGENT_SECRET" \
+            -name "${{ inputs.agent_name }}" \
+            -workDir "/Users/runner/agent" \
+            -webSocket \
+            -noReconnect


### PR DESCRIPTION
This is to be used by https://github.com/jenkinsci/github-actions-cloud-plugin 

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
