### PR TITLE
github: Add Jenkins update service status check to template

### DIFF
--- a/.github/ISSUE_TEMPLATE/jenkinsupdate.md
+++ b/.github/ISSUE_TEMPLATE/jenkinsupdate.md
@@ -14,5 +14,7 @@ New version: TBC
 
 Previous patching issue: (Pick the latest from https://github.com/adoptium/infrastructure/issues?q=is%3Aissue%20state%3Aclosed%20jenkins%20regular%20update)
 
+Prior to updating check jenkins update service status :  http://status.jenkins.io/
+
 Part of https://github.com/adoptium/infrastructure/issues/3380
 


### PR DESCRIPTION
Update the regular jenkins maintenance issue template to add a reminder to check Jenkins update service status before updating.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes]
- [X] VPC/QPC not applicable for this PR
