### PR TITLE
WinPB: Playbook Fixes For Windows Docker Build Image Creation

### DIFF
--- a/ansible/docker/Dockerfile.win2022
+++ b/ansible/docker/Dockerfile.win2022
@@ -6,7 +6,7 @@ ARG PW=T3mp=Passwd
 # Download Cygwin Bootstrapper & Verify Its Checksum
 RUN powershell -Command \
     "wget -UseBasicParsing https://cygwin.com/setup-x86_64.exe -OutFile setup-x86_64.exe; \
-    $expectedChecksum = 'e7815d360ab098fdd1f03f10f43f363c73a632e8866e304c72573cf1e6a0dec8'; \
+    $expectedChecksum = '2c9f2fb56e1fb687b5d9680afa8f8b06e6214f0e483096af0eae1946431226c5'; \
     $fileChecksum = CertUtil -hashfile setup-x86_64.exe SHA256 | Select-String -Pattern '([A-Fa-f0-9]{64})' | ForEach-Object { $_.Matches[0].Groups[1].Value }; \
     if ($fileChecksum -ne $expectedChecksum) { \
         Write-Host 'Checksum verification failed!' -ForegroundColor Red; \
@@ -16,12 +16,87 @@ RUN powershell -Command \
         Write-Host 'Checksum verification succeeded!' -ForegroundColor Green; \
     }"
 
+# Download Cygwin Package Cache & Verify Checksum
+RUN powershell -Command \
+    "$url = 'https://ci.adoptium.net/userContent/cygwin/cygwin_cache_20260101.zip'; \
+    $dest = 'C:\\temp\\cygwin_cache.zip'; \
+    $expectedChecksum = 'c9c3d4d408718ec595583c821c7c8dc317d4f46db4536a8277e85e1717c0da7f'; \
+    if (-not (Test-Path 'C:\\cygwin64\\bin\\bash.exe')) { \
+        Write-Host 'Downloading Cygwin cache...' -ForegroundColor Cyan; \
+        New-Item -ItemType Directory -Force -Path 'C:\\temp' | Out-Null; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest -Uri $url -OutFile $dest -UseBasicParsing; \
+        Write-Host 'Verifying checksum...' -ForegroundColor Cyan; \
+        $fileChecksum = (Get-FileHash -Path $dest -Algorithm SHA256).Hash.ToLower(); \
+        if ($fileChecksum -ne $expectedChecksum) { \
+            Write-Host 'Checksum verification failed!' -ForegroundColor Red; \
+            Write-Host \"Expected: $expectedChecksum\" -ForegroundColor Red; \
+            Write-Host \"Got: $fileChecksum\" -ForegroundColor Red; \
+            Remove-Item $dest -Force; \
+            exit 1; \
+        } else { \
+            Write-Host 'Checksum verification succeeded!' -ForegroundColor Green; \
+        } \
+    } else { \
+        Write-Host 'Cygwin already installed, skipping cache download.' -ForegroundColor Yellow; \
+    }"
+
+# Unzip Cygwin Cache
+RUN powershell -Command \
+    "$src = 'C:\\temp\\cygwin_cache.zip'; \
+    $dest = $env:CYGWIN_CACHE_DIR; \
+    if (-not $dest) { $dest = 'C:\\cygwin_cache' }; \
+    if (-not (Test-Path 'C:\\cygwin64\\bin\\bash.exe')) { \
+        if (Test-Path $src) { \
+            Write-Host \"Extracting Cygwin cache to $dest...\" -ForegroundColor Cyan; \
+            New-Item -ItemType Directory -Force -Path $dest | Out-Null; \
+            Expand-Archive -Path $src -DestinationPath $dest -Force; \
+            Write-Host 'Cygwin cache extracted successfully!' -ForegroundColor Green; \
+        } else { \
+            Write-Host 'Cygwin cache zip file not found!' -ForegroundColor Red; \
+            exit 1; \
+        } \
+    } else { \
+        Write-Host 'Cygwin already installed, skipping cache extraction.' -ForegroundColor Yellow; \
+    }"
+
+
 # Set up cygwin with git and ansible as a bootstrap, and add to system default path
-RUN setup-x86_64.exe --packages git,ansible --download --local-install --delete-orphans --site https://mirrors.kernel.org/sourceware/cygwin --local-package-dir c:\cygwin_packages --root C:\cygwin64 --wait --quiet-mode & \
-    C:\cygwin64\bin\git config --system core.autocrlf false & \
-    del setup-x86_64.exe & \
-    setx PATH "c:\cygwin64\bin;%PATH%" & \
-    mkdir c:\temp
+# RUN setup-x86_64.exe --packages git,ansible --download --local-install --delete-orphans --site https://mirrors.kernel.org/sourceware/cygwin --local-package-dir c:\cygwin_packages --root C:\cygwin64 --wait --quiet-mode & \
+#    C:\cygwin64\bin\git config --system core.autocrlf false & \
+#    del setup-x86_64.exe & \
+#    setx PATH "c:\cygwin64\bin;%PATH%" & \
+#    mkdir c:\temp
+
+# Set up cygwin with git and ansible from package cache, and add to system default path
+RUN powershell -Command \
+    "$setup = 'C:\temp\setup-x86_64.exe'; \
+    if (-not (Test-Path $setup)) { \
+        Copy-Item 'setup-x86_64.exe' $setup; \
+    }; \
+    $args = @( \
+        '--quiet-mode', \
+        '--local-install', \
+        '--delete-orphans', \
+        '--only-site', \
+        '--no-verify', \
+        '--no-version-check', \
+        '--root', 'C:\cygwin64', \
+        '--local-package-dir', 'C:\cygwin_cache', \
+        '--site', 'file:///cygwin_cache', \
+        '--packages', 'git,ansible' \
+    ); \
+    Write-Host 'Installing Cygwin with git and ansible from package cache...' -ForegroundColor Cyan; \
+    $p = Start-Process -FilePath $setup -ArgumentList $args -NoNewWindow -Wait -PassThru; \
+    if ($p.ExitCode -ne 0) { \
+        Write-Host \"Cygwin install from cache failed (exit $($p.ExitCode))\" -ForegroundColor Red; \
+        exit 1; \
+    }; \
+    Write-Host 'Cygwin installation completed successfully!' -ForegroundColor Green;" && \
+    C:\cygwin64\bin\git config --system core.autocrlf false && \
+    del C:\temp\setup-x86_64.exe && \
+    setx PATH "c:\cygwin64\bin;%PATH%"
+
 
 # Download Ansible Config Script & Verify Its Checksum
 RUN powershell -Command \
@@ -46,12 +121,12 @@ RUN PowerShell .\ConfigureRemotingForAnsible.ps1 -CertValidityDays 9999 & \
 ENV TERM=dumb
 
 RUN net user ansible %PW% /ADD & net localgroup "Administrators" ansible /ADD & net localgroup "Remote Management Users" ansible /ADD & \
-    C:\cygwin64\bin\git clone https://github.com/sxa/infrastructure -b windows_docker_support c:/infrastructure & \
+    C:\cygwin64\bin\git clone https://github.com/adoptium/infrastructure -b master c:/infrastructure & \
     sed -i -e 's/hosts: .*/hosts: localhost/' infrastructure/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml & \
     echo localhost ansible_connection=winrm > infrastructure/ansible/hosts & \
     cd infrastructure\ansible & \
     C:\cygwin64\bin\python3.7m.exe /usr/bin/ansible-playbook -e git_sha=00000000 -e ansible_user=ansible -e ansible_password=%PW% -i hosts \
-    --skip-tags=adoptopenjdk,reboot,NTP_TIME,MSVS_2013,MSVS_2017,MSVS_2019 playbooks/AdoptOpenJDK_Windows_Playbook/main.yml & \
+    --skip-tags=adoptopenjdk,reboot,NTP_TIME,MSVS_2013,MSVS_2017,MSVS_2019,Windows_Updates playbooks/AdoptOpenJDK_Windows_Playbook/main.yml & \
     net user ansible /DELETE
 
 ENTRYPOINT ["C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\Common7\\Tools\\VsDevCmd.bat", "&&", "powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Incredibuild/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Incredibuild/tasks/main.yml
@@ -3,21 +3,32 @@
 # Incredibuild - Configuration Tasks  #
 #######################################
 
-- name: Check if the ibxbuild service exists
-  ansible.windows.win_service_info:
-    name: IBXDashboard
-  register: service_info
+- name: Check if the IBXDashboard service exists
+  win_shell: |
+    $service = Get-Service -Name IBXDashboard -ErrorAction SilentlyContinue
+    if ($service) { Write-Output "exists" } else { Write-Output "not_found" }
+  register: service_check
+  changed_when: false
+  failed_when: false
+  tags: IncrediBuild
+
+- name: Set service exists fact
+  set_fact:
+    service_exists: "{{ 'exists' in service_check.stdout }}"
+  tags: IncrediBuild
 
 - name: Stop the IBX Dashboard service if it exists
-  ansible.windows.win_service:
+  win_service:
     name: IBXDashboard
     state: stopped
-  when: service_info.exists
+  when: service_exists | bool
+  tags: IncrediBuild
 
 - name: Check if incredibuild.conf file exists
   win_stat:
     path: 'C:\Program Files (x86)\IncrediBuild\Dashboard\Apache24\conf\incredibuild.conf'
   register: incredibuild_conf_file
+  tags: IncrediBuild
 
 - name: Replace APACHE_PORT in incredibuild.conf if file exists
   win_lineinfile:
@@ -26,9 +37,11 @@
     line: 'define APACHE_PORT 31000'
     backup: yes
   when: incredibuild_conf_file.stat.exists
+  tags: IncrediBuild
 
 - name: Start the IBX Dashboard service if it exists
-  ansible.windows.win_service:
+  win_service:
     name: IBXDashboard
     state: started
-  when: service_info.exists
+  when: service_exists | bool
+  tags: IncrediBuild

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2022_REDIST/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2022_REDIST/tasks/main.yml
@@ -19,13 +19,13 @@
   tags: MSVS_2022_REDIST
 
 - name: Check if C:\openjdk\devkit exists
-  ansible.windows.win_stat:
+  win_stat:
     path: 'c:\openjdk\devkit'
   register: directory_status
   tags: MSVS_2022_REDIST
 
 - name: Create  C:\openjdk\devkit if it does not exist
-  ansible.windows.win_file:
+  win_file:
     path: 'c:\openjdk\devkit\'
     state: directory
   when: not directory_status.stat.exists
@@ -40,6 +40,7 @@
     checksum_algorithm: sha256
     dest: 'c:\openjdk\devkit\vs2022_redist_{{ wsdk_version }}.zip'
     force: no
+  when: not vs2022sdk_installed.stat.exists
   tags: MSVS_2022_REDIST
 
 - name: Unzip Visual Studio 2022 Redists

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/WiX/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/WiX/tasks/main.yml
@@ -58,7 +58,7 @@
 
 # Add WiX extensions for jpackage tests
 - name: Add WiX extensions
-  ansible.windows.win_shell: |
+  win_shell: |
     wix extension add -g WixToolset.Util.wixext/{{ wix_version }}
     wix extension add -g WixToolset.Ui.wixext/{{ wix_version }}
   register: wixext_add


### PR DESCRIPTION
Fixes #4353 

Make several fixes to the windows playbooks to ensure that the build of the Windows docker build image succeeds.

Also adjust the Windows 2022 dockerfile, to pin the cygwin package repository to the latest version that has ansible still available.

The docker build image job has successfully run with these changes in place.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR

