### PR TITLE
windowsPb: Change hosts variable to all

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ To run the playbooks against a remote machine, make sure your ssh keys are appro
 perl -p -i -e 's/hosts: .*/hosts: all/' ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
 ```
 This will change the `hosts` line in the playbook to `hosts: all` so that it will run against unspecified machines (if the chosen playbook already has `hosts: all`, you can skip that command). Then to specifiy machines you can run:
+```
 echo "test-<provider>-<distribution>-<arch>-<number> ansible_host=<ip_address_of_machine>" > hosts
 ansible-playbook -i hosts -u root --skip-tags=adoptopenjdk,jenkins ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
 ```

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ ansible-playbook -i hosts --skip-tags=adoptopenjdk,jenkins ansible/playbooks/Ado
 To run the playbooks against a remote machine, make sure your ssh keys are appropriately configured to log into the remote machines as root, then:
 ```
 perl -p -i -e 's/hosts: .*/hosts: all/' ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+```
+This will change the `hosts` line in the playbook to `hosts: all` so that it will run against unspecified machines (if the chosen playbook already has `hosts: all`, you can skip that command). Then to specifiy machines you can run:
 echo "test-<provider>-<distribution>-<arch>-<number> ansible_host=<ip_address_of_machine>" > hosts
 ansible-playbook -i hosts -u root --skip-tags=adoptopenjdk,jenkins ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
 ```

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -6,7 +6,7 @@
 # It can be defined as 'all' or a specific group which the host belongs to.
 # For example, it can be 'all' or 'x86' for when a host is in the group 'x86'.
 - name: Ansible Unix playbook
-  hosts: "{{ Groups | default('localhost:build:test:perf:jck:!*zos*:!*win*:!*aix*') }}"
+  hosts: all
   gather_facts: yes
   tasks:
     - name: Run Tasks

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -6,7 +6,7 @@
 # It can be defined as 'all' or a specific group which the host belongs to.
 # For example, it can be 'all' or 'x86' for when a host is in the group 'x86'.
 - name: Ansible Unix playbook
-  hosts: all
+  hosts: "{{ Groups | default('localhost:build:test:perf:jck:!*zos*:!*win*:!*aix*') }}"
   gather_facts: yes
   tasks:
     - name: Run Tasks

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -22,7 +22,7 @@
 # It can be defined as 'all' or a specific group which the host belongs to.
 # For example, it can be 'all' or 'x86' for when a host is in the group 'x86'.
 - name: Ansible Windows playbook
-  hosts: "{{ Groups | default('localhost:build:test:perf:jck:!*zos*:!*win*:!*aix*') }}"
+  hosts: all
   gather_facts: yes
   tasks:
     - name: Load Standard Variables


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [x] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Allows awx to detect windows hosts. Fixes https://github.com/adoptium/infrastructure/issues/4299#issuecomment-4343971485

Im not sure why we'd need `"{{ Groups | default('localhost:build:test:perf:jck:!*zos*:!*win*:!*aix*') }}"`, the only times we run the playbook are in AWX or manually and in both cases we manually specify the hosts. im leaving it on the Unix playbook since nothings broken there