### PR TITLE
tools: Machine audit scripts collect last executed playbook on machines

### DIFF
--- a/ansible/machine_audit/platform/aix.py
+++ b/ansible/machine_audit/platform/aix.py
@@ -164,7 +164,7 @@ def get_last_executed_playbook():
             return None
     
     except Exception as e:
-        
+
         return None
 
 def collect_info():
@@ -172,8 +172,8 @@ def collect_info():
         'timestamp': get_timestamp(),
         'hostname': get_hostname(),
         'os': get_os_info(),
-        'packages': check_packages(),
-        'last_executed_playbook': get_last_executed_playbook()
+        'last_executed_playbook': get_last_executed_playbook(),
+        'packages': check_packages()
     }
 
 def write_output(data):

--- a/ansible/machine_audit/platform/aix.py
+++ b/ansible/machine_audit/platform/aix.py
@@ -130,12 +130,50 @@ def check_packages():
     
     return results
 
+def get_last_executed_playbook():
+
+    log_file = '/var/log/ansible.log'
+    
+    try:
+        if not os.path.exists(log_file):
+            return None
+        
+        with open(log_file, 'rb') as f:
+            f.seek(0, os.SEEK_END)
+            file_size = f.tell()
+            
+            if file_size == 0:
+                return None
+            
+            buffer_size = min(1024, file_size)
+            f.seek(max(0, file_size - buffer_size), os.SEEK_SET)
+            lines = f.read().decode('utf-8', errors='ignore').splitlines()
+            
+            if not lines:
+                return None
+            
+            last_line = lines[-1].strip()
+            
+            parts = last_line.split()
+            if len(parts) >= 4:
+                date = parts[1]
+                time = parts[2]
+                sha = parts[3]
+                return f"{date} {time} {sha}"
+            
+            return None
+    
+    except Exception as e:
+        
+        return None
+
 def collect_info():
     return {
         'timestamp': get_timestamp(),
         'hostname': get_hostname(),
         'os': get_os_info(),
-        'packages': check_packages()
+        'packages': check_packages(),
+        'last_executed_playbook': get_last_executed_playbook()
     }
 
 def write_output(data):

--- a/ansible/machine_audit/platform/linux.py
+++ b/ansible/machine_audit/platform/linux.py
@@ -194,8 +194,8 @@ def collect_info():
         'timestamp': get_timestamp(),
         'hostname': get_hostname(),
         'os': get_os_info(),
-        'packages': check_packages(),
-        'last_executed_playbook': get_last_executed_playbook()
+        'last_executed_playbook': get_last_executed_playbook(),
+        'packages': check_packages()
     }
 
 def write_output(data):

--- a/ansible/machine_audit/platform/linux.py
+++ b/ansible/machine_audit/platform/linux.py
@@ -150,12 +150,52 @@ def check_packages():
     
     return results
 
+def get_last_executed_playbook():
+
+    log_file = '/var/log/ansible.log'
+    
+    try:
+        if not os.path.exists(log_file):
+            return None
+        
+        with open(log_file, 'rb') as f:
+
+            f.seek(0, os.SEEK_END)
+            file_size = f.tell()
+            
+            if file_size == 0:
+                return None
+            
+            buffer_size = min(1024, file_size)
+            f.seek(max(0, file_size - buffer_size), os.SEEK_SET)
+            lines = f.read().decode('utf-8', errors='ignore').splitlines()
+            
+            if not lines:
+                return None
+            
+            last_line = lines[-1].strip()
+            
+            parts = last_line.split()
+            if len(parts) >= 4:
+                
+                date = parts[1]
+                time = parts[2]
+                sha = parts[3]
+                return f"{date} {time} {sha}"
+            
+            return None
+    
+    except Exception as e:
+
+        return None
+
 def collect_info():
     return {
         'timestamp': get_timestamp(),
         'hostname': get_hostname(),
         'os': get_os_info(),
-        'packages': check_packages()
+        'packages': check_packages(),
+        'last_executed_playbook': get_last_executed_playbook()
     }
 
 def write_output(data):

--- a/ansible/machine_audit/platform/windows.ps1
+++ b/ansible/machine_audit/platform/windows.ps1
@@ -122,12 +122,42 @@ function Get-PackageInfo {
     return $results
 }
 
+function Get-LastExecutedPlaybook {
+
+    $logFile = "$HOME\ansible.log"
+    
+    try {
+        if (-not (Test-Path $logFile)) {
+            return $null
+        }
+        
+        $content = Get-Content $logFile -Tail 1 -ErrorAction Stop
+        
+        if (-not $content) {
+            return $null
+        }
+        
+        $parts = $content.Trim() -split '\s+'
+        
+        if ($parts.Count -ge 4) {
+            $date = $parts[1]
+            $time = $parts[2]
+            $sha = $parts[3]
+            return "$date $time $sha"
+        }
+        return $null
+    }
+    catch {
+        return $null
+    }
+}
 function Get-MachineInfo {
     return @{
         timestamp = Get-Timestamp
         hostname = Get-HostnameInfo
         os = Get-OSInfo
         packages = Get-PackageInfo
+        last_executed_playbook = Get-LastExecutedPlaybook
     }
 }
 

--- a/ansible/machine_audit/platform/windows.ps1
+++ b/ansible/machine_audit/platform/windows.ps1
@@ -156,8 +156,8 @@ function Get-MachineInfo {
         timestamp = Get-Timestamp
         hostname = Get-HostnameInfo
         os = Get-OSInfo
-        packages = Get-PackageInfo
         last_executed_playbook = Get-LastExecutedPlaybook
+        packages = Get-PackageInfo
     }
 }
 


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

re https://github.com/adoptium/infrastructure/issues/4334

Captures date time and Infra repo SHA from the local ansible log in /var/log/ansible.log (aix and linux) and $HOME/ansible.log (windows)
```
"last_executed_playbook": "2025-02-25 13:01:18 538a599ed6027747a95b4d0e298a16f591dbecff",
```

Example output
```
{
  "timestamp": "2026-05-13T12:52:31Z",
  "hostname": "test-osuosl-ubuntu2404-ppc64le-2.adoptopenjdk.net",
  "os": {
    "name": "Ubuntu",
    "version": "24.04.4 LTS (Noble Numbat)",
    "kernel": "6.8.0-40-generic",
    "architecture": "ppc64le"
  },
  "last_executed_playbook": "2025-02-25 13:01:18 538a599ed6027747a95b4d0e298a16f591dbecff",
  "packages": {
...
```
Testing

- [x] Linux
- [x] AIX
- [x] Windows