### PR TITLE
tools: Machine audit - Refine checked packages

### DIFF
--- a/ansible/machine_audit/packages/aix
+++ b/ansible/machine_audit/packages/aix
@@ -29,20 +29,20 @@
       "path": "/usr/java25_64/bin/java"
     },
     {
-      "name": "gcc",
-      "path": "default"
+      "name": "xlc13",
+      "path": "/opt/IBM/xlc/13.1.3/bin/xlc"
     },
     {
-      "name": "g++",
-      "path": "default"
+      "name": "xlc13++",
+      "path": "/opt/IBM/xlC/13.1.3/bin/xlc++"
     },
     {
-      "name": "xlc",
-      "path": "default"
+      "name": "xlc16",
+      "path": "/opt/IBM/xlc/16.1.0/bin/xlc"
     },
     {
-      "name": "xlC",
-      "path": "default"
+      "name": "xlc16++",
+      "path": "/opt/IBM/xlC/16.1.0/bin/xlc++"
     },
     {
       "name": "make",

--- a/ansible/machine_audit/packages/aix
+++ b/ansible/machine_audit/packages/aix
@@ -1,27 +1,118 @@
 {
   "build_packages": [
-    "gcc",
-    "g++",
-    "xlc",
-    "xlC",
-    "make",
-    "gmake",
-    "cmake",
-    "autoconf",
-    "automake",
-    "libtool",
-    "git",
-    "ant"
+    {
+      "name": "JDK8",
+      "path": "/usr/java8_64/bin/java"
+    },
+    {
+      "name": "JDK10",
+      "path": "/usr/java10_64/bin/java"
+    },
+    {
+      "name": "JDK11",
+      "path": "/usr/java11_64/bin/java"
+    },
+    {
+      "name": "JDK17",
+      "path": "/usr/java17_64/bin/java"
+    },
+    {
+      "name": "JDK21",
+      "path": "/usr/java21_64/bin/java"
+    },
+    {
+      "name": "JDK24",
+      "path": "/usr/java24_64/bin/java"
+    },
+    {
+      "name": "JDK25",
+      "path": "/usr/java25_64/bin/java"
+    },
+    {
+      "name": "gcc",
+      "path": "default"
+    },
+    {
+      "name": "g++",
+      "path": "default"
+    },
+    {
+      "name": "xlc",
+      "path": "default"
+    },
+    {
+      "name": "xlC",
+      "path": "default"
+    },
+    {
+      "name": "make",
+      "path": "default"
+    },
+    {
+      "name": "gmake",
+      "path": "default"
+    },
+    {
+      "name": "cmake",
+      "path": "default"
+    },
+    {
+      "name": "autoconf",
+      "path": "default"
+    },
+    {
+      "name": "automake",
+      "path": "default"
+    },
+    {
+      "name": "libtool",
+      "path": "default"
+    },
+    {
+      "name": "git",
+      "path": "default"
+    },
+    {
+      "name": "ant",
+      "path": "default"
+    }
   ],
   "test_packages": [
-    "python3",
-    "python",
-    "perl",
-    "ksh",
-    "bash",
-    "curl",
-    "wget",
-    "tar",
-    "gzip"
+    {
+      "name": "python3",
+      "path": "default"
+    },
+    {
+      "name": "python",
+      "path": "default"
+    },
+    {
+      "name": "perl",
+      "path": "default"
+    },
+    {
+      "name": "ksh",
+      "path": "default"
+    },
+    {
+      "name": "bash",
+      "path": "default"
+    },
+    {
+      "name": "curl",
+      "path": "default"
+    },
+    {
+      "name": "wget",
+      "path": "default"
+    },
+    {
+      "name": "tar",
+      "path": "default"
+    },
+    {
+      "name": "gzip",
+      "path": "default"
+    }
   ]
 }

--- a/ansible/machine_audit/packages/aix
+++ b/ansible/machine_audit/packages/aix
@@ -63,27 +63,11 @@
     {
       "name": "automake",
       "path": "default"
-    },
-    {
-      "name": "libtool",
-      "path": "default"
-    },
-    {
-      "name": "git",
-      "path": "default"
-    },
-    {
-      "name": "ant",
-      "path": "default"
     }
   ],
   "test_packages": [
     {
-      "name": "python3",
-      "path": "default"
-    },
-    {
-      "name": "python",
+      "name": "ant",
       "path": "default"
     },
     {
@@ -91,11 +75,7 @@
       "path": "default"
     },
     {
-      "name": "ksh",
-      "path": "default"
-    },
-    {
-      "name": "bash",
+      "name": "git",
       "path": "default"
     },
     {
@@ -104,14 +84,6 @@
     },
     {
       "name": "wget",
-      "path": "default"
-    },
-    {
-      "name": "tar",
-      "path": "default"
-    },
-    {
-      "name": "gzip",
       "path": "default"
     }
   ]

--- a/ansible/machine_audit/packages/linux
+++ b/ansible/machine_audit/packages/linux
@@ -1,26 +1,102 @@
 {
   "build_packages": [
-    "gcc",
-    "g++",
-    "make",
-    "cmake",
-    "autoconf",
-    "automake",
-    "libtool",
-    "pkg-config",
-    "git",
-    "ant"
+    {
+      "name": "JDK8",
+      "path": "/usr/lib/jvm/jdk8/bin/java"
+    },
+    {
+      "name": "JDK10",
+      "path": "/usr/lib/jvm/jdk10/bin/java"
+    },
+    {
+      "name": "JDK11",
+      "path": "/usr/lib/jvm/jdk11/bin/java"
+    },
+    {
+      "name": "JDK17",
+      "path": "/usr/lib/jvm/jdk17/bin/java"
+    },
+    {
+      "name": "JDK21",
+      "path": "/usr/lib/jvm/jdk17/bin/java"
+    },
+    {
+      "name": "JDK24",
+      "path": "/usr/lib/jvm/jdk24/bin/java"
+    },
+    {
+      "name": "JDK25",
+      "path": "/usr/lib/jvm/jdk25/bin/java"
+    },
+    {
+      "name": "gcc",
+      "path": "default"
+    },
+    {
+      "name": "g++",
+      "path": "default"
+    },
+    {
+      "name": "make",
+      "path": "default"
+    },
+    {
+      "name": "cmake",
+      "path": "default"
+    },
+    {
+      "name": "autoconf",
+      "path": "default"
+    },
+    {
+      "name": "automake",
+      "path": "default"
+    },
+    {
+      "name": "libtool",
+      "path": "default"
+    },
+    {
+      "name": "git",
+      "path": "default"
+    },
+    {
+      "name": "ant",
+      "path": "default"
+    }
   ],
   "test_packages": [
-    "python3",
-    "python",
-    "perl",
-    "curl",
-    "wget",
-    "tar",
-    "unzip",
-    "zip",
-    "gzip",
-    "xz"
+    {
+      "name": "perl",
+      "path": "default"
+    },
+    {
+      "name": "curl",
+      "path": "default"
+    },
+    {
+      "name": "wget",
+      "path": "default"
+    },
+    {
+      "name": "tar",
+      "path": "default"
+    },
+    {
+      "name": "unzip",
+      "path": "default"
+    },
+    {
+      "name": "zip",
+      "path": "default"
+    },
+    {
+      "name": "gzip",
+      "path": "default"
+    },
+    {
+      "name": "xz",
+      "path": "default"
+    }
   ]
 }

--- a/ansible/machine_audit/packages/linux
+++ b/ansible/machine_audit/packages/linux
@@ -18,7 +18,7 @@
     },
     {
       "name": "JDK21",
-      "path": "/usr/lib/jvm/jdk17/bin/java"
+      "path": "/usr/lib/jvm/jdk21/bin/java"
     },
     {
       "name": "JDK24",

--- a/ansible/machine_audit/packages/linux
+++ b/ansible/machine_audit/packages/linux
@@ -49,19 +49,11 @@
       "path": "default"
     },
     {
+      "name": "docker",
+      "path": "default"
+    },
+    {
       "name": "automake",
-      "path": "default"
-    },
-    {
-      "name": "libtool",
-      "path": "default"
-    },
-    {
-      "name": "git",
-      "path": "default"
-    },
-    {
-      "name": "ant",
       "path": "default"
     }
   ],
@@ -75,27 +67,15 @@
       "path": "default"
     },
     {
+      "name": "git",
+      "path": "default"
+    },
+    {
+      "name": "ant",
+      "path": "default"
+    },
+    {
       "name": "wget",
-      "path": "default"
-    },
-    {
-      "name": "tar",
-      "path": "default"
-    },
-    {
-      "name": "unzip",
-      "path": "default"
-    },
-    {
-      "name": "zip",
-      "path": "default"
-    },
-    {
-      "name": "gzip",
-      "path": "default"
-    },
-    {
-      "name": "xz",
       "path": "default"
     }
   ]

--- a/ansible/machine_audit/packages/windows
+++ b/ansible/machine_audit/packages/windows
@@ -2,7 +2,7 @@
   "build_packages": [
     {
       "name": "Java7",
-      "path": "C:\\Program Files\\Java\\java-se-7u75-ri"
+      "path": "C:\\openjdk\\jdk-7"
     },
     {
       "name": "JDK8",

--- a/ansible/machine_audit/packages/windows
+++ b/ansible/machine_audit/packages/windows
@@ -2,35 +2,51 @@
   "build_packages": [
     {
       "name": "Java7",
-      "path": "C:\\Program Files\\Java\\java-se-7u75-ri"
+      "path": "C:\\Program Files\\Java\\java-se-7u75-ri\\bin\\java"
     },
     {
       "name": "JDK8",
-      "path": "C:\\openjdk\\jdk-8\\bin\\java"
+      "path": "C:\\openjdk\\jdk-8\\bin\\java.exe"
     },
     {
       "name": "JDK10",
-      "path": "C:\\openjdk\\jdk-10\\bin\\java"
+      "path": "C:\\openjdk\\jdk-10\\bin\\java.exe"
     },
     {
       "name": "JDK11",
-      "path": "C:\\openjdk\\jdk-11\\bin\\java"
+      "path": "C:\\openjdk\\jdk-11\\bin\\java.exe"
     },
     {
       "name": "JDK17",
-      "path": "C:\\openjdk\\jdk-17\\bin\\java"
+      "path": "C:\\openjdk\\jdk-17\\bin\\java.exe"
     },
     {
       "name": "JDK21",
-      "path": "C:\\openjdk\\jdk-21\\bin\\java"
+      "path": "C:\\openjdk\\jdk-21\\bin\\java.exe"
     },
     {
       "name": "JDK24",
-      "path": "C:\\openjdk\\jdk-24\\bin\\java"
+      "path": "C:\\openjdk\\jdk-24\\bin\\java.exe"
     },
     {
       "name": "JDK25",
-      "path": "C:\\openjdk\\jdk-25\\bin\\java"
+      "path": "C:\\openjdk\\jdk-25\\bin\\java.exe"
+    },
+    {
+      "name": "MSVS_2013",
+      "path": "C:\\Program Files (x86)\\Microsoft Visual Studio 12.0"
+    },
+    {
+      "name": "MSVS_2017",
+      "path": "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community"
+    },
+    {
+      "name": "MSVS_2019",
+      "path": "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community"
+    },
+    {
+      "name": "MSVS_2022",
+      "path": "C:\\Program Files (x86)\\Microsoft Visual Studio\\2022"
     },
     {
       "name": "nmake",
@@ -41,21 +57,17 @@
       "path": "default"
     },
     {
-      "name": "git",
-      "path": "default"
-    },
-    {
       "name": "ant",
-      "path": "default"
-    },
-    {
-      "name": "cygwin",
       "path": "default"
     }
   ],
   "test_packages": [
     {
       "name": "perl",
+      "path": "default"
+    },
+    {
+      "name": "git",
       "path": "default"
     },
     {

--- a/ansible/machine_audit/packages/windows
+++ b/ansible/machine_audit/packages/windows
@@ -55,15 +55,15 @@
     {
       "name": "cmake",
       "path": "default"
-    },
-    {
-      "name": "ant",
-      "path": "default"
     }
   ],
   "test_packages": [
     {
       "name": "perl",
+      "path": "default"
+    },
+    {
+      "name": "ant",
       "path": "default"
     },
     {
@@ -84,18 +84,6 @@
     },
     {
       "name": "tar",
-      "path": "default"
-    },
-    {
-      "name": "7z",
-      "path": "default"
-    },
-    {
-      "name": "zip",
-      "path": "default"
-    },
-    {
-      "name": "unzip",
       "path": "default"
     }
   ]

--- a/ansible/machine_audit/packages/windows
+++ b/ansible/machine_audit/packages/windows
@@ -1,19 +1,90 @@
 {
   "build_packages": [
-    "nmake",
-    "cmake",
-    "git",
-    "ant",
-    "cygwin"
+    {
+      "name": "Java7",
+      "path": "C:\\Program Files\\Java\\java-se-7u75-ri"
+    },
+    {
+      "name": "JDK8",
+      "path": "C:\\openjdk\\jdk-8\\bin\\java"
+    },
+    {
+      "name": "JDK10",
+      "path": "C:\\openjdk\\jdk-10\\bin\\java"
+    },
+    {
+      "name": "JDK11",
+      "path": "C:\\openjdk\\jdk-11\\bin\\java"
+    },
+    {
+      "name": "JDK17",
+      "path": "C:\\openjdk\\jdk-17\\bin\\java"
+    },
+    {
+      "name": "JDK21",
+      "path": "C:\\openjdk\\jdk-21\\bin\\java"
+    },
+    {
+      "name": "JDK24",
+      "path": "C:\\openjdk\\jdk-24\\bin\\java"
+    },
+    {
+      "name": "JDK25",
+      "path": "C:\\openjdk\\jdk-25\\bin\\java"
+    },
+    {
+      "name": "nmake",
+      "path": "default"
+    },
+    {
+      "name": "cmake",
+      "path": "default"
+    },
+    {
+      "name": "git",
+      "path": "default"
+    },
+    {
+      "name": "ant",
+      "path": "default"
+    },
+    {
+      "name": "cygwin",
+      "path": "default"
+    }
   ],
   "test_packages": [
-    "perl",
-    "powershell",
-    "curl",
-    "wget",
-    "tar",
-    "7z",
-    "zip",
-    "unzip"
+    {
+      "name": "perl",
+      "path": "default"
+    },
+    {
+      "name": "powershell",
+      "path": "default"
+    },
+    {
+      "name": "curl",
+      "path": "default"
+    },
+    {
+      "name": "wget",
+      "path": "default"
+    },
+    {
+      "name": "tar",
+      "path": "default"
+    },
+    {
+      "name": "7z",
+      "path": "default"
+    },
+    {
+      "name": "zip",
+      "path": "default"
+    },
+    {
+      "name": "unzip",
+      "path": "default"
+    }
   ]
 }

--- a/ansible/machine_audit/packages/windows
+++ b/ansible/machine_audit/packages/windows
@@ -2,7 +2,7 @@
   "build_packages": [
     {
       "name": "Java7",
-      "path": "C:\\Program Files\\Java\\java-se-7u75-ri\\bin\\java"
+      "path": "C:\\Program Files\\Java\\java-se-7u75-ri"
     },
     {
       "name": "JDK8",

--- a/ansible/machine_audit/platform/aix.py
+++ b/ansible/machine_audit/platform/aix.py
@@ -100,16 +100,30 @@ def check_packages():
         'test_packages': {}
     }
     
-    for package in packages_data.get('build_packages', []):
-        path = shutil.which(package)
-        results['build_packages'][package] = {
+    for package_info in packages_data.get('build_packages', []):
+        package_name = package_info.get('name', package_info) if isinstance(package_info, dict) else package_info
+        package_path = package_info.get('path', 'default') if isinstance(package_info, dict) else 'default'
+        
+        if package_path != 'default' and os.path.isfile(package_path) and os.access(package_path, os.X_OK):
+            path = package_path
+        else:
+            path = shutil.which(package_name)
+        
+        results['build_packages'][package_name] = {
             'installed': path is not None,
             'path': path
         }
     
-    for package in packages_data.get('test_packages', []):
-        path = shutil.which(package)
-        results['test_packages'][package] = {
+    for package_info in packages_data.get('test_packages', []):
+        package_name = package_info.get('name', package_info) if isinstance(package_info, dict) else package_info
+        package_path = package_info.get('path', 'default') if isinstance(package_info, dict) else 'default'
+        
+        if package_path != 'default' and os.path.isfile(package_path) and os.access(package_path, os.X_OK):
+            path = package_path
+        else:
+            path = shutil.which(package_name)
+        
+        results['test_packages'][package_name] = {
             'installed': path is not None,
             'path': path
         }

--- a/ansible/machine_audit/platform/linux.py
+++ b/ansible/machine_audit/platform/linux.py
@@ -120,16 +120,30 @@ def check_packages():
         'test_packages': {}
     }
     
-    for package in packages_data.get('build_packages', []):
-        path = shutil.which(package)
-        results['build_packages'][package] = {
+    for package_info in packages_data.get('build_packages', []):
+        package_name = package_info.get('name', package_info) if isinstance(package_info, dict) else package_info
+        package_path = package_info.get('path', 'default') if isinstance(package_info, dict) else 'default'
+        
+        if package_path != 'default' and os.path.isfile(package_path) and os.access(package_path, os.X_OK):
+            path = package_path
+        else:
+            path = shutil.which(package_name)
+        
+        results['build_packages'][package_name] = {
             'installed': path is not None,
             'path': path
         }
     
-    for package in packages_data.get('test_packages', []):
-        path = shutil.which(package)
-        results['test_packages'][package] = {
+    for package_info in packages_data.get('test_packages', []):
+        package_name = package_info.get('name', package_info) if isinstance(package_info, dict) else package_info
+        package_path = package_info.get('path', 'default') if isinstance(package_info, dict) else 'default'
+        
+        if package_path != 'default' and os.path.isfile(package_path) and os.access(package_path, os.X_OK):
+            path = package_path
+        else:
+            path = shutil.which(package_name)
+        
+        results['test_packages'][package_name] = {
             'installed': path is not None,
             'path': path
         }

--- a/ansible/machine_audit/platform/windows.ps1
+++ b/ansible/machine_audit/platform/windows.ps1
@@ -66,12 +66,10 @@ function Test-PackageInstalled {
     
     $path = $null
     
-    # If a specific path is provided and it's not "default", check that path
     if ($PackagePath -ne "default" -and (Test-Path $PackagePath)) {
         $path = $PackagePath
     }
     else {
-        # Otherwise use Get-Command to find the package
         $path = Get-CommandPath -Command $Package
     }
     

--- a/ansible/machine_audit/platform/windows.ps1
+++ b/ansible/machine_audit/platform/windows.ps1
@@ -60,10 +60,21 @@ function Get-CommandPath {
 
 function Test-PackageInstalled {
     param(
-        [string]$Package
+        [string]$Package,
+        [string]$PackagePath = "default"
     )
     
-    $path = Get-CommandPath -Command $Package
+    $path = $null
+    
+    # If a specific path is provided and it's not "default", check that path
+    if ($PackagePath -ne "default" -and (Test-Path $PackagePath)) {
+        $path = $PackagePath
+    }
+    else {
+        # Otherwise use Get-Command to find the package
+        $path = Get-CommandPath -Command $Package
+    }
+    
     return @{
         installed = ($null -ne $path)
         path = $path
@@ -82,12 +93,28 @@ function Get-PackageInfo {
     try {
         $packagesData = Get-Content $packagesFile -Raw | ConvertFrom-Json
         
-        foreach ($package in $packagesData.build_packages) {
-            $results.build_packages[$package] = Test-PackageInstalled -Package $package
+        foreach ($packageInfo in $packagesData.build_packages) {
+            if ($packageInfo -is [string]) {
+                $packageName = $packageInfo
+                $packagePath = "default"
+            }
+            else {
+                $packageName = $packageInfo.name
+                $packagePath = $packageInfo.path
+            }
+            $results.build_packages[$packageName] = Test-PackageInstalled -Package $packageName -PackagePath $packagePath
         }
         
-        foreach ($package in $packagesData.test_packages) {
-            $results.test_packages[$package] = Test-PackageInstalled -Package $package
+        foreach ($packageInfo in $packagesData.test_packages) {
+            if ($packageInfo -is [string]) {
+                $packageName = $packageInfo
+                $packagePath = "default"
+            }
+            else {
+                $packageName = $packageInfo.name
+                $packagePath = $packageInfo.path
+            }
+            $results.test_packages[$packageName] = Test-PackageInstalled -Package $packageName -PackagePath $packagePath
         }
     }
     catch {
@@ -165,4 +192,3 @@ function Main {
 }
 
 Main
-


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

More work on https://github.com/adoptium/infrastructure/issues/4334
If theres a path specified then the scripts will search the path for the installed packages, else it will run a `which` command. Ive added suitable packages to the list for all platforms