### PR TITLE
doc: allow commit prefix 'docker:' for container generation code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,6 +166,7 @@ Wherever possible, prefix the commit message with the area which you are changin
 - winPB:
 - aixPB:
 - ansible:
+- docker:
 - vagrant:
 - pbTests:
 - docs:


### PR DESCRIPTION
Noted during https://github.com/adoptium/infrastructure/pull/4393 that the `docker:` prefix wasn't listed as valid in the contributing documentation.

This should be used for anything related to container generation e.g. things in ansible/docker or potentially the dockerstatic images since those are used be the jenkins files in `ansible/docker` e.g. by the [test_image_updater job](https://ci.adoptium.net/job/test_image_updater/).

Not that this is already in widespread use and was first used in a commit from 2020.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
