### PR TITLE
tools: Provide a new jenkins-scripts tool for global Jenkins config.xml logRotator updates to ensure necessary retention policy

### DIFF
--- a/tools/jenkins_scripts/LOG_ROTATOR_UPDATE.md
+++ b/tools/jenkins_scripts/LOG_ROTATOR_UPDATE.md
@@ -1,0 +1,303 @@
+# Jenkins logRotator Configuration Tool
+
+Safely configure logRotator settings in Jenkins job `config.xml` files.
+
+## Purpose
+
+This script ensures all Jenkins jobs have proper build retention policies configured:
+1. Sets `removeLastBuild=true` to allow deletion of the last build
+2. Ensures `daysToKeep` and `artifactDaysToKeep` are set (default: 365 days)
+3. Ensures `numToKeep` and `artifactNumToKeep` are set (default: 5 builds)
+4. Creates complete logRotator configuration for jobs that don't have one
+
+This prevents old builds from accumulating and consuming excessive memory/disk space.
+
+## Features
+
+- ✅ **Safe XML parsing** - Uses Python's built-in ElementTree with character entity preservation
+- ✅ **Automatic backups** - Creates backups preserving directory structure
+- ✅ **Pattern matching** - Supports glob and regex for job selection
+- ✅ **Dry-run mode** - Preview changes without modifying files
+- ✅ **Smart defaults** - Creates sensible retention policies
+- ✅ **Detailed reporting** - Shows exactly what changed per field
+- ✅ **Dual format support** - Handles both `<logRotator>` and `<jenkins.model.BuildDiscarderProperty>` formats
+- ✅ **Character entity preservation** - Maintains escaped characters like `&#xd;` in XML
+
+## Requirements
+
+- Python 3.6+
+- No external dependencies (uses only Python standard library)
+
+## Quick Start
+
+```bash
+# Test on single job
+python3 logRotatorUpdate.py /home/jenkins/.jenkins /backup/dir \
+    --pattern "my-job" \
+    --verbose \
+    --dry-run
+
+# Update all jobs
+python3 logRotatorUpdate.py /home/jenkins/.jenkins /backup/dir
+```
+
+## Command-Line Options
+
+| Option | Description |
+|--------|-------------|
+| `jenkins_home` | Path to JENKINS_HOME directory (required) |
+| `backup_dir` | Directory for backups (required) |
+| `--pattern PATTERN` | Process only jobs matching this pattern (glob or regex) |
+| `--dry-run` | Show changes without modifying files |
+| `--verbose` | Show detailed output for all jobs |
+| `--list-matches` | List all jobs (or matching jobs if pattern provided) without processing |
+
+## Configuration Rules
+
+The script applies these rules:
+
+1. **If logRotator exists:**
+   - Sets `daysToKeep=365` if missing/empty/-1
+   - Sets `artifactDaysToKeep=365` if missing/empty/-1
+   - Sets `numToKeep=5` if missing/empty/-1
+   - Sets `artifactNumToKeep=5` if missing/empty/-1
+   - Sets `removeLastBuild=true`
+
+2. **If logRotator doesn't exist:**
+   - Creates complete logRotator with:
+     - `daysToKeep=365`
+     - `numToKeep=5`
+     - `artifactDaysToKeep=365`
+     - `artifactNumToKeep=5`
+     - `removeLastBuild=true`
+
+## Pattern Examples
+
+```bash
+# Exact match
+--pattern "my-job"
+
+# Glob patterns
+--pattern "Test*"              # All jobs starting with Test
+--pattern "build-*"            # All jobs starting with build-
+
+# Regex patterns
+--pattern "Test.*"             # All jobs starting with Test
+--pattern ".*openjdk8.*"       # All jobs containing openjdk8
+--pattern "build-scripts/.*"   # All jobs in build-scripts folder
+```
+
+## Supported XML Formats
+
+The tool supports both current and legacy Jenkins XML formats:
+
+**Format 1: Direct logRotator (older Jenkins versions)**
+```xml
+<properties>
+  <logRotator>
+    <daysToKeep>365</daysToKeep>
+    <numToKeep>5</numToKeep>
+    <artifactDaysToKeep>365</artifactDaysToKeep>
+    <artifactNumToKeep>5</artifactNumToKeep>
+    <removeLastBuild>true</removeLastBuild>
+  </logRotator>
+</properties>
+```
+
+**Format 2: BuildDiscarderProperty (current Jenkins versions)**
+```xml
+<properties>
+  <jenkins.model.BuildDiscarderProperty>
+    <strategy class="hudson.tasks.LogRotator">
+      <daysToKeep>365</daysToKeep>
+      <numToKeep>5</numToKeep>
+      <artifactDaysToKeep>365</artifactDaysToKeep>
+      <artifactNumToKeep>5</artifactNumToKeep>
+      <removeLastBuild>true</removeLastBuild>
+    </strategy>
+  </jenkins.model.BuildDiscarderProperty>
+</properties>
+```
+
+Both formats are fully supported and will be updated appropriately.
+
+## XML Changes
+
+**Before (missing logRotator):**
+```xml
+<project>
+  <properties/>
+  <!-- No logRotator -->
+</project>
+```
+
+**After:**
+```xml
+<project>
+  <properties>
+    <jenkins.model.BuildDiscarderProperty>
+      <strategy class="hudson.tasks.LogRotator">
+        <daysToKeep>365</daysToKeep>
+        <numToKeep>5</numToKeep>
+        <artifactDaysToKeep>365</artifactDaysToKeep>
+        <artifactNumToKeep>5</artifactNumToKeep>
+        <removeLastBuild>true</removeLastBuild>
+      </strategy>
+    </jenkins.model.BuildDiscarderProperty>
+  </properties>
+</project>
+```
+
+## Output Indicators
+
+- ✅ Modified - Job was successfully updated
+- ✅ Created - New logRotator was created
+- ℹ️ No changes - Job already has correct configuration
+- ❌ Error - Problem processing job (e.g., multiple logRotators)
+
+## Example Output
+
+```
+================================================================================
+SUMMARY
+================================================================================
+Total: 150
+✅ Modified: 45
+✅ Created: 30 (new logRotator)
+⏭️  Skipped: 70 (no changes needed)
+❌ Errors: 5
+================================================================================
+
+FIELD STATISTICS
+================================================================================
+daysToKeep:
+  - Set to 365: 45 jobs
+  - Created with 365: 30 jobs
+  
+artifactDaysToKeep:
+  - Set to 365: 45 jobs
+  - Created with 365: 30 jobs
+
+numToKeep:
+  - Set to 5: 20 jobs
+  - Created with 5: 30 jobs
+
+removeLastBuild:
+  - Set to true: 75 jobs
+================================================================================
+```
+
+## Safety Features
+
+1. **Automatic Backups**: Backups created in separate directory preserving structure
+2. **Dry-run Mode**: Test changes without modifying files
+3. **Error Handling**: Graceful error handling per job
+4. **Skip Logic**: Skips jobs that don't need changes
+5. **Detailed Logging**: Shows exactly what changed per field
+6. **Character Preservation**: Maintains XML character entities like `&#xd;`
+7. **XML Version Preservation**: Keeps original XML version (1.0 or 1.1)
+
+## Character Entity Preservation
+
+The tool preserves XML character entities (like `&#xd;` for carriage return) by:
+1. Detecting and replacing them with unique placeholders before parsing
+2. Processing the XML normally
+3. Restoring the original entities after writing
+
+This ensures that special characters in descriptions and other fields remain exactly as they were.
+
+## Troubleshooting
+
+**Permission denied:**
+- Ensure write access to Jenkins job directories and backup directory
+- May need to run as Jenkins user or with sudo
+
+**Rollback:**
+```bash
+# Backups are in the backup directory preserving structure
+# Find backup
+ls -la /backup/dir/jobs/my-job/config.xml
+
+# Restore
+cp /backup/dir/jobs/my-job/config.xml \
+   /home/jenkins/.jenkins/jobs/my-job/config.xml
+```
+
+**Multiple logRotators error:**
+- Manual intervention required
+- Check config.xml for duplicate logRotator definitions
+- Remove duplicates manually
+
+## Post-Update Steps
+
+1. **Reload Jenkins**: Manage Jenkins → Reload Configuration from Disk
+2. **Verify Changes**: Check a few jobs in Jenkins UI to confirm settings
+3. **Monitor**: Watch for any issues after reload
+
+## Usage Examples
+
+### Basic Usage
+
+```bash
+# Update all jobs with defaults
+python3 logRotatorUpdate.py /home/jenkins/.jenkins /backup/jenkins
+
+# Dry-run to preview changes
+python3 logRotatorUpdate.py /home/jenkins/.jenkins /backup/jenkins --dry-run --verbose
+```
+
+### Pattern Matching
+
+```bash
+# Update only test jobs
+python3 logRotatorUpdate.py /home/jenkins/.jenkins /backup/jenkins --pattern "Test*"
+
+# Update jobs in specific folder
+python3 logRotatorUpdate.py /home/jenkins/.jenkins /backup/jenkins --pattern "build-scripts/.*"
+
+# List all jobs without processing
+python3 logRotatorUpdate.py /home/jenkins/.jenkins /backup/jenkins --list-matches
+
+# List only jobs matching a pattern without processing
+python3 logRotatorUpdate.py /home/jenkins/.jenkins /backup/jenkins --pattern "Test*" --list-matches
+```
+
+### Verbose Output
+
+```bash
+# See detailed changes for all jobs
+python3 logRotatorUpdate.py /home/jenkins/.jenkins /backup/jenkins --verbose
+
+# Combine with pattern and dry-run
+python3 logRotatorUpdate.py /home/jenkins/.jenkins /backup/jenkins \
+    --pattern "my-job" \
+    --verbose \
+    --dry-run
+```
+
+## Version History
+
+### v2.1.0 (Current)
+- Changed default retention from 30 to 365 days
+- Modified backup strategy to preserve directory structure
+- Enhanced summary statistics with per-field changes
+- Added character entity preservation (e.g., `&#xd;`)
+- Added XML version preservation (1.0 or 1.1)
+- Fixed `--list-matches` to work with or without pattern
+
+### v2.0.0
+- Added support for both logRotator formats
+- Removed archival logic (both formats are valid)
+- Enhanced field-level statistics
+
+### v1.0.0
+- Initial release
+- Support for direct `<logRotator>` format only
+
+## License
+
+Internal tool for Adoptium infrastructure management.
+
+## Author
+
+Adoptium Infrastructure Team

--- a/tools/jenkins_scripts/LOG_ROTATOR_UPDATE.md
+++ b/tools/jenkins_scripts/LOG_ROTATOR_UPDATE.md
@@ -6,9 +6,11 @@ Safely configure logRotator settings in Jenkins job `config.xml` files.
 
 This script ensures all Jenkins jobs have proper build retention policies configured:
 1. Sets `removeLastBuild=true` to allow deletion of the last build
-2. Ensures `daysToKeep` and `artifactDaysToKeep` are set (default: 365 days)
-3. Ensures `numToKeep` and `artifactNumToKeep` are set (default: 5 builds)
-4. Creates complete logRotator configuration for jobs that don't have one
+2. Ensures `daysToKeep` is set (default: 365 days)
+3. Ensures `numToKeep` is set (default: 5 builds)
+4. Creates complete logRotator configuration for jobs that don't have one (including artifact sub-policies)
+
+**Note:** Artifact retention settings (`artifactDaysToKeep`, `artifactNumToKeep`) are sub-policies of the basic settings and are only set when creating a new logRotator. Existing artifact settings are left unchanged as they may be intentionally configured differently.
 
 This prevents old builds from accumulating and consuming excessive memory/disk space.
 
@@ -58,53 +60,44 @@ The script applies these rules:
 
 1. **If logRotator exists:**
    - Sets `daysToKeep=365` if missing/empty/-1
-   - Sets `artifactDaysToKeep=365` if missing/empty/-1
    - Sets `numToKeep=5` if missing/empty/-1
-   - Sets `artifactNumToKeep=5` if missing/empty/-1
    - Sets `removeLastBuild=true`
+   - **Does NOT modify** `artifactDaysToKeep` or `artifactNumToKeep` (sub-policies, may be intentionally different)
 
 2. **If logRotator doesn't exist:**
-   - Creates complete logRotator with:
+   - Creates complete logRotator with all settings:
      - `daysToKeep=365`
      - `numToKeep=5`
-     - `artifactDaysToKeep=365`
-     - `artifactNumToKeep=5`
+     - `artifactDaysToKeep=365` (sub-policy)
+     - `artifactNumToKeep=5` (sub-policy)
      - `removeLastBuild=true`
 
 ## Pattern Examples
 
+Patterns match against the filesystem path structure. Jenkins stores folders as `jobs/<folder>/jobs/<job>`, so patterns must account for this structure.
+
 ```bash
-# Exact match
+# Exact match (top-level job)
 --pattern "my-job"
 
 # Glob patterns
---pattern "Test*"              # All jobs starting with Test
---pattern "build-*"            # All jobs starting with build-
+--pattern "Test*"                    # All top-level jobs starting with Test
+--pattern "build-*"                  # All top-level jobs starting with build-
 
 # Regex patterns
---pattern "Test.*"             # All jobs starting with Test
---pattern ".*openjdk8.*"       # All jobs containing openjdk8
---pattern "build-scripts/.*"   # All jobs in build-scripts folder
+--pattern "Test.*"                   # All top-level jobs starting with Test
+--pattern ".*openjdk8.*"             # All jobs containing openjdk8 (any level)
+--pattern "folder/jobs/.*"           # All jobs in "folder" (filesystem structure)
+--pattern "build-scripts/jobs/.*"    # All jobs in "build-scripts" folder
 ```
+
+**Note:** Patterns match the filesystem path relative to `JENKINS_HOME/jobs/`. For jobs in folders, the path includes `/jobs/` directories (e.g., `folder/jobs/job-name`).
 
 ## Supported XML Formats
 
 The tool supports both current and legacy Jenkins XML formats:
 
-**Format 1: Direct logRotator (older Jenkins versions)**
-```xml
-<properties>
-  <logRotator>
-    <daysToKeep>365</daysToKeep>
-    <numToKeep>5</numToKeep>
-    <artifactDaysToKeep>365</artifactDaysToKeep>
-    <artifactNumToKeep>5</artifactNumToKeep>
-    <removeLastBuild>true</removeLastBuild>
-  </logRotator>
-</properties>
-```
-
-**Format 2: BuildDiscarderProperty (current Jenkins versions)**
+**Format 1: BuildDiscarderProperty (current Jenkins standard)**
 ```xml
 <properties>
   <jenkins.model.BuildDiscarderProperty>
@@ -119,7 +112,20 @@ The tool supports both current and legacy Jenkins XML formats:
 </properties>
 ```
 
-Both formats are fully supported and will be updated appropriately.
+**Format 2: Direct logRotator (legacy format)**
+```xml
+<properties>
+  <logRotator>
+    <daysToKeep>365</daysToKeep>
+    <numToKeep>5</numToKeep>
+    <artifactDaysToKeep>365</artifactDaysToKeep>
+    <artifactNumToKeep>5</artifactNumToKeep>
+    <removeLastBuild>true</removeLastBuild>
+  </logRotator>
+</properties>
+```
+
+Both formats are fully supported and will be updated appropriately. When creating a new logRotator (if none exists), the tool uses the current BuildDiscarderProperty format.
 
 ## XML Changes
 

--- a/tools/jenkins_scripts/README.md
+++ b/tools/jenkins_scripts/README.md
@@ -1,0 +1,164 @@
+# Jenkins Scripts
+
+Collection of utility scripts for managing Jenkins configurations and infrastructure.
+
+## Available Tools
+
+### logRotatorUpdate.py
+
+Configure build retention policies (logRotator settings) in Jenkins job config.xml files.
+
+**Key Features:**
+- Sets build retention policies (days to keep, number to keep)
+- Supports both XML formats (direct logRotator and BuildDiscarderProperty)
+- Automatic backups with directory structure preservation
+- Pattern matching for selective job updates
+- Dry-run mode for safe testing
+- Character entity preservation in XML
+
+**Quick Start:**
+```bash
+# Update all jobs
+python3 logRotatorUpdate.py /home/jenkins/.jenkins /backup/dir
+
+# Test on specific jobs
+python3 logRotatorUpdate.py /home/jenkins/.jenkins /backup/dir \
+    --pattern "Test*" --dry-run --verbose
+```
+
+**[Full Documentation →](LOG_ROTATOR_UPDATE.md)**
+
+## Requirements
+
+All scripts require:
+- Python 3.6+
+- No external dependencies (uses only Python standard library)
+
+## Common Features
+
+- **Safe Operations**: All tools include dry-run modes and automatic backups
+- **Pattern Matching**: Support for glob and regex patterns to target specific jobs
+- **Detailed Reporting**: Clear output showing what changed and why
+- **Error Handling**: Graceful error handling with detailed error messages
+
+## Installation
+
+No installation required. Scripts can be run directly:
+
+```bash
+# Clone or download the scripts
+cd /path/to/jenkins_scripts
+
+# Run any script
+python3 logRotatorUpdate.py --help
+```
+
+## Usage Patterns
+
+### Dry-Run First
+Always test changes with `--dry-run` before applying:
+```bash
+python3 logRotatorUpdate.py /home/jenkins/.jenkins /backup/dir \
+    --pattern "my-jobs*" --dry-run --verbose
+```
+
+### Pattern Matching
+Use patterns to target specific jobs:
+```bash
+# Glob patterns
+--pattern "Test*"              # Jobs starting with Test
+--pattern "build-*"            # Jobs starting with build-
+
+# Regex patterns  
+--pattern ".*openjdk8.*"       # Jobs containing openjdk8
+--pattern "folder/.*"          # Jobs in specific folder
+```
+
+### List Matching Jobs
+Preview which jobs match your pattern:
+```bash
+python3 logRotatorUpdate.py /home/jenkins/.jenkins /backup/dir \
+    --pattern "Test*" --list-matches
+```
+
+## Post-Update Steps
+
+After running any script that modifies Jenkins configurations:
+
+1. **Reload Jenkins Configuration**
+   - Navigate to: Manage Jenkins → Reload Configuration from Disk
+   - Or use Jenkins CLI: `java -jar jenkins-cli.jar -s http://jenkins reload-configuration`
+
+2. **Verify Changes**
+   - Check a few jobs in Jenkins UI to confirm settings
+   - Review the script output for any errors
+
+3. **Monitor**
+   - Watch Jenkins logs for any issues
+   - Check job execution after changes
+
+## Backup and Recovery
+
+All scripts create backups before making changes:
+
+```bash
+# Backups preserve directory structure
+/backup/dir/
+  └── jobs/
+      └── my-job/
+          └── config.xml
+
+# Restore from backup
+cp /backup/dir/jobs/my-job/config.xml \
+   /home/jenkins/.jenkins/jobs/my-job/config.xml
+
+# Then reload Jenkins configuration
+```
+
+## Troubleshooting
+
+### Permission Denied
+- Ensure write access to Jenkins directories and backup directory
+- May need to run as Jenkins user: `sudo -u jenkins python3 script.py ...`
+- Or with sudo: `sudo python3 script.py ...`
+
+### Script Errors
+- Check Python version: `python3 --version` (requires 3.6+)
+- Verify paths are correct and accessible
+- Use `--verbose` flag for detailed output
+- Check script output for specific error messages
+
+### Jenkins Not Reflecting Changes
+- Reload Jenkins configuration from disk
+- Check file permissions on modified config.xml files
+- Verify XML is well-formed (scripts validate before writing)
+
+## Contributing
+
+When adding new scripts to this collection:
+
+1. Follow the established patterns (dry-run, backups, pattern matching)
+2. Use only Python standard library (no external dependencies)
+3. Include comprehensive documentation
+4. Add usage examples
+5. Update this README with a summary and link to detailed docs
+
+## Version History
+
+See individual tool documentation for version history:
+- [logRotatorUpdate.py versions](LOG_ROTATOR_UPDATE.md#version-history)
+
+## License
+
+Internal tools for Adoptium infrastructure management.
+
+## Author
+
+Adoptium Infrastructure Team
+
+## Support
+
+For issues or questions:
+- Check the detailed documentation for each tool
+- Review troubleshooting sections
+- Contact the Adoptium Infrastructure Team

--- a/tools/jenkins_scripts/README.md
+++ b/tools/jenkins_scripts/README.md
@@ -63,16 +63,19 @@ python3 logRotatorUpdate.py /home/jenkins/.jenkins /backup/dir \
 ```
 
 ### Pattern Matching
-Use patterns to target specific jobs:
+Use patterns to target specific jobs. Patterns match the filesystem path structure (Jenkins stores folders as `jobs/<folder>/jobs/<job>`):
+
 ```bash
 # Glob patterns
---pattern "Test*"              # Jobs starting with Test
---pattern "build-*"            # Jobs starting with build-
+--pattern "Test*"                 # Top-level jobs starting with Test
+--pattern "build-*"               # Top-level jobs starting with build-
 
-# Regex patterns  
---pattern ".*openjdk8.*"       # Jobs containing openjdk8
---pattern "folder/.*"          # Jobs in specific folder
+# Regex patterns
+--pattern ".*openjdk8.*"          # Jobs containing openjdk8 (any level)
+--pattern "folder/jobs/.*"        # Jobs in "folder" (filesystem structure)
 ```
+
+**Note:** For jobs in folders, patterns must include `/jobs/` directories (e.g., `folder/jobs/job-name`).
 
 ### List Matching Jobs
 Preview which jobs match your pattern:

--- a/tools/jenkins_scripts/logRotatorUpdate.py
+++ b/tools/jenkins_scripts/logRotatorUpdate.py
@@ -28,6 +28,13 @@ import re
 import fnmatch
 import uuid
 
+# Default logRotator configuration values
+DEFAULT_DAYS_TO_KEEP = 365
+DEFAULT_NUM_TO_KEEP = 5
+DEFAULT_ARTIFACT_DAYS_TO_KEEP = 365
+DEFAULT_ARTIFACT_NUM_TO_KEEP = 5
+DEFAULT_REMOVE_LAST_BUILD = 'true'
+
 def backup_file(config_path, backup_dir, jenkins_home):
     """
     Create a backup of the config file preserving directory structure.
@@ -105,11 +112,11 @@ def create_logrotator(root):
     logrotator = ET.SubElement(properties, 'logRotator')
     
     # Set default values
-    ET.SubElement(logrotator, 'daysToKeep').text = '365'
-    ET.SubElement(logrotator, 'numToKeep').text = '5'
-    ET.SubElement(logrotator, 'artifactDaysToKeep').text = '365'
-    ET.SubElement(logrotator, 'artifactNumToKeep').text = '5'
-    ET.SubElement(logrotator, 'removeLastBuild').text = 'true'
+    ET.SubElement(logrotator, 'daysToKeep').text = str(DEFAULT_DAYS_TO_KEEP)
+    ET.SubElement(logrotator, 'numToKeep').text = str(DEFAULT_NUM_TO_KEEP)
+    ET.SubElement(logrotator, 'artifactDaysToKeep').text = str(DEFAULT_ARTIFACT_DAYS_TO_KEEP)
+    ET.SubElement(logrotator, 'artifactNumToKeep').text = str(DEFAULT_ARTIFACT_NUM_TO_KEEP)
+    ET.SubElement(logrotator, 'removeLastBuild').text = DEFAULT_REMOVE_LAST_BUILD
     
     return logrotator, 'direct'
 
@@ -167,7 +174,10 @@ def configure_logrotator(config_path, backup_dir, jenkins_home, dry_run=False):
                 xml_version = '1.1'
         
         # Find and replace character entities with unique placeholders
-        # Pattern matches &#x followed by hex digits and semicolon
+        # This is necessary because some job descriptions contain escape characters
+        # for things like newline (&#xd;), which ElementTree would decode during parsing
+        # and not re-encode when writing, causing them to become literal characters.
+        # Pattern matches &#x followed by hex digits and semicolon (e.g., &#xd; &#xa;)
         entity_pattern = re.compile(r'&#x([0-9a-fA-F]+);')
         entity_map = {}  # Maps placeholder to original entity
         
@@ -209,11 +219,11 @@ def configure_logrotator(config_path, backup_dir, jenkins_home, dry_run=False):
             
             # Record after state
             result['after'] = {
-                'daysToKeep': '365',
-                'numToKeep': '5',
-                'artifactDaysToKeep': '365',
-                'artifactNumToKeep': '5',
-                'removeLastBuild': 'true'
+                'daysToKeep': str(DEFAULT_DAYS_TO_KEEP),
+                'numToKeep': str(DEFAULT_NUM_TO_KEEP),
+                'artifactDaysToKeep': str(DEFAULT_ARTIFACT_DAYS_TO_KEEP),
+                'artifactNumToKeep': str(DEFAULT_ARTIFACT_NUM_TO_KEEP),
+                'removeLastBuild': DEFAULT_REMOVE_LAST_BUILD
             }
         elif len(logrotators) == 1:
             # Single logRotator - update it
@@ -226,35 +236,35 @@ def configure_logrotator(config_path, backup_dir, jenkins_home, dry_run=False):
                 result['before'][field] = elem.text if elem is not None else None
             
             # Ensure daysToKeep and artifactDaysToKeep have values
-            days_changed, days_action = ensure_element(logrotator, 'daysToKeep', 365)
+            days_changed, days_action = ensure_element(logrotator, 'daysToKeep', DEFAULT_DAYS_TO_KEEP)
             if days_changed:
                 result['modified'] = True
-                result['changes'].append(f'daysToKeep {days_action}: 365')
+                result['changes'].append(f'daysToKeep {days_action}: {DEFAULT_DAYS_TO_KEEP}')
             
-            artifact_days_changed, artifact_days_action = ensure_element(logrotator, 'artifactDaysToKeep', 365)
+            artifact_days_changed, artifact_days_action = ensure_element(logrotator, 'artifactDaysToKeep', DEFAULT_ARTIFACT_DAYS_TO_KEEP)
             if artifact_days_changed:
                 result['modified'] = True
-                result['changes'].append(f'artifactDaysToKeep {artifact_days_action}: 365')
+                result['changes'].append(f'artifactDaysToKeep {artifact_days_action}: {DEFAULT_ARTIFACT_DAYS_TO_KEEP}')
             
             # Ensure numToKeep and artifactNumToKeep exist
-            num_changed, num_action = ensure_element(logrotator, 'numToKeep', 5)
+            num_changed, num_action = ensure_element(logrotator, 'numToKeep', DEFAULT_NUM_TO_KEEP)
             if num_changed:
                 result['modified'] = True
-                result['changes'].append(f'numToKeep {num_action}: 5')
+                result['changes'].append(f'numToKeep {num_action}: {DEFAULT_NUM_TO_KEEP}')
             
-            artifact_num_changed, artifact_num_action = ensure_element(logrotator, 'artifactNumToKeep', 5)
+            artifact_num_changed, artifact_num_action = ensure_element(logrotator, 'artifactNumToKeep', DEFAULT_ARTIFACT_NUM_TO_KEEP)
             if artifact_num_changed:
                 result['modified'] = True
-                result['changes'].append(f'artifactNumToKeep {artifact_num_action}: 5')
+                result['changes'].append(f'artifactNumToKeep {artifact_num_action}: {DEFAULT_ARTIFACT_NUM_TO_KEEP}')
             
             # Set removeLastBuild=true
             remove_last_build = logrotator.find('removeLastBuild')
             
             if remove_last_build is not None:
-                if remove_last_build.text != 'true':
-                    remove_last_build.text = 'true'
+                if remove_last_build.text != DEFAULT_REMOVE_LAST_BUILD:
+                    remove_last_build.text = DEFAULT_REMOVE_LAST_BUILD
                     result['modified'] = True
-                    result['changes'].append('removeLastBuild set to true')
+                    result['changes'].append(f'removeLastBuild set to {DEFAULT_REMOVE_LAST_BUILD}')
             else:
                 # Add new element after artifactNumToKeep
                 artifact_num = logrotator.find('artifactNumToKeep')
@@ -262,11 +272,11 @@ def configure_logrotator(config_path, backup_dir, jenkins_home, dry_run=False):
                     children = list(logrotator)
                     index = children.index(artifact_num) + 1
                     remove_last_build = ET.Element('removeLastBuild')
-                    remove_last_build.text = 'true'
+                    remove_last_build.text = DEFAULT_REMOVE_LAST_BUILD
                     logrotator.insert(index, remove_last_build)
                 else:
                     remove_last_build = ET.SubElement(logrotator, 'removeLastBuild')
-                    remove_last_build.text = 'true'
+                    remove_last_build.text = DEFAULT_REMOVE_LAST_BUILD
                 
                 result['modified'] = True
                 result['changes'].append('removeLastBuild created: true')

--- a/tools/jenkins_scripts/logRotatorUpdate.py
+++ b/tools/jenkins_scripts/logRotatorUpdate.py
@@ -7,7 +7,7 @@ Supports both <logRotator> and <jenkins.model.BuildDiscarderProperty> formats.
 
 Features:
 1. Set removeLastBuild=true
-2. Ensure daysToKeep and artifactDaysToKeep are set (default: 30)
+2. Ensure daysToKeep and artifactDaysToKeep are set (default: 365)
 3. Create logRotator if missing with sensible defaults
 4. Validate only one logRotator definition exists
 5. Support both XML formats (direct logRotator and BuildDiscarderProperty)

--- a/tools/jenkins_scripts/logRotatorUpdate.py
+++ b/tools/jenkins_scripts/logRotatorUpdate.py
@@ -262,15 +262,24 @@ def configure_logrotator(config_path, backup_dir, jenkins_home, dry_run=False):
                     result['modified'] = True
                     result['changes'].append(f'removeLastBuild set to {DEFAULT_REMOVE_LAST_BUILD}')
             else:
-                # Add new element after numToKeep
-                num_keep = logrotator.find('numToKeep')
-                if num_keep is not None:
+                # Add new element maintaining proper order:
+                # daysToKeep, numToKeep, artifactDaysToKeep, artifactNumToKeep, removeLastBuild
+                # Insert after the last existing element in the sequence
+                insert_after = None
+                for field in ['artifactNumToKeep', 'artifactDaysToKeep', 'numToKeep', 'daysToKeep']:
+                    elem = logrotator.find(field)
+                    if elem is not None:
+                        insert_after = elem
+                        break
+                
+                if insert_after is not None:
                     children = list(logrotator)
-                    index = children.index(num_keep) + 1
+                    index = children.index(insert_after) + 1
                     remove_last_build = ET.Element('removeLastBuild')
                     remove_last_build.text = DEFAULT_REMOVE_LAST_BUILD
                     logrotator.insert(index, remove_last_build)
                 else:
+                    # Fallback: append at end
                     remove_last_build = ET.SubElement(logrotator, 'removeLastBuild')
                     remove_last_build.text = DEFAULT_REMOVE_LAST_BUILD
                 

--- a/tools/jenkins_scripts/logRotatorUpdate.py
+++ b/tools/jenkins_scripts/logRotatorUpdate.py
@@ -22,7 +22,6 @@ Version: 2.1.0
 import os
 import sys
 import xml.etree.ElementTree as ET
-from datetime import datetime
 import argparse
 import re
 import fnmatch
@@ -57,8 +56,8 @@ def backup_file(config_path, backup_dir, jenkins_home):
     os.makedirs(os.path.dirname(backup_path), exist_ok=True)
     
     # Copy file
-    with open(config_path, 'r') as src:
-        with open(backup_path, 'w') as dst:
+    with open(config_path, 'rb') as src:
+        with open(backup_path, 'wb') as dst:
             dst.write(src.read())
     
     return backup_path
@@ -98,27 +97,30 @@ def ensure_element(parent, tag, default_value):
         elem = ET.SubElement(parent, tag)
         elem.text = str(default_value)
         return True, 'created'
-    elif elem.text is None or elem.text.strip() == '' or elem.text == '-1':
+    elif elem.text is None or elem.text.strip() == '' or elem.text.strip() == '-1':
         elem.text = str(default_value)
         return True, 'set'
     return False, 'unchanged'
 
 def create_logrotator(root):
-    """Create a new logRotator element (direct format under properties)."""
+    """Create a new logRotator using BuildDiscarderProperty format (current Jenkins standard)."""
     properties = root.find('properties')
     if properties is None:
         properties = ET.SubElement(root, 'properties')
     
-    logrotator = ET.SubElement(properties, 'logRotator')
+    # Create BuildDiscarderProperty wrapper (current format)
+    build_discarder = ET.SubElement(properties, 'jenkins.model.BuildDiscarderProperty')
+    strategy = ET.SubElement(build_discarder, 'strategy')
+    strategy.set('class', 'hudson.tasks.LogRotator')
     
     # Set default values
-    ET.SubElement(logrotator, 'daysToKeep').text = str(DEFAULT_DAYS_TO_KEEP)
-    ET.SubElement(logrotator, 'numToKeep').text = str(DEFAULT_NUM_TO_KEEP)
-    ET.SubElement(logrotator, 'artifactDaysToKeep').text = str(DEFAULT_ARTIFACT_DAYS_TO_KEEP)
-    ET.SubElement(logrotator, 'artifactNumToKeep').text = str(DEFAULT_ARTIFACT_NUM_TO_KEEP)
-    ET.SubElement(logrotator, 'removeLastBuild').text = DEFAULT_REMOVE_LAST_BUILD
+    ET.SubElement(strategy, 'daysToKeep').text = str(DEFAULT_DAYS_TO_KEEP)
+    ET.SubElement(strategy, 'numToKeep').text = str(DEFAULT_NUM_TO_KEEP)
+    ET.SubElement(strategy, 'artifactDaysToKeep').text = str(DEFAULT_ARTIFACT_DAYS_TO_KEEP)
+    ET.SubElement(strategy, 'artifactNumToKeep').text = str(DEFAULT_ARTIFACT_NUM_TO_KEEP)
+    ET.SubElement(strategy, 'removeLastBuild').text = DEFAULT_REMOVE_LAST_BUILD
     
-    return logrotator, 'direct'
+    return strategy, 'BuildDiscarderProperty'
 
 def validate_single_logrotator(root):
     """
@@ -175,36 +177,40 @@ def configure_logrotator(config_path, backup_dir, jenkins_home, dry_run=False):
         
         # Find and replace character entities with unique placeholders
         # This is necessary because some job descriptions contain escape characters
-        # for things like newline (&#xd;), which ElementTree would decode during parsing
+        # for things like newline (&#xd; or &#13;), which ElementTree would decode during parsing
         # and not re-encode when writing, causing them to become literal characters.
-        # Pattern matches &#x followed by hex digits and semicolon (e.g., &#xd; &#xa;)
-        entity_pattern = re.compile(r'&#x([0-9a-fA-F]+);')
-        entity_map = {}  # Maps placeholder to original entity
+        # Pattern matches both hex (&#xHH;) and decimal (&#DDD;) numeric character references
+        entity_pattern = re.compile(r'&#x?[0-9a-fA-F]+;')
+        entity_map = {}  # Maps entity to placeholder for O(1) lookup
+        entity_to_placeholder = {}  # Reverse map for restoration
         
         def replace_entity(match):
-            entity = match.group(0)  # e.g., '&#xd;'
-            if entity not in entity_map:
+            entity = match.group(0)  # e.g., '&#xd;' or '&#13;'
+            if entity not in entity_to_placeholder:
                 # Create unique placeholder that won't appear in XML
-                placeholder = f'__XMLENTITY_{uuid.uuid4().hex[:8]}_{match.group(1)}__'
+                # Use entity value in placeholder for debugging
+                placeholder = f'__XMLENTITY_{uuid.uuid4().hex[:8]}__'
+                entity_to_placeholder[entity] = placeholder
                 entity_map[placeholder] = entity
-            else:
-                # Find existing placeholder for this entity
-                placeholder = [k for k, v in entity_map.items() if v == entity][0]
-            return placeholder
+            return entity_to_placeholder[entity]
         
         modified_content = entity_pattern.sub(replace_entity, original_content)
         
-        # Write temporary file with placeholders
-        temp_path = config_path + '.tmp'
-        with open(temp_path, 'w', encoding='utf-8') as f:
-            f.write(modified_content)
+        # Create unique temporary file to avoid conflicts with concurrent runs
+        temp_path = f"{config_path}.tmp.{uuid.uuid4().hex[:8]}"
         
-        # Parse XML from temporary file
-        tree = ET.parse(temp_path)
-        root = tree.getroot()
-        
-        # Clean up temp file
-        os.remove(temp_path)
+        try:
+            # Write temporary file with placeholders
+            with open(temp_path, 'w', encoding='utf-8') as f:
+                f.write(modified_content)
+            
+            # Parse XML from temporary file
+            tree = ET.parse(temp_path)
+            root = tree.getroot()
+        finally:
+            # Always clean up temp file, even if parsing fails
+            if os.path.exists(temp_path):
+                os.remove(temp_path)
         
         # Find all logRotator elements (both formats)
         logrotators = find_all_logrotators(root)
@@ -235,27 +241,17 @@ def configure_logrotator(config_path, backup_dir, jenkins_home, dry_run=False):
                 elem = logrotator.find(field)
                 result['before'][field] = elem.text if elem is not None else None
             
-            # Ensure daysToKeep and artifactDaysToKeep have values
+            # Ensure basic retention settings have values (daysToKeep and numToKeep)
+            # Note: Artifact settings are sub-policies and should not be modified if they exist
             days_changed, days_action = ensure_element(logrotator, 'daysToKeep', DEFAULT_DAYS_TO_KEEP)
             if days_changed:
                 result['modified'] = True
                 result['changes'].append(f'daysToKeep {days_action}: {DEFAULT_DAYS_TO_KEEP}')
             
-            artifact_days_changed, artifact_days_action = ensure_element(logrotator, 'artifactDaysToKeep', DEFAULT_ARTIFACT_DAYS_TO_KEEP)
-            if artifact_days_changed:
-                result['modified'] = True
-                result['changes'].append(f'artifactDaysToKeep {artifact_days_action}: {DEFAULT_ARTIFACT_DAYS_TO_KEEP}')
-            
-            # Ensure numToKeep and artifactNumToKeep exist
             num_changed, num_action = ensure_element(logrotator, 'numToKeep', DEFAULT_NUM_TO_KEEP)
             if num_changed:
                 result['modified'] = True
                 result['changes'].append(f'numToKeep {num_action}: {DEFAULT_NUM_TO_KEEP}')
-            
-            artifact_num_changed, artifact_num_action = ensure_element(logrotator, 'artifactNumToKeep', DEFAULT_ARTIFACT_NUM_TO_KEEP)
-            if artifact_num_changed:
-                result['modified'] = True
-                result['changes'].append(f'artifactNumToKeep {artifact_num_action}: {DEFAULT_ARTIFACT_NUM_TO_KEEP}')
             
             # Set removeLastBuild=true
             remove_last_build = logrotator.find('removeLastBuild')
@@ -266,11 +262,11 @@ def configure_logrotator(config_path, backup_dir, jenkins_home, dry_run=False):
                     result['modified'] = True
                     result['changes'].append(f'removeLastBuild set to {DEFAULT_REMOVE_LAST_BUILD}')
             else:
-                # Add new element after artifactNumToKeep
-                artifact_num = logrotator.find('artifactNumToKeep')
-                if artifact_num is not None:
+                # Add new element after numToKeep
+                num_keep = logrotator.find('numToKeep')
+                if num_keep is not None:
                     children = list(logrotator)
-                    index = children.index(artifact_num) + 1
+                    index = children.index(num_keep) + 1
                     remove_last_build = ET.Element('removeLastBuild')
                     remove_last_build.text = DEFAULT_REMOVE_LAST_BUILD
                     logrotator.insert(index, remove_last_build)
@@ -339,10 +335,7 @@ def process_job(job_path, job_name, backup_dir, jenkins_home, dry_run=False, ver
         print(f"{'='*80}")
         
         if result['error']:
-            if result.get('archive_required'):
-                print(f"🗄️  ARCHIVE: {result['error']}")
-            else:
-                print(f"❌ Error: {result['error']}")
+            print(f"❌ Error: {result['error']}")
         elif result['modified']:
             if result['created_logrotator']:
                 print(f"✅ Created logRotator ({result['format']})")
@@ -450,12 +443,14 @@ python3 logRotatorUpdate.py /home/jenkins/.jenkins /backup/jenkins-configs \\
     print("="*80)
     
     # Find matching jobs
-    if args.pattern:
-        matching_jobs = find_matching_jobs(jobs_dir, args.pattern)
-        print(f"\nFound {len(matching_jobs)} matching jobs")
-    else:
-        matching_jobs = [(os.path.join(jobs_dir, j), j) for j in os.listdir(jobs_dir) if os.path.isdir(os.path.join(jobs_dir, j))]
-        if not args.list_matches:
+    # Use '*' pattern when no pattern specified to recursively find ALL jobs (including those in folders)
+    pattern = args.pattern if args.pattern else '*'
+    matching_jobs = find_matching_jobs(jobs_dir, pattern)
+    
+    if not args.list_matches:
+        if args.pattern:
+            print(f"\nFound {len(matching_jobs)} matching jobs")
+        else:
             print(f"\nFound {len(matching_jobs)} jobs")
     
     # If list-matches mode, just list and exit

--- a/tools/jenkins_scripts/logRotatorUpdate.py
+++ b/tools/jenkins_scripts/logRotatorUpdate.py
@@ -7,10 +7,13 @@ Supports both <logRotator> and <jenkins.model.BuildDiscarderProperty> formats.
 
 Features:
 1. Set removeLastBuild=true
-2. Ensure daysToKeep and artifactDaysToKeep are set (default: 365)
-3. Create logRotator if missing with sensible defaults
+2. Ensure daysToKeep and numToKeep are set (default: 365 days, 5 builds)
+3. Create logRotator if missing with sensible defaults (including artifact sub-policies)
 4. Validate only one logRotator definition exists
 5. Support both XML formats (direct logRotator and BuildDiscarderProperty)
+
+Note: Artifact retention settings (artifactDaysToKeep, artifactNumToKeep) are sub-policies
+and are only set when creating a new logRotator. Existing artifact settings are not modified.
 
 NO EXTERNAL DEPENDENCIES - Uses only Python standard library.
 Requires: Python 3.6+
@@ -21,6 +24,7 @@ Version: 2.1.0
 
 import os
 import sys
+import io
 import xml.etree.ElementTree as ET
 import argparse
 import re
@@ -309,7 +313,6 @@ def configure_logrotator(config_path, backup_dir, jenkins_home, dry_run=False):
             result['backup'] = backup_file(config_path, backup_dir, jenkins_home)
             
             # Write modified XML preserving original version and encoding
-            import io
             output = io.BytesIO()
             tree.write(output, encoding='UTF-8', xml_declaration=False)
             xml_content = output.getvalue().decode('UTF-8')
@@ -402,11 +405,14 @@ def main():
         epilog="""
 Features:
   1. Set removeLastBuild=true
-  2. Ensure daysToKeep and artifactDaysToKeep are set (default: 365)
-  3. Create logRotator if missing with sensible defaults
+  2. Ensure daysToKeep and numToKeep are set (default: 365 days, 5 builds)
+  3. Create logRotator if missing with sensible defaults (including artifact sub-policies)
   4. Support both logRotator and BuildDiscarderProperty formats
   5. Validate only one logRotator definition exists
   6. Create backups preserving directory structure
+
+Note: Artifact settings (artifactDaysToKeep, artifactNumToKeep) are only set when creating
+new logRotators. Existing artifact settings are not modified as they are sub-policies.
 
 Examples:
 # Test on single job
@@ -436,9 +442,24 @@ python3 logRotatorUpdate.py /home/jenkins/.jenkins /backup/jenkins-configs \\
     
     jobs_dir = os.path.join(args.jenkins_home, 'jobs')
     
+    # Validate Jenkins home directory
     if not os.path.exists(jobs_dir):
         print(f"❌ Error: Jobs directory not found: {jobs_dir}")
         sys.exit(1)
+    
+    # Validate and create backup directory if needed (unless in list-matches mode)
+    if not args.list_matches:
+        if not os.path.exists(args.backup_dir):
+            try:
+                os.makedirs(args.backup_dir, exist_ok=True)
+                print(f"✅ Created backup directory: {args.backup_dir}")
+            except OSError as e:
+                print(f"❌ Error: Cannot create backup directory: {args.backup_dir}")
+                print(f"   {e}")
+                sys.exit(1)
+        elif not os.access(args.backup_dir, os.W_OK):
+            print(f"❌ Error: Backup directory is not writable: {args.backup_dir}")
+            sys.exit(1)
     
     print("="*80)
     print("Jenkins logRotator Configuration Tool")

--- a/tools/jenkins_scripts/logRotatorUpdate.py
+++ b/tools/jenkins_scripts/logRotatorUpdate.py
@@ -1,0 +1,568 @@
+#!/usr/bin/env python3
+"""
+Jenkins logRotator Configuration Tool
+
+Safely configure logRotator settings in Jenkins job config.xml files.
+Supports both <logRotator> and <jenkins.model.BuildDiscarderProperty> formats.
+
+Features:
+1. Set removeLastBuild=true
+2. Ensure daysToKeep and artifactDaysToKeep are set (default: 30)
+3. Create logRotator if missing with sensible defaults
+4. Validate only one logRotator definition exists
+5. Support both XML formats (direct logRotator and BuildDiscarderProperty)
+
+NO EXTERNAL DEPENDENCIES - Uses only Python standard library.
+Requires: Python 3.6+
+
+Author: Adoptium Infrastructure Team
+Version: 2.1.0
+"""
+
+import os
+import sys
+import xml.etree.ElementTree as ET
+from datetime import datetime
+import argparse
+import re
+import fnmatch
+import uuid
+
+def backup_file(config_path, backup_dir, jenkins_home):
+    """
+    Create a backup of the config file preserving directory structure.
+    
+    Args:
+        config_path: Full path to the config.xml file
+        backup_dir: Root directory for backups
+        jenkins_home: Jenkins home directory (to calculate relative path)
+    
+    Returns:
+        Path to the backup file
+    """
+    # Calculate relative path from jenkins_home
+    rel_path = os.path.relpath(config_path, jenkins_home)
+    
+    # Create backup path preserving structure
+    backup_path = os.path.join(backup_dir, rel_path)
+    
+    # Create parent directories if needed
+    os.makedirs(os.path.dirname(backup_path), exist_ok=True)
+    
+    # Copy file
+    with open(config_path, 'r') as src:
+        with open(backup_path, 'w') as dst:
+            dst.write(src.read())
+    
+    return backup_path
+
+def find_all_logrotators(root):
+    """
+    Find all logRotator elements in both formats.
+    Returns list of tuples: (element, format_type)
+    """
+    logrotators = []
+    
+    # Format 1: Direct <logRotator> element under <properties>
+    for elem in root.iter('logRotator'):
+        logrotators.append((elem, 'direct'))
+    
+    # Format 2: <strategy class="hudson.tasks.LogRotator"> inside BuildDiscarderProperty
+    for elem in root.iter('strategy'):
+        if elem.get('class') == 'hudson.tasks.LogRotator':
+            # Check if it's inside BuildDiscarderProperty
+            for p in root.iter():
+                if elem in list(p):
+                    if 'BuildDiscarder' in p.tag:
+                        logrotators.append((elem, 'build_discarder'))
+                        break
+    
+    return logrotators
+
+def ensure_element(parent, tag, default_value):
+    """
+    Ensure an element exists with a value, create or update if needed.
+    
+    Returns:
+        tuple: (changed: bool, action: str)
+    """
+    elem = parent.find(tag)
+    if elem is None:
+        elem = ET.SubElement(parent, tag)
+        elem.text = str(default_value)
+        return True, 'created'
+    elif elem.text is None or elem.text.strip() == '' or elem.text == '-1':
+        elem.text = str(default_value)
+        return True, 'set'
+    return False, 'unchanged'
+
+def create_logrotator(root):
+    """Create a new logRotator element (direct format under properties)."""
+    properties = root.find('properties')
+    if properties is None:
+        properties = ET.SubElement(root, 'properties')
+    
+    logrotator = ET.SubElement(properties, 'logRotator')
+    
+    # Set default values
+    ET.SubElement(logrotator, 'daysToKeep').text = '365'
+    ET.SubElement(logrotator, 'numToKeep').text = '5'
+    ET.SubElement(logrotator, 'artifactDaysToKeep').text = '365'
+    ET.SubElement(logrotator, 'artifactNumToKeep').text = '5'
+    ET.SubElement(logrotator, 'removeLastBuild').text = 'true'
+    
+    return logrotator, 'direct'
+
+def validate_single_logrotator(root):
+    """
+    Validate that exactly one logRotator definition exists.
+    Returns: (is_valid: bool, count: int, message: str)
+    """
+    logrotators = find_all_logrotators(root)
+    count = len(logrotators)
+    
+    if count == 0:
+        return False, 0, "No logRotator found (expected 1)"
+    elif count == 1:
+        return True, 1, "Single logRotator found"
+    else:
+        formats = [fmt for _, fmt in logrotators]
+        return False, count, f"Multiple logRotators found: {formats}"
+
+def configure_logrotator(config_path, backup_dir, jenkins_home, dry_run=False):
+    """
+    Configure logRotator settings in a Jenkins job config.xml.
+    
+    Args:
+        config_path: Path to config.xml file
+        backup_dir: Directory for backups
+        jenkins_home: Jenkins home directory
+        dry_run: If True, don't write changes
+    
+    Returns:
+        dict with status information
+    """
+    result = {
+        'path': config_path,
+        'modified': False,
+        'created_logrotator': False,
+        'format': None,
+        'changes': [],
+        'error': None,
+        'backup': None,
+        'before': {},
+        'after': {}
+    }
+    
+    try:
+        # Read original file to detect XML version and preserve character entities
+        with open(config_path, 'r', encoding='utf-8') as f:
+            original_content = f.read()
+        
+        # Detect XML version
+        first_line = original_content.split('\n')[0]
+        xml_version = '1.0'  # default
+        if 'version=' in first_line:
+            if 'version="1.1"' in first_line or "version='1.1'" in first_line:
+                xml_version = '1.1'
+        
+        # Find and replace character entities with unique placeholders
+        # Pattern matches &#x followed by hex digits and semicolon
+        entity_pattern = re.compile(r'&#x([0-9a-fA-F]+);')
+        entity_map = {}  # Maps placeholder to original entity
+        
+        def replace_entity(match):
+            entity = match.group(0)  # e.g., '&#xd;'
+            if entity not in entity_map:
+                # Create unique placeholder that won't appear in XML
+                placeholder = f'__XMLENTITY_{uuid.uuid4().hex[:8]}_{match.group(1)}__'
+                entity_map[placeholder] = entity
+            else:
+                # Find existing placeholder for this entity
+                placeholder = [k for k, v in entity_map.items() if v == entity][0]
+            return placeholder
+        
+        modified_content = entity_pattern.sub(replace_entity, original_content)
+        
+        # Write temporary file with placeholders
+        temp_path = config_path + '.tmp'
+        with open(temp_path, 'w', encoding='utf-8') as f:
+            f.write(modified_content)
+        
+        # Parse XML from temporary file
+        tree = ET.parse(temp_path)
+        root = tree.getroot()
+        
+        # Clean up temp file
+        os.remove(temp_path)
+        
+        # Find all logRotator elements (both formats)
+        logrotators = find_all_logrotators(root)
+        
+        if len(logrotators) == 0:
+            # No logRotator - create one with defaults
+            logrotator, format_type = create_logrotator(root)
+            result['created_logrotator'] = True
+            result['modified'] = True
+            result['format'] = format_type
+            result['changes'].append(f'Created logRotator ({format_type})')
+            
+            # Record after state
+            result['after'] = {
+                'daysToKeep': '365',
+                'numToKeep': '5',
+                'artifactDaysToKeep': '365',
+                'artifactNumToKeep': '5',
+                'removeLastBuild': 'true'
+            }
+        elif len(logrotators) == 1:
+            # Single logRotator - update it
+            logrotator, format_type = logrotators[0]
+            result['format'] = format_type
+            
+            # Record current state
+            for field in ['daysToKeep', 'numToKeep', 'artifactDaysToKeep', 'artifactNumToKeep', 'removeLastBuild']:
+                elem = logrotator.find(field)
+                result['before'][field] = elem.text if elem is not None else None
+            
+            # Ensure daysToKeep and artifactDaysToKeep have values
+            days_changed, days_action = ensure_element(logrotator, 'daysToKeep', 365)
+            if days_changed:
+                result['modified'] = True
+                result['changes'].append(f'daysToKeep {days_action}: 365')
+            
+            artifact_days_changed, artifact_days_action = ensure_element(logrotator, 'artifactDaysToKeep', 365)
+            if artifact_days_changed:
+                result['modified'] = True
+                result['changes'].append(f'artifactDaysToKeep {artifact_days_action}: 365')
+            
+            # Ensure numToKeep and artifactNumToKeep exist
+            num_changed, num_action = ensure_element(logrotator, 'numToKeep', 5)
+            if num_changed:
+                result['modified'] = True
+                result['changes'].append(f'numToKeep {num_action}: 5')
+            
+            artifact_num_changed, artifact_num_action = ensure_element(logrotator, 'artifactNumToKeep', 5)
+            if artifact_num_changed:
+                result['modified'] = True
+                result['changes'].append(f'artifactNumToKeep {artifact_num_action}: 5')
+            
+            # Set removeLastBuild=true
+            remove_last_build = logrotator.find('removeLastBuild')
+            
+            if remove_last_build is not None:
+                if remove_last_build.text != 'true':
+                    remove_last_build.text = 'true'
+                    result['modified'] = True
+                    result['changes'].append('removeLastBuild set to true')
+            else:
+                # Add new element after artifactNumToKeep
+                artifact_num = logrotator.find('artifactNumToKeep')
+                if artifact_num is not None:
+                    children = list(logrotator)
+                    index = children.index(artifact_num) + 1
+                    remove_last_build = ET.Element('removeLastBuild')
+                    remove_last_build.text = 'true'
+                    logrotator.insert(index, remove_last_build)
+                else:
+                    remove_last_build = ET.SubElement(logrotator, 'removeLastBuild')
+                    remove_last_build.text = 'true'
+                
+                result['modified'] = True
+                result['changes'].append('removeLastBuild created: true')
+            
+            # Record after state
+            for field in ['daysToKeep', 'numToKeep', 'artifactDaysToKeep', 'artifactNumToKeep', 'removeLastBuild']:
+                elem = logrotator.find(field)
+                result['after'][field] = elem.text if elem is not None else None
+        else:
+            # Multiple logRotators - ERROR
+            formats = [fmt for _, fmt in logrotators]
+            result['error'] = f'Multiple logRotator definitions found ({len(logrotators)}): {formats}. Manual intervention required.'
+            return result
+        
+        # Validate only one logRotator exists after modifications
+        if result['modified']:
+            is_valid, count, message = validate_single_logrotator(root)
+            if not is_valid:
+                result['error'] = f'Validation failed: {message}. Changes not saved.'
+                result['modified'] = False
+                return result
+        
+        if result['modified'] and not dry_run:
+            # Create backup
+            result['backup'] = backup_file(config_path, backup_dir, jenkins_home)
+            
+            # Write modified XML preserving original version and encoding
+            import io
+            output = io.BytesIO()
+            tree.write(output, encoding='UTF-8', xml_declaration=False)
+            xml_content = output.getvalue().decode('UTF-8')
+            
+            # Restore character entities from placeholders
+            for placeholder, entity in entity_map.items():
+                xml_content = xml_content.replace(placeholder, entity)
+            
+            # Write with correct XML declaration
+            with open(config_path, 'w', encoding='UTF-8') as f:
+                f.write(f'<?xml version="{xml_version}" encoding="UTF-8"?>')
+                f.write(xml_content)
+        
+        return result
+        
+    except Exception as e:
+        result['error'] = str(e)
+        return result
+
+def process_job(job_path, job_name, backup_dir, jenkins_home, dry_run=False, verbose=False):
+    """Process a single job directory."""
+    config_path = os.path.join(job_path, 'config.xml')
+    
+    if not os.path.exists(config_path):
+        return None
+    
+    result = configure_logrotator(config_path, backup_dir, jenkins_home, dry_run=dry_run)
+    
+    if verbose or result['error'] or result['modified']:
+        print(f"\n{'='*80}")
+        print(f"Job: {job_name}")
+        print(f"{'='*80}")
+        
+        if result['error']:
+            if result.get('archive_required'):
+                print(f"🗄️  ARCHIVE: {result['error']}")
+            else:
+                print(f"❌ Error: {result['error']}")
+        elif result['modified']:
+            if result['created_logrotator']:
+                print(f"✅ Created logRotator ({result['format']})")
+            else:
+                print(f"✅ Modified logRotator ({result['format']})")
+            
+            if result['backup']:
+                print(f"   Backup: {os.path.basename(result['backup'])}")
+            
+            print(f"\nChanges:")
+            for change in result['changes']:
+                print(f"  - {change}")
+            
+            if result['before']:
+                print(f"\nBefore:")
+                for k, v in result['before'].items():
+                    print(f"  {k}: {v}")
+            
+            print(f"\nAfter:")
+            for k, v in result['after'].items():
+                print(f"  {k}: {v}")
+        else:
+            print(f"ℹ️  No changes needed ({result['format']})")
+    
+    return result
+
+def matches_pattern(job_name, pattern):
+    """Check if job name matches the pattern (glob or regex)."""
+    if job_name == pattern:
+        return True
+    if fnmatch.fnmatch(job_name, pattern):
+        return True
+    try:
+        if re.match(pattern, job_name):
+            return True
+    except re.error:
+        pass
+    return False
+
+def find_matching_jobs(jobs_dir, pattern):
+    """Find all jobs matching the pattern."""
+    matching_jobs = []
+    for root, dirs, files in os.walk(jobs_dir):
+        if 'config.xml' in files:
+            rel_path = os.path.relpath(root, jobs_dir)
+            job_name = rel_path.replace(os.sep, '/')
+            if matches_pattern(job_name, pattern):
+                matching_jobs.append((root, job_name))
+    return matching_jobs
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Configure logRotator settings in Jenkins job configs',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Features:
+  1. Set removeLastBuild=true
+  2. Ensure daysToKeep and artifactDaysToKeep are set (default: 365)
+  3. Create logRotator if missing with sensible defaults
+  4. Support both logRotator and BuildDiscarderProperty formats
+  5. Validate only one logRotator definition exists
+  6. Create backups preserving directory structure
+
+Examples:
+# Test on single job
+python3 logRotatorUpdate.py /home/jenkins/.jenkins /backup/jenkins-configs \\
+    --pattern "my-job" --verbose --dry-run
+
+# Update all Test* jobs
+python3 logRotatorUpdate.py /home/jenkins/.jenkins /backup/jenkins-configs \\
+    --pattern "Test*"
+
+# Update all jobs
+python3 logRotatorUpdate.py /home/jenkins/.jenkins /backup/jenkins-configs
+
+# List matching jobs without processing
+python3 logRotatorUpdate.py /home/jenkins/.jenkins /backup/jenkins-configs \\
+    --pattern "Test*" --list-matches
+        """
+    )
+    parser.add_argument('jenkins_home', help='Path to JENKINS_HOME directory')
+    parser.add_argument('backup_dir', help='Directory for backups (preserves folder structure)')
+    parser.add_argument('--pattern', help='Process jobs matching this pattern (glob or regex)')
+    parser.add_argument('--dry-run', action='store_true', help='Show changes without modifying files')
+    parser.add_argument('--verbose', action='store_true', help='Show details for all jobs')
+    parser.add_argument('--list-matches', action='store_true', help='List matching jobs without processing')
+    
+    args = parser.parse_args()
+    
+    jobs_dir = os.path.join(args.jenkins_home, 'jobs')
+    
+    if not os.path.exists(jobs_dir):
+        print(f"❌ Error: Jobs directory not found: {jobs_dir}")
+        sys.exit(1)
+    
+    print("="*80)
+    print("Jenkins logRotator Configuration Tool")
+    print("="*80)
+    print(f"Python: {sys.version.split()[0]}")
+    print(f"Jenkins Home: {args.jenkins_home}")
+    if args.pattern:
+        print(f"Pattern: {args.pattern}")
+    if args.dry_run:
+        print("Mode: DRY RUN")
+    print("="*80)
+    
+    # Find matching jobs
+    if args.pattern:
+        matching_jobs = find_matching_jobs(jobs_dir, args.pattern)
+        print(f"\nFound {len(matching_jobs)} matching jobs")
+    else:
+        matching_jobs = [(os.path.join(jobs_dir, j), j) for j in os.listdir(jobs_dir) if os.path.isdir(os.path.join(jobs_dir, j))]
+        if not args.list_matches:
+            print(f"\nFound {len(matching_jobs)} jobs")
+    
+    # If list-matches mode, just list and exit
+    if args.list_matches:
+        print(f"\nMatching jobs:")
+        for _, job_name in sorted(matching_jobs, key=lambda x: x[1]):
+            print(f"  {job_name}")
+        return
+    
+    # Process jobs
+    stats = {
+        'total': 0,
+        'modified': 0,
+        'created': 0,
+        'skipped': 0,
+        'errors': 0,
+        'multiple_logrotators': 0,
+        'fields': {
+            'daysToKeep': {'count': 0, 'jobs': []},
+            'artifactDaysToKeep': {'count': 0, 'jobs': []},
+            'numToKeep': {'count': 0, 'jobs': []},
+            'artifactNumToKeep': {'count': 0, 'jobs': []},
+            'removeLastBuild': {'count': 0, 'jobs': []}
+        }
+    }
+    
+    for job_path, job_name in matching_jobs:
+        stats['total'] += 1
+        result = process_job(job_path, job_name, args.backup_dir, args.jenkins_home,
+                           dry_run=args.dry_run, verbose=args.verbose)
+        
+        if result is None:
+            continue
+        
+        if result['error']:
+            stats['errors'] += 1
+            if 'Multiple logRotator' in result['error']:
+                stats['multiple_logrotators'] += 1
+            if not args.verbose:
+                print(f"❌ {job_name}: {result['error']}")
+        elif result['modified']:
+            # Track field changes
+            for change in result['changes']:
+                for field in stats['fields'].keys():
+                    if field in change:
+                        stats['fields'][field]['count'] += 1
+                        stats['fields'][field]['jobs'].append(job_name)
+                        break
+            
+            if result['created_logrotator']:
+                stats['created'] += 1
+                if not args.verbose:
+                    print(f"✅ {job_name} (created {result['format']})")
+            else:
+                stats['modified'] += 1
+                if not args.verbose:
+                    changes_summary = ', '.join(result['changes'][:2])
+                    if len(result['changes']) > 2:
+                        changes_summary += f" +{len(result['changes'])-2} more"
+                    print(f"✅ {job_name} ({changes_summary})")
+        else:
+            stats['skipped'] += 1
+        
+        if stats['total'] % 100 == 0 and not args.verbose:
+            print(f"Progress: {stats['total']} jobs...")
+    
+    # Summary
+    print("\n" + "="*80)
+    print("SUMMARY")
+    print("="*80)
+    print(f"Total jobs: {stats['total']}")
+    print(f"✅ Modified: {stats['modified']}")
+    print(f"✅ Created: {stats['created']} (new logRotator)")
+    print(f"⏭️  Skipped: {stats['skipped']} (no changes needed)")
+    print(f"❌ Errors: {stats['errors']}")
+    if stats['multiple_logrotators'] > 0:
+        print(f"⚠️  Multiple logRotators: {stats['multiple_logrotators']} (manual fix required)")
+    
+    # Field change statistics with default values
+    field_defaults = {
+        'daysToKeep': '365',
+        'artifactDaysToKeep': '365',
+        'numToKeep': '5',
+        'artifactNumToKeep': '5',
+        'removeLastBuild': 'true'
+    }
+    
+    if any(data['count'] > 0 for data in stats['fields'].values()):
+        print("\nField Changes:")
+        for field, data in stats['fields'].items():
+            if data['count'] > 0:
+                default = field_defaults[field]
+                print(f"  {field} set to {default}: {data['count']} jobs")
+    
+    # Show jobs with significant changes by field (excluding removeLastBuild)
+    has_significant_changes = False
+    for field, data in stats['fields'].items():
+        if field != 'removeLastBuild' and data['count'] > 0:
+            has_significant_changes = True
+            break
+    
+    if has_significant_changes:
+        print(f"\nJobs with retention policy changes:")
+        for field, data in stats['fields'].items():
+            if field != 'removeLastBuild' and data['count'] > 0:
+                default = field_defaults[field]
+                print(f"\n  {field} set to {default} ({data['count']} jobs):")
+                for job in sorted(data['jobs']):
+                    print(f"    - {job}")
+    
+    print("="*80)
+    
+    if args.dry_run:
+        print("\n⚠️  DRY RUN - No changes were made")
+        print("Run without --dry-run to apply changes")
+
+if __name__ == '__main__':
+    main()
+
+# Made with Bob


### PR DESCRIPTION
Fixes https://github.com/adoptium/infrastructure/issues/4384

Assisted-by: IBM Bob

Added new jenkins_scripts:
- README.md : Documents jenkins_scripts
- logRotatorUpdate.py : Jenkins config.xml logRotator policy updater script
- LOG_ROTATOR_UPDATE.md : Documentation for logRotatorUpdate.py

## logRotatorUpdate.py : 
Safely configure logRotator settings in Jenkins job `config.xml` files.

### Purpose

This script ensures all Jenkins jobs have proper build retention policies configured:
1. Sets `removeLastBuild=true` to allow deletion of the last build
2. Ensures `daysToKeep` and `artifactDaysToKeep` are set (default: 365 days)
3. Ensures `numToKeep` and `artifactNumToKeep` are set (default: 5 builds)
4. Creates complete logRotator configuration for jobs that don't have one

This prevents old builds from accumulating and consuming excessive memory/disk space.

### Features

- ✅ **Safe XML parsing** - Uses Python's built-in ElementTree with character entity preservation
- ✅ **Automatic backups** - Creates backups preserving directory structure
- ✅ **Pattern matching** - Supports glob and regex for job selection
- ✅ **Dry-run mode** - Preview changes without modifying files
- ✅ **Smart defaults** - Creates sensible retention policies
- ✅ **Detailed reporting** - Shows exactly what changed per field
- ✅ **Dual format support** - Handles both `<logRotator>` and `<jenkins.model.BuildDiscarderProperty>` formats
- ✅ **Character entity preservation** - Maintains escaped characters like `&#xd;` in XML


##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [x] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
