### PR TITLE
Docker: Update Build Image Docker Build To Use Newer Buildx

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,6 +90,7 @@ def dockerBuildArm32(architecture, distro, dockerfile) {
     docker.withRegistry('https://index.docker.io/v1/', 'dockerhub') {
         sh """
             docker buildx build --platform linux/arm/v7 \
+            --provenance=false \
             --build-arg git_sha=$git_sha --build-arg ansible_arch=$ansible_arch \
             -f ansible/docker/$dockerfile \
             -t adoptopenjdk/${distro}_build_image:linux-$architecture --push .
@@ -100,11 +101,14 @@ def dockerBuildArm32(architecture, distro, dockerfile) {
 def dockerBuild(architecture, distro, dockerfile) {
     git poll: false, url: 'https://github.com/adoptium/infrastructure.git'
     def git_sha = "${env.GIT_COMMIT.trim()}"
-    dockerImage = docker.build("adoptopenjdk/${distro}_build_image:linux-$architecture",
-        "--build-arg git_sha=$git_sha -f ansible/docker/$dockerfile .")
-    // dockerhub is the ID of the credentials stored in Jenkins 
     docker.withRegistry('https://index.docker.io/v1/', 'dockerhub') {
-        dockerImage.push()
+        sh """
+            docker buildx build --platform linux/$architecture \
+            --provenance=false \
+            --build-arg git_sha=$git_sha \
+            -f ansible/docker/$dockerfile \
+            -t adoptopenjdk/${distro}_build_image:linux-$architecture --push .
+        """
     }
 }
 
@@ -116,7 +120,7 @@ def dockerManifest() {
             # Centos6
             export TARGET="adoptopenjdk/centos6_build_image"
             AMD64=$TARGET:linux-amd64
-            docker manifest create $TARGET $AMD64
+            docker manifest create --amend $TARGET $AMD64
             docker manifest annotate $TARGET $AMD64 --arch amd64 --os linux
             docker manifest push $TARGET
             # Centos7
@@ -124,7 +128,7 @@ def dockerManifest() {
             AMD64=$TARGET:linux-amd64
             ARM64=$TARGET:linux-arm64
             PPC64LE=$TARGET:linux-ppc64le
-            docker manifest create $TARGET $AMD64 $ARM64 $PPC64LE
+            docker manifest create --amend $TARGET $AMD64 $ARM64 $PPC64LE
             docker manifest annotate $TARGET $AMD64 --arch amd64 --os linux
             docker manifest annotate $TARGET $ARM64 --arch arm64 --os linux
             docker manifest annotate $TARGET $PPC64LE --arch ppc64le --os linux
@@ -132,14 +136,14 @@ def dockerManifest() {
             # Ubuntu1604
             export TARGET="adoptopenjdk/ubuntu1604_build_image"
             ARMV7L=$TARGET:linux-armv7l
-            docker manifest create $TARGET $ARMV7L
+            docker manifest create --amend $TARGET $ARMV7L
             docker manifest annotate $TARGET $ARMV7L --arch arm --os linux
             docker manifest push $TARGET
             # Alpine3
             export TARGET="adoptopenjdk/alpine3_build_image"
             AMD64=$TARGET:linux-amd64
             ARM64=$TARGET:linux-arm64
-            docker manifest create $TARGET $AMD64 $ARM64
+            docker manifest create --amend $TARGET $AMD64 $ARM64
             docker manifest annotate $TARGET $AMD64 --arch amd64 --os linux
             docker manifest annotate $TARGET $ARM64 --arch arm64 --os linux
             docker manifest push $TARGET

--- a/ansible/docker/Jenkinsfile
+++ b/ansible/docker/Jenkinsfile
@@ -104,6 +104,7 @@ def dockerBuildArm32(architecture, distro, dockerfile) {
     docker.withRegistry('https://ghcr.io', 'ghcr-adoptium') {
         sh """
             docker buildx build --platform linux/arm/v7 \
+            --provenance=false \
             --build-arg git_sha=$git_sha --build-arg ansible_arch=$architecture \
             -f ansible/docker/$dockerfile \
             -t ghcr.io/adoptium/adoptium_build_image:${distro}_linux-$architecture --push .
@@ -117,12 +118,15 @@ def dockerBuild(architecture, distro, dockerfile) {
     sh "rm -vf *.sha256"
     git poll: false, url: 'https://github.com/adoptium/infrastructure.git'
     def git_sha = "${env.GIT_COMMIT.trim()}"
-    dockerImage = docker.build("ghcr.io/adoptium/adoptium_build_image:${distro}_linux-$architecture",
-        "--build-arg git_sha=$git_sha -f ansible/docker/$dockerfile .")
-    // dockerhub is the ID of the credentials stored in Jenkins
     docker.withRegistry('https://ghcr.io', 'ghcr-adoptium') {
-        dockerImage.push()
-        sh "docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/adoptium/adoptium_build_image:${distro}_linux-${architecture} > ${distro}_linux-${architecture}.sha256"
+        sh """
+            docker buildx build --platform linux/$architecture \
+            --provenance=false \
+            --build-arg git_sha=$git_sha \
+            -f ansible/docker/$dockerfile \
+            -t ghcr.io/adoptium/adoptium_build_image:${distro}_linux-$architecture --push .
+            docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/adoptium/adoptium_build_image:${distro}_linux-${architecture} > ${distro}_linux-${architecture}.sha256
+        """
         archiveArtifacts artifacts: '*linux*.sha256', fingerprint: true
     }
 }
@@ -135,7 +139,7 @@ def dockerManifest() {
             # Centos6
             export TARGET="ghcr.io/adoptium/adoptium_build_image:centos6"
             AMD64=${TARGET}_linux-amd64
-            docker manifest create $TARGET $AMD64
+            docker manifest create --amend $TARGET $AMD64
             docker manifest annotate $TARGET $AMD64 --arch amd64 --os linux
             docker manifest push $TARGET
             # Centos7
@@ -143,7 +147,7 @@ def dockerManifest() {
             AMD64=${TARGET}_linux-amd64
             ARM64=${TARGET}_linux-arm64
             PPC64LE=${TARGET}_linux-ppc64le
-            docker manifest create $TARGET $AMD64 $ARM64 $PPC64LE
+            docker manifest create --amend $TARGET $AMD64 $ARM64 $PPC64LE
             docker manifest annotate $TARGET $AMD64 --arch amd64 --os linux
             docker manifest annotate $TARGET $ARM64 --arch arm64 --os linux
             docker manifest annotate $TARGET $PPC64LE --arch ppc64le --os linux
@@ -151,14 +155,14 @@ def dockerManifest() {
             # Ubuntu1604
             export TARGET="ghcr.io/adoptium/adoptium_build_image:ubuntu1604"
             ARMV7L=${TARGET}_linux-armv7l
-            docker manifest create $TARGET $ARMV7L
+            docker manifest create --amend $TARGET $ARMV7L
             docker manifest annotate $TARGET $ARMV7L --arch arm --os linux
             docker manifest push $TARGET
             # Alpine3
             export TARGET="ghcr.io/adoptium/adoptium_build_image:alpine3"
             AMD64=${TARGET}_linux-amd64
             ARM64=${TARGET}_linux-arm64
-            docker manifest create $TARGET $AMD64 $ARM64
+            docker manifest create --amend $TARGET $AMD64 $ARM64
             docker manifest annotate $TARGET $AMD64 --arch amd64 --os linux
             docker manifest annotate $TARGET $ARM64 --arch arm64 --os linux
             docker manifest push $TARGET

--- a/ansible/docker/Jenkinsfile
+++ b/ansible/docker/Jenkinsfile
@@ -172,14 +172,13 @@ def dockerManifest() {
 def cosign() {
     // dockerhub is the ID of the credentials stored in Jenkins
     docker.withRegistry('https://ghcr.io', 'ghcr-adoptium') {
-        git poll: false, url: 'https://github.com/sxa/infrastructure.git'
         sh '''
-            curl -sSL -X POST --url https://auth.eclipse.org/auth/realms/sigstore/protocol/openid-connect/token --header "Content-Type: application/x-www-form-urlencoded" --data @/home/jenkins/idp.txt | jq -r ".access_token" | head -c -1 > token.txt
+            curl -sSL -X POST --url https://auth.eclipse.org/auth/realms/foundation-service-accounts/protocol/openid-connect/token --header "Content-Type: application/x-www-form-urlencoded" --data @/home/jenkins/idp.txt | jq -r ".access_token" | head -c -1 > token.txt
             for IMAGE_SHA in *.sha256; do
               IMAGE="$(cat $IMAGE_SHA)"
               echo "Running cosign against image $IMAGE"
-              cosign sign "$IMAGE" --oidc-issuer=https://auth.eclipse.org/auth/realms/sigstore --identity-token=token.txt -y
-              cosign verify "${IMAGE}" --certificate-oidc-issuer=https://auth.eclipse.org/auth/realms/sigstore --certificate-identity=temurin-bot@eclipse.org
+              cosign sign "$IMAGE" --oidc-issuer=https://auth.eclipse.org/auth/realms/foundation-service-accounts --identity-token=token.txt -y
+              cosign verify "${IMAGE}" --certificate-oidc-issuer=https://auth.eclipse.org/auth/realms/foundation-service-accounts --certificate-identity=temurin-bot@eclipse.org
             done
             rm -vf token.txt
         '''

--- a/ansible/docker/Jenkinsfile.test
+++ b/ansible/docker/Jenkinsfile.test
@@ -86,13 +86,14 @@ def dockerBuild(architecture, distro, staticdockerfile) {
     sh "rm -vf *.sha256"
     git poll: false, url: 'https://github.com/adoptium/infrastructure.git'
     def git_sha = "${env.GIT_COMMIT.trim()}"
-    dockerImage =
-    docker.build("ghcr.io/adoptium/test-containers:${distro}-${architecture}",
-        "-f ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/$staticdockerfile .")
-    // dockerhub is the ID of the credentials stored in Jenkins
     docker.withRegistry('https://ghcr.io', 'ghcr-adoptium') {
-        dockerImage.push()
-        sh "docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/adoptium/test-containers:${distro}-${architecture} > ${distro}_linux-${architecture}.sha256"
+        sh """
+            docker buildx build --platform linux/$architecture \
+            --provenance=false \
+            -f ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/$staticdockerfile \
+            -t ghcr.io/adoptium/test-containers:${distro}-${architecture} --push .
+            docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/adoptium/test-containers:${distro}-${architecture} > ${distro}_linux-${architecture}.sha256
+        """
         archiveArtifacts artifacts: '*linux*.sha256', fingerprint: true
     }
 }
@@ -113,7 +114,7 @@ def dockerManifest() {
             docker manifest inspect $S390X 2>/dev/null | grep mediaType
             docker manifest inspect $PPC64LE 2>/dev/null | grep mediaType
             echo "Debug SF01"
-            docker manifest create $TARGET $AMD64 $ARM64 $S390X $PPC64LE
+            docker manifest create --amend $TARGET $AMD64 $ARM64 $S390X $PPC64LE
             docker manifest annotate $TARGET $AMD64 --arch amd64 --os linux
             docker manifest annotate $TARGET $ARM64 --arch arm64 --os linux
             docker manifest annotate $TARGET $S390X --arch s390x --os linux
@@ -125,7 +126,7 @@ def dockerManifest() {
             AMD64=${TARGET}-amd64
             ARM64=${TARGET}-arm64
 #           PPC64LE=${TARGET}-ppc64le
-            docker manifest create $TARGET $AMD64 $ARM64 # $PPC64LE
+            docker manifest create --amend $TARGET $AMD64 $ARM64 # $PPC64LE
             docker manifest annotate $TARGET $AMD64 --arch amd64     --os linux
             docker manifest annotate $TARGET $ARM64 --arch arm64     --os linux
 #            docker manifest annotate $TARGET $PPC64LE --arch ppc64le --os linux


### PR DESCRIPTION
Fixes #4445 

Update image builder dockerfiles to be compatibile with docker buildx , rather than docker build. Use --amend to ensure that where a previous run files, manifests are updated, rather than erroring, and --no-provenance, to ensure compatibility with our docker registrys. ( See the issue for a full description )

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR

Test jobs all completed ok..

✔️ Centos7 Build Image Updater Runs OK from my fork/branch with a fix : https://ci.adoptium.net/job/centos7_docker_image_updater/837/

✔️ Build Image Updater Test Run ( With identical fix as above ) : - works ok, except for cosign job
https://ci.adoptium.net/job/build_image_updater/223/

:heavy_check_mark: Rerun With Cosign Fix: https://ci.adoptium.net/job/build_image_updater/224/

✔️ Test Image Updater Test Run ( with identical fix as above ) :
https://ci.adoptium.net/job/test_image_updater/243/
