### PR TITLE
docker: Set Nagios ssh public key in static dockerfile during playbook runtime

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/deploy_container/tasks/deploy.yml
@@ -53,6 +53,12 @@
     regexp: "Jenkins_User_SSHKey"
     replace: "{{ Jenkins_User_SSHKey }}"
 
+- name: Set nagios authorized_Key in dockerfiles
+  replace:
+    dest: /tmp/Dockerfile.{{ docker_image }}
+    regexp: "Nagios_User_SSHKey"
+    replace: "{{ Nagios_User_SSHKey }}"
+
 - name: Build {{ docker_image }} docker images {{ docker_build_command }}
   command: "{{ docker_build_command }} --cpu-period=100000 --cpu-quota=800000 -t aqa_{{ docker_image }}{{ arm32_suffix }} --memory=6G -f /tmp/Dockerfile.{{ docker_image }} /tmp/"
 


### PR DESCRIPTION
- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Sets the nagios public key in the dockerfile during playbook execution, same as how we do it for the jenkins public key