### PR TITLE
UnixPb: Update Test_Tool_Packages for ubuntu 26

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -43,6 +43,10 @@
 ############################
 # Build Packages and tools #
 ############################
+- name: Set qemu package name based on Ubuntu version
+  set_fact:
+    qemu_package: "{{ 'qemu-user-binfmt' if ansible_distribution_major_version == '26' else 'qemu-user-static' }}"
+
 - name: Call Build Packages and Tools Task
   include_tasks: build_packages_and_tools.yml
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
@@ -118,7 +118,7 @@ Test_Tool_Packages:
   - xauth
   - xvfb
   - binfmt-support
-  - qemu-user-static
+  - "{{ qemu_package }}"
   - unzip
   - libexpat1-dev
   - libcurl4-openssl-dev


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->
In ubuntu 26.04 qemu-user-static is not present. Instead we need to go for either qemu-user-binfmt or qemu-user-binfmt-hwe.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
