### PR TITLE
inventory: Remove build-digitalocean and 2 build azure windows nodes from inventory

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -31,11 +31,6 @@ hosts:
 
       - azure:
           win2022-x64-1: {ip: 172.187.129.163, user: adoptopenjdk}
-          win2022-x64-2: {ip: 172.187.176.15, user: adoptopenjdk}
-          win2022-x64-3: {ip: 51.142.8.47, user: adoptopenjdk}
-
-      - digitalocean:
-          centos69-x64-2: {ip: 167.71.130.191}
 
       - marist:
           rhel8-s390x-1: {ip: 148.100.75.98, user: linux1}


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

The build-digitalocean machine was decommissioned a short while ago, The build-azure-win nodes were removed to make way for the windows dockerhost machines