### PR TITLE
UnixPb: Fix ptrace_scope configuration when 10-ptrace.conf is missing in ubuntu 26.04

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/performance_tools/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/performance_tools/tasks/main.yml
@@ -66,3 +66,4 @@
         path: /etc/sysctl.d/10-ptrace.conf
         regexp: '^kernel.yama.ptrace_scope'
         line: kernel.yama.ptrace_scope = 0
+        create: yes


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->
The ptrace_scope configuration task fails on Ubuntu 26 because /etc/sysctl.d/10-ptrace.conf is not present by default.
Add `create: yes` to the lineinfile task so the file is created when missing and the ptrace_scope setting can be persisted successfully.
```
TASK [../AdoptOpenJDK_Unix_Playbook/roles/performance_tools : Set ptrace_scope value persistant across reboot] ************************************************************************************************************************************* [ERROR]: Task failed: Module failed: Destination /etc/sysctl.d/10-ptrace.conf does not exist ! Origin: /Users/aswathysk/ansible/infra-can/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/performance_tools/tasks/main.yml:64:7 62 shell: echo 0 | dd of=/proc/sys/kernel/yama/ptrace_scope 63 64 - name: Set ptrace_scope value persistant across reboot ^ column 7 fatal: [rtj-ubu26s390x-svl-test-2.dev.fyre.ibm.com]: FAILED! => {"changed": false, "msg": "Destination /etc/sysctl.d/10-ptrace.conf does not exist !", "rc": 257} fatal: [rtj-ubu26s390x-svl-test-3.dev.fyre.ibm.com]: FAILED! => {"changed": false, "msg": "Destination /etc/sysctl.d/10-ptrace.conf does not exist !", "rc": 257}
```

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
