### PR TITLE
UnixPB: Use package module instead of command for installing packages

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/build_packages_and_tools.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/build_packages_and_tools.yml
@@ -25,7 +25,9 @@
   tags: build_tools
 
 - name: Install Build Tool Packages (RHEL8+)
-  command: dnf -y install {{ Build_Tool_Packages }}
+  package:
+    name: "{{ Build_Tool_Packages }}"
+    state: "{{ package_var }}"
   when:
     - (ansible_distribution == "RedHat" and (ansible_distribution_major_version | int >= 8))
   tags: build_tools
@@ -57,7 +59,9 @@
   tags: test_tools
 
 - name: Install Test Tool Packages ( RHEL8+ )
-  command: dnf -y install {{ Test_Tool_Packages }}
+  package:
+    name: "{{ Test_Tool_Packages }}"
+    state: "{{ package_var }}"
   when:
     - (ansible_distribution == "RedHat" and (ansible_distribution_major_version | int >= 8))
   tags: test_tools


### PR DESCRIPTION
 - use package module instead of command for installing packages

Signed-off-by: Aswin K R <aswinkr77@gmail.com>

The current method is parsing packages as a list which is causing failures:
```
"TASK [../AdoptOpenJDK
 _Unix_Playbook/roles/Common : Install Test Tool Packages ( RHEL8+ )] ***\", \"fatal: [10.23.133.6]: FAILED! => {\\\"ch
anged\\\": true, \\\"cmd\\\": [\\\"dnf\\\", \\\"-y\\\", \\\"install\\\", \\\"[acl,\\\", \\\"perl,\\\", \\\"perl-Digest
-SHA,\\\", \\\"perl-Time-HiRes,\\\", \\\"perl-Test-Simple,\\\", \\\"xorg-x11-xauth,\\\", \\\"zlib-devel,\\\", \\\"perl-
devel,\\\", \\\"expat-devel,\\\", \\\"libcurl-devel,\\\", \\\"mercurial,\\\", \\\"gnutls,\\\", \\\"gnutls-utils,\\\", \
\\"shared-mime-info,\\\", \\\"nss-devel,\\\", \\\"nss-tools]\\\"], \\\"delta\\\": \\\"0:00:16.459977\\\", \\\"end\\\":
\\\"2026-06-25 06:41:39.985215\\\", \\\"msg\\\": \\\"non-zero return code\\\", \\\"rc\\\": 1, \\\"start\\\": \\\"202
6-06-25 06:41:23.525238\\\", \\\"stderr\\\": \\\"Error: Unable to find a match: [acl, perl, perl-Digest-SHA, perl-Ti
me-HiRes, perl-Test-Simple, xorg-x11-xauth, zlib-devel, perl-devel, expat-devel, libcurl-devel, mercurial, gnutls, g
nutls-utils, shared-mime-info, nss-devel, nss-tools]\\\", \\\"stderr_lines\\\": [\\\"Error: Unable to find a match: 
[acl, perl, perl-Digest-SHA, perl-Time-HiRes, perl-Test-Simple, xorg-x11-xauth, zlib-devel, perl-devel, expat-devel,
libcurl-devel, mercurial, gnutls, gnutls-utils, shared-mime-info, nss-devel, nss-tools]\\\"], \\\"stdout\\\": \\\"U
pdating Subscription Management repositories.\\\\nRed Hat CodeReady Linux Builder for RHEL 8 x86_  80 kB/s | 4.5 kB
00:00    \\\\nRed Hat Enterprise Linux 8 for x86_64 - Supplem  68 kB/s | 3.8 kB     00:00    \\\\nRed Hat Ente
rprise Linux 8 for x86_64 - AppStre  81 kB/s | 4.5 kB     00:00    \\\\nRed Hat Enterprise Linux 8 for x86_64 -
BaseOS   71 kB/s | 4.1 kB     00:00    \\\\nNo match for argument: [acl,\\\\nNo match for argument: perl,\\\\
nNo match for argument: perl-Digest-SHA,\\\\nNo match for argument: perl-Time-HiRes,\\\\nNo match for argumen
t: perl-Test-Simple,\\\\nNo match for argument: xorg-x11-xauth,\\\\nNo match for argument: zlib-devel,\\\\nNo
match for argument: perl-devel,\\\\nNo match for argument: expat-devel,\\\\nNo match for argument: libcurl-de
vel,\\\\nNo match for argument: mercurial,\\\\nNo match for argument: gnutls,\\\\nNo match for argument: gnut
ls-utils,\\\\nNo match for argument: shared-mime-info,\\\\nNo match for argument: nss-devel,\\\\nNo match for
argument: nss-tools]\\\", 
```
for eg:
It's parsing it into ` dnf -y install ['acl', 'perl', 'perl-Digest-SHA']`


##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
