### PR TITLE
inventory: Add missing test-azure-win11-aarch64-3 to inventory

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -78,6 +78,7 @@ hosts:
           win2022-x64-4: {ip: 20.77.112.43, user: adoptopenjdk}
           win11-aarch64-1: {ip: 20.4.31.184, user: adoptopenjdk}
           win11-aarch64-2: {ip: 108.143.205.79, user: adoptopenjdk}
+          win11-aarch64-3: {ip: 4.231.23.141, user: adoptopenjdk}
 
       - aws:
           rhel76-armv8-1: {ip: 18.202.36.216, user: ec2-user}


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Not sure why test-azure-win11-aarch64-3 hasn't been included in the inventory.yml file. Its in jenkins and is used for tests