### PR TITLE
inventory: Add test-osuosl-aix73-ppc64-2 to inventory

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -87,6 +87,7 @@ hosts:
           aix72-ppc64-5: {ip: 140.211.9.99, description: p9-aix1-adopt05.osuosl.org, 7200-02-04-1914}
           aix72-ppc64-6: {ip: 140.211.9.100, description: p9-aix1-adopt06.osuosl.org, 7200-02-04-1914}
           aix73-ppc64-1: {ip: 140.211.9.10, description: p8-aix1-adopt01.osuosl.org, 7300-01-02-2320}
+          aix73-ppc64-2: {ip: 140.211.9.21, description: p10-aix-adopt03.osuosl.org, 7300-00-04-2320}
           centos74-ppc64le-1: {ip: 140.211.168.228, user: centos}
           centos74-ppc64le-2: {ip: 140.211.168.217, user: centos}
           centosstream10-ppc64le-1: {ip: 140.211.168.22, user: centos}


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Branch name should say aix73, was a typo. This machine is in jenkins and has been up for some time, just forgot to put it into the inventory