### PR TITLE
UnixPB: Fix Syntax For Riscv Ubuntu Failure

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -23,7 +23,7 @@
   tags: patch_update
 
 - name: Create /etc/apt/keyrings directory for x86_64
-  ansible.builtin.file:
+  file:
     path: /etc/apt/keyrings
     state: directory
     mode: '0755'
@@ -32,15 +32,15 @@
   tags: [patch_update, azul-key]
 
 - name: Download and convert Azul Zulu GPG Package Signing Key for x86_64
-  ansible.builtin.shell: curl -fsSL https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems | gpg --dearmor > /etc/apt/keyrings/azulsystems.gpg
-  args:
+  shell:
+    cmd: curl -fsSL https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems | gpg --dearmor > /etc/apt/keyrings/azulsystems.gpg
     creates: /etc/apt/keyrings/azulsystems.gpg
   when:
     - ansible_architecture == "x86_64"
   tags: [patch_update, azul-key]
 
 - name: Add Azul Zulu repository for x86_64
-  ansible.builtin.apt_repository:
+  apt_repository:
     repo: 'deb [signed-by=/etc/apt/keyrings/azulsystems.gpg] http://repos.azulsystems.com/ubuntu stable main'
     state: present
     filename: azul-zulu


### PR DESCRIPTION
Fixes #4392 

A syntax error in the Ubuntu specific tasks running the playbook was occuring on riscv. This fixes the syntax error, and removes the occasionally problematic ansible.builtin prefixes.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)

VPC In Progress : https://ci.adoptium.net/job/VagrantPlaybookCheck/2282/
VPC In Progress : https://ci.adoptium.net/job/VagrantPlaybookCheck/2283/
:heavy_check_mark: Ubuntu 20 : https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Ubuntu2004,label=vagrant/2282/console
:heavy_check_mark: Ubuntu 22 : https://ci.adoptium.net/job/VagrantPlaybookCheck/OS=Ubuntu2204,label=vagrant/2282/console