### PR TITLE
UnixPb: apt_key deprecated in ubuntu 26

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -22,16 +22,20 @@
   when: ansible_architecture == "aarch64"
   tags: patch_update
 
-- name: Add Azul Zulu GPG Package Signing Key for x86_64
-  apt_key:
-    url: https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems
-    state: present
+- name: Download and convert Azul Zulu GPG Package Signing Key for x86_64
+  ansible.builtin.shell: |
+    curl -fsSL https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems | gpg --dearmor > /etc/apt/keyrings/azulsystems.gpg
+  args:
+    creates: /etc/apt/keyrings/azulsystems.gpg
   when:
     - ansible_architecture == "x86_64"
   tags: [patch_update, azul-key]
 
 - name: Add Azul Zulu repository for x86_64
-  apt_repository: repo='deb http://repos.azulsystems.com/ubuntu stable main'
+  ansible.builtin.apt_repository:
+    repo: 'deb [signed-by=/etc/apt/keyrings/azulsystems.gpg] http://repos.azulsystems.com/ubuntu stable main'
+    state: present
+    filename: azul-zulu
   when:
     - ansible_architecture == "x86_64"
   tags: patch_update


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->
Updated the Ansible playbook to fix the deprecated apt_key module error for Ubuntu 26.04
#https://github.com/adoptium/infrastructure/issues/4387


##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
