### PR TITLE
github: Add Ubuntu 2604 to dockerstatic workflow

### DIFF
--- a/.github/workflows/check_dockerstatic.yml
+++ b/.github/workflows/check_dockerstatic.yml
@@ -80,12 +80,12 @@ jobs:
       max-parallel: 4
       matrix:
        include:
-         - os: ubuntu20.04
-           dockerfile: "Dockerfile.u2004"
          - os: ubuntu22.04
            dockerfile: "Dockerfile.u2204"
          - os: ubuntu24.04
            dockerfile: "Dockerfile.u2404"
+         - os: ubuntu26.04
+           dockerfile: "Dockerfile.u2604"
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Test Dockerfile on ${{ matrix.os }}


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Re https://github.com/adoptium/infrastructure/issues/4420

20.04 is EOL, should be replaced by 26.04 now that the dockerfile is in