### PR TITLE
github: bump bash to 4.x or above

### DIFF
--- a/.github/workflows/jenkins-agent-macos15-intel.yml
+++ b/.github/workflows/jenkins-agent-macos15-intel.yml
@@ -32,7 +32,9 @@ jobs:
 
     steps:
       - name: Mask secret
-        run: echo "::add-mask::${{ inputs.agent_secret }}"
+        run: |
+          secret=$(jq -r '.inputs.agent_secret' "$GITHUB_EVENT_PATH")
+          echo "::add-mask::$secret"
 
       - name: Upgrade bash
         run: |

--- a/.github/workflows/jenkins-agent-macos15-intel.yml
+++ b/.github/workflows/jenkins-agent-macos15-intel.yml
@@ -34,6 +34,16 @@ jobs:
       - name: Mask secret
         run: echo "::add-mask::${{ inputs.agent_secret }}"
 
+      - name: Upgrade bash
+        run: |
+          brew install bash
+          sudo bash -c 'echo /usr/local/bin/bash >> /etc/shells'
+          sudo dscl . -change /Users/runner UserShell /bin/bash /usr/local/bin/bash
+          echo "/usr/local/bin" >> "$GITHUB_PATH"
+          echo "SHELL=/usr/local/bin/bash" >> "$GITHUB_ENV"
+          echo "BASH=/usr/local/bin/bash" >> "$GITHUB_ENV"
+          /usr/local/bin/bash --version
+
       - name: Install ant-contrib
         run: |
           ANT_LIB="$(ant -diagnostics | grep 'ant.home' | head -1 | sed 's/.*: //')/lib"


### PR DESCRIPTION
the aqa-test scripts have several bash scripts that require Bash 4.x or above.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
