### PR TITLE
Inventory: Remove windows nodes & add missing win 11 node

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -68,9 +68,7 @@ hosts:
           ubuntu2404-x64-1: {ip: 20.115.98.159, user: azureuser}
           rhel10-x64-1: {ip: 20.117.121.109, user: azureuser}
           win2022-x64-1: {ip: 51.132.234.42, user: adoptopenjdk}
-          win2022-x64-2: {ip: 20.77.53.16, user: adoptopenjdk}
-          win2022-x64-3: {ip: 20.68.165.213, user: adoptopenjdk}
-          win2022-x64-4: {ip: 20.77.112.43, user: adoptopenjdk}
+          win11-x64-1: {ip: 20.56.162.171, user: adoptopenjdk}
           win11-aarch64-1: {ip: 20.4.31.184, user: adoptopenjdk}
           win11-aarch64-2: {ip: 108.143.205.79, user: adoptopenjdk}
           win11-aarch64-3: {ip: 4.231.23.141, user: adoptopenjdk}


### PR DESCRIPTION
Fixes #4435 

Remove 3 x Windows Server 2022 x64 Machines
Remove 1 x Windows 11 x64 Machine
Add missing Windows 11 x64 Machine to inventory.

Removed machines, due to switch to dynamic provisioning, 1 x Win 11 & 1 x Win 2022 x64 nodes have been left in place and online.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR
- [X] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
