### PR TITLE
unixPb: Retrieve infrastructure SHA from remote instead of locally

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/logs/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/logs/tasks/main.yml
@@ -12,7 +12,6 @@
 - name: Get Latest git commit SHA
   shell: git ls-remote https://github.com/adoptium/infrastructure.git HEAD | awk '{split($0,a," "); print a[1]}'
   register: git_output
-  delegate_to: localhost
   ignore_errors: yes
   when: git_sha is not defined
 

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/logs/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/logs/tasks/main.yml
@@ -10,7 +10,7 @@
   register: date_output
 
 - name: Get Latest git commit SHA
-  shell: git rev-parse HEAD
+  shell: git ls-remote https://github.com/adoptium/infrastructure.git HEAD | awk '{split($0,a," "); print a[1]}'
   register: git_output
   delegate_to: localhost
   ignore_errors: yes

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
@@ -22,7 +22,7 @@
   register: date_output
 
 - name: Get Latest git commit SHA
-  shell: git rev-parse HEAD
+  shell: git ls-remote https://github.com/adoptium/infrastructure.git HEAD | awk '{split($0,a," "); print a[1]}'
   register: git_output
   delegate_to: localhost
   ignore_errors: yes

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/logs/tasks/main.yml
@@ -24,7 +24,6 @@
 - name: Get Latest git commit SHA
   shell: git ls-remote https://github.com/adoptium/infrastructure.git HEAD | awk '{split($0,a," "); print a[1]}'
   register: git_output
-  delegate_to: localhost
   ignore_errors: yes
   when: git_sha is not defined
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/logs/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/logs/tasks/main.yml
@@ -12,7 +12,7 @@
 
 # Accounts for cases where playbook executor is windows and its executing on localhost
 - name: Get Latest git commit SHA (Windows local container)
-  win_command: C:\cygwin64\bin\git ls-remote https://github.com/adoptium/infrastructure.git HEAD | awk '{split($0,a," "); print a[1]}'
+  win_shell: C:\cygwin64\bin\git ls-remote https://github.com/adoptium/infrastructure.git HEAD | awk '{split($0,a," "); print a[1]}'
   register: git_output
   ignore_errors: yes
   when:
@@ -20,7 +20,7 @@
     - inventory_hostname == "localhost" or inventory_hostname == "127.0.0.1"
 
 - name: Get Latest git commit SHA (Windows remote)
-  win_command: C:\cygwin64\bin\git ls-remote https://github.com/adoptium/infrastructure.git HEAD | awk '{split($0,a," "); print a[1]}'
+  win_shell: C:\cygwin64\bin\git ls-remote https://github.com/adoptium/infrastructure.git HEAD | awk '{split($0,a," "); print a[1]}'
   register: git_output
   ignore_errors: yes
   when:

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/logs/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/logs/tasks/main.yml
@@ -12,7 +12,7 @@
 
 # Accounts for cases where playbook executor is windows and its executing on localhost
 - name: Get Latest git commit SHA (Windows local container)
-  win_shell: C:\cygwin64\bin\git ls-remote https://github.com/adoptium/infrastructure.git HEAD | awk '{split($0,a," "); print a[1]}'
+  win_shell: $(C:\cygwin64\bin\git ls-remote https://github.com/adoptium/infrastructure.git HEAD).Split("HEAD")[0]
   register: git_output
   ignore_errors: yes
   when:
@@ -20,7 +20,7 @@
     - inventory_hostname == "localhost" or inventory_hostname == "127.0.0.1"
 
 - name: Get Latest git commit SHA (Windows remote)
-  win_shell: C:\cygwin64\bin\git ls-remote https://github.com/adoptium/infrastructure.git HEAD | awk '{split($0,a," "); print a[1]}'
+  win_shell: $(C:\cygwin64\bin\git ls-remote https://github.com/adoptium/infrastructure.git HEAD).Split("HEAD")[0]
   register: git_output
   ignore_errors: yes
   when:

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/logs/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/logs/tasks/main.yml
@@ -29,7 +29,7 @@
 
 - name: Set git_output to git_sha
   set_fact:
-    git_sha: "{{ git_output.stdout }}"
+    git_sha: "{{ git_output.stdout | trim }}"
   when: git_sha is not defined
 
 - name: Update Log File

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/logs/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/logs/tasks/main.yml
@@ -20,9 +20,8 @@
     - inventory_hostname == "localhost" or inventory_hostname == "127.0.0.1"
 
 - name: Get Latest git commit SHA (Windows remote)
-  shell: git rev-parse HEAD
+  win_command: C:\cygwin64\bin\git ls-remote https://github.com/adoptium/infrastructure.git HEAD | awk '{split($0,a," "); print a[1]}'
   register: git_output
-  delegate_to: localhost
   ignore_errors: yes
   when:
     - git_sha is not defined

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/logs/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/logs/tasks/main.yml
@@ -12,7 +12,7 @@
 
 # Accounts for cases where playbook executor is windows and its executing on localhost
 - name: Get Latest git commit SHA (Windows local container)
-  win_command: C:\cygwin64\bin\git -C C:/infrastructure rev-parse HEAD
+  win_command: C:\cygwin64\bin\git ls-remote https://github.com/adoptium/infrastructure.git HEAD | awk '{split($0,a," "); print a[1]}'
   register: git_output
   ignore_errors: yes
   when:

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/logs/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/logs/tasks/main.yml
@@ -12,7 +12,7 @@
 
 # Accounts for cases where playbook executor is windows and its executing on localhost
 - name: Get Latest git commit SHA (Windows local container)
-  win_shell: $(C:\cygwin64\bin\git ls-remote https://github.com/adoptium/infrastructure.git HEAD).Split("HEAD")[0]
+  win_shell: $(C:\cygwin64\bin\git ls-remote https://github.com/adoptium/infrastructure.git HEAD).Split("")[0]
   register: git_output
   ignore_errors: yes
   when:
@@ -20,7 +20,7 @@
     - inventory_hostname == "localhost" or inventory_hostname == "127.0.0.1"
 
 - name: Get Latest git commit SHA (Windows remote)
-  win_shell: $(C:\cygwin64\bin\git ls-remote https://github.com/adoptium/infrastructure.git HEAD).Split("HEAD")[0]
+  win_shell: $(C:\cygwin64\bin\git ls-remote https://github.com/adoptium/infrastructure.git HEAD).Split("")[0]
   register: git_output
   ignore_errors: yes
   when:


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Fixes https://github.com/adoptium/infrastructure/issues/4144

Testing

- [x] Linux
- [x] AIX
- [x] Windows
