### PR TITLE
Docker: Fix Seccomp Compatibility For Centos 7

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
@@ -123,3 +123,36 @@
   when: ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version | int >= 7)) or
         ansible_distribution == "Ubuntu" or ansible_distribution == "Debian" or ansible_distribution == "SLES"
   tags: docker
+
+- name: Ensure Docker daemon directory exists
+  file:
+    path: /etc/docker
+    state: directory
+    mode: '0755'
+  when: ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version | int >= 7)) or
+        ansible_distribution == "Ubuntu" or ansible_distribution == "Debian" or ansible_distribution == "SLES"
+  tags: docker
+
+- name: Configure Docker daemon with seccomp fix
+  copy:
+    content: |
+      {
+        "seccomp-profile": "unconfined"
+      }
+    dest: /etc/docker/daemon.json
+    mode: '0644'
+  register: docker_daemon_config
+  when: ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version | int >= 7)) or
+        ansible_distribution == "Ubuntu" or ansible_distribution == "Debian" or ansible_distribution == "SLES"
+  tags: docker
+
+- name: Restart Docker service after daemon.json changes
+  service:
+    name: docker
+    state: restarted
+  when:
+    - docker_daemon_config is defined
+    - docker_daemon_config.changed
+    - ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version | int >= 7)) or
+      ansible_distribution == "Ubuntu" or ansible_distribution == "Debian" or ansible_distribution == "SLES"
+  tags: docker

--- a/ansible/vagrant/Vagrantfile.Debian12
+++ b/ansible/vagrant/Vagrantfile.Debian12
@@ -3,7 +3,12 @@
 
 $script = <<SCRIPT
 # Configure DPKG to be noninteractive
-ENV DEBIAN_FRONTEND=noninteractive 
+export DEBIAN_FRONTEND=noninteractive
+
+# Pre-configure GRUB to prevent interactive prompts during upgrades
+echo "grub-pc grub-pc/install_devices_empty boolean true" | sudo debconf-set-selections
+echo "grub-pc grub-pc/install_devices string /dev/sda" | sudo debconf-set-selections
+
 # Update Repository Addresses For Debian
 sudo apt-get update
 sudo apt-get install tree -y


### PR DESCRIPTION
Fixes #4423 

Following a recent change to docker ( containers based on Centos 7 & other things, using older glibc ) , are unable to use things such as curl, wget etc, and cannot connect to network addresses.

The referenced issue has all the details, but this add a backwards compatibility switch for docker to ensure our containers continue to work.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)

ALL PASSED, except Debian 12  - VPC https://ci.adoptium.net/job/VagrantPlaybookCheck/2287/

Debian 12 Failure : Due to issue with apt update / grub disk being full in VagrantBox.. will fix this, and rerun
Debian 12 Rerun here : https://ci.adoptium.net/job/VagrantPlaybookCheck/2288/OS=Debian12,label=vagrant/console , passed point of failure, and new code.