### PR TITLE
UnixPB: Remove Ansible FQNs For Compatibility

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adopt_syscfg/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adopt_syscfg/tasks/main.yml
@@ -5,7 +5,7 @@
 #########################
 
 - name: Set kernel.core_pattern in sysctl.conf
-  ansible.builtin.lineinfile:
+  lineinfile:
     path: /etc/sysctl.conf
     regexp: '^kernel\.core_pattern\s*='
     line: 'kernel.core_pattern = core.%p'
@@ -15,7 +15,7 @@
   tags: adoptopenjdk
 
 - name: Apply sysctl settings immediately
-  ansible.builtin.sysctl:
+  sysctl:
     name: kernel.core_pattern
     value: 'core.%p'
     state: present


### PR DESCRIPTION
Fixes #1829 

Fix New Adopt_Syscfg role to work with old versions of ansible, by removing fully qualified module names..


##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR

