### PR TITLE
inventory: 2 new centosstream10 ppc64le test nodes

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -93,6 +93,8 @@ hosts:
           aix73-ppc64-1: {ip: 140.211.9.10, description: p8-aix1-adopt01.osuosl.org, 7300-01-02-2320}
           centos74-ppc64le-1: {ip: 140.211.168.228, user: centos}
           centos74-ppc64le-2: {ip: 140.211.168.217, user: centos}
+          centosstream10-ppc64le-1: {ip: 140.211.168.22, user: centos}
+          centosstream10-ppc64le-2: {ip: 140.211.168.48, user: centos}
           ubuntu2404-ppc64le-1: {ip: 140.211.10.70, user: ubuntu}
           ubuntu2404-ppc64le-2: {ip: 140.211.168.207, user: ubuntu}
           ubuntu2404-ppc64le-3: {ip: 140.211.168.177, user: ubuntu}


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Re https://github.com/adoptium/infrastructure/issues/4366, https://github.com/adoptium/infrastructure/issues/4333

These 2 nodes are going to replace the 2 test-osuosl-centos74-ppc64le nodes. Will remove them from the inventory soon