### PR TITLE
WinPB: Revert Cygwin Package Pin

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
@@ -29,46 +29,10 @@
   register: cygwin_download
   tags: cygwin
 
-- name: Retrieve Cygwin Package Cache
-  win_get_url:
-    url: "https://ci.adoptium.net/userContent/cygwin/cygwin_cache_20240825.zip"
-    dest: "C:\\temp\\cygwin_cache.zip"
-    force: no
-    checksum: "a2ec4dfbc67272312817228afb2bbff6f4ffc44df6088169ac11f191af00ec21"
-    checksum_algorithm: sha256
-  when: not cygwin_installed.stat.exists
-  register: cygwin_cache_download
-  tags: cygwin
-
-# Unzip Cygwin Cache
-- name: Unzip Cygwin Cache
-  win_unzip:
-    src: C:\TEMP\cygwin_cache.zip
-    dest: "{{ Cygwin_CACHE_DIR }}"
-  when: not cygwin_installed.stat.exists
-  tags: cygwin
-
-# Install strictly from the local cache (NO internet)
-# Change How The Args Are Parsed To Improve PS Interpretation
-- name: Install Cygwin From The Package Cache
+# Note: Gawk is pinned due to this upstream bug : https://bugs.openjdk.org/browse/JDK-8314555 GAWK for cygwin must be <= 5.3.2-1
+- name: Install Cygwin
   win_shell: |
-    $setup = 'C:\temp\cygwin.exe'
-    $list  = @(
-      '--quiet-mode',
-      '--local-install',
-      '--delete-orphans',
-      '--only-site',
-      '--no-verify',
-      '--no-version-check',
-      '--root', '{{ Cygwin_INST_DIR }}',
-      '--local-package-dir', '{{ Cygwin_CACHE_DIR }}',
-      '--site', 'file:///{{ Cygwin_CACHE_DIR_POSIX }}',
-      '--packages', 'autoconf,automake,bsdtar,cmake,cpio,curl,gcc-core,git,gnupg,gnupg2,grep,jq,libtool,make,mingw64-x86_64-gcc-core,perl,rsync,unzip,wget,zip'
-    ) | ForEach-Object { if ($_ -match '\s') { '"{0}"' -f $_ } else { $_ } }
-
-    $argString = $list -join ' '
-    $p = Start-Process -FilePath $setup -ArgumentList $argString -NoNewWindow -Wait -PassThru
-    if ($p.ExitCode -ne 0) { throw "Cygwin install from cache failed (exit $($p.ExitCode))" }
+      Start-Process -Wait -FilePath 'C:\temp\cygwin.exe' -ArgumentList '--packages autoconf,automake,bsdtar,cmake,cpio,curl,gawk=5.3.2-1,gcc-core,git,gnupg,gnupg2,grep,jq,libtool,make,mingw64-x86_64-gcc-core,perl,rsync,unzip,wget,zip --quiet-mode --download --local-install --delete-orphans --site https://mirrors.kernel.org/sourceware/cygwin/ --local-package-dir C:\cygwin_packages --root C:\cygwin64'
   args:
     executable: powershell
   when: not cygwin_installed.stat.exists


### PR DESCRIPTION
Reverts #4077 

Fixes #4288 

Need to check all jdk versions build with the current cygwin package sets....

Pin Gawk to v5.3.2-1 due to this upstream bug : https://bugs.openjdk.org/browse/JDK-8314555

All JDK versions (8,11,17,21,26) have built locally.. running VPC checks.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)

:heavy_check_mark: : Windows 2022 : JDK8 VPC Check : https://ci.adoptium.net/job/VagrantPlaybookCheck/2270/
:heavy_check_mark: Windows 2022 : JDK11 VPC Check : https://ci.adoptium.net/job/VagrantPlaybookCheck/2271/
:heavy_check_mark: : Windows 2022 : JDK17 VPC Check : https://ci.adoptium.net/job/VagrantPlaybookCheck/2272/
 : Windows 2022 : JDK21 VPC Check : https://ci.adoptium.net/job/VagrantPlaybookCheck/2274/
