### PR TITLE
windowsPb: Change path of ansible log file on windows

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/logs/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/logs/tasks/main.yml
@@ -35,6 +35,6 @@
 - name: Update Log File
   win_lineinfile:
     create: yes
-    path: '{{ log_path }}\ansible.log'
+    path: '{{ log_path }}'
     insertafter: EOF
     line: "{{ position }} {{ date_output.start }} {{ git_sha }}"

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/logs/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/logs/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - name: Set Log path
   set_fact:
-    log_path: 'C:\Users\{{ ansible_user }}'
+    log_path: 'C:\ansible.log'
 
 # This task doesn't actually matter, aslong as it runs and is registered. The timestamp for the registered variable is used
 - name: Dummy task to get timestamp


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

The new path allows the jenkins user to read the ansible.log during TKG processes [which look up the ansible.log file on windows machines](https://github.com/adoptium/TKG/pull/834/). This new path is consistent for every machine. For example on some machines the admin user is `adoptopenjdk`, on others its `adoptium`, which means 'C:\Users\{{ ansible_user }}' will be different, which confuses TKG