### PR TITLE
UnixPB: Add Qemu Config For Ubuntu Dockerhosts.

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/dockerhost.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/dockerhost.yml
@@ -37,6 +37,8 @@
     - Vendor
     - IPv6
     - Docker
+    - role: Qemu-Config   # Ubuntu 20+ x86_64 only — sets up QEMU binfmt with F flag for riscv64 container emulation
+      tags: [qemu_config, adoptopenjdk]
     - DockerStatic
     - role: housekeeping           # override mode when needed
       vars:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Qemu-Config/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Qemu-Config/tasks/main.yml
@@ -1,0 +1,87 @@
+---
+###############
+# Qemu-Config #
+###############
+
+# Configures QEMU binfmt_misc on Ubuntu 20+ x86_64 dockerhosts so that
+# linux/riscv64 containers can be emulated via QEMU user-mode.
+#
+# Key fix: re-registers the qemu-riscv64 binfmt entry with the F (fix-binary)
+# flag so the QEMU static binary is loaded into memory at registration time
+# and is therefore available inside containers that don't ship QEMU themselves.
+# Without F, g++ segfaults mid-compilation with RISC-V ELF targets.
+
+- name: Install qemu-user-static package
+  package:
+    name:
+      - qemu-user-static
+    state: present
+  when:
+    - ansible_distribution == "Ubuntu"
+    - ansible_distribution_major_version | int >= 20
+    - ansible_architecture == "x86_64"
+  tags: [qemu_config, adoptopenjdk]
+
+- name: Enable systemd-binfmt.service
+  service:
+    name: systemd-binfmt
+    enabled: yes
+  when:
+    - ansible_distribution == "Ubuntu"
+    - ansible_distribution_major_version | int >= 20
+    - ansible_architecture == "x86_64"
+  tags: [qemu_config, adoptopenjdk]
+
+- name: Write persistent binfmt.d config for qemu-riscv64 with F flag
+  copy:
+    dest: /etc/binfmt.d/qemu-riscv64.conf
+    content: |
+      :qemu-riscv64:M:0:\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\xf3\x00:\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/usr/libexec/qemu-binfmt/riscv64-binfmt-P:POF
+    owner: root
+    group: root
+    mode: '0644'
+  register: binfmt_conf
+  when:
+    - ansible_distribution == "Ubuntu"
+    - ansible_distribution_major_version | int >= 20
+    - ansible_architecture == "x86_64"
+  tags: [qemu_config, adoptopenjdk]
+
+- name: Remove existing riscv64 binfmt registration (if present)
+  shell:
+    cmd: echo -1 > /proc/sys/fs/binfmt_misc/qemu-riscv64
+    executable: /bin/bash
+  failed_when: false
+  changed_when: false
+  when:
+    - binfmt_conf.changed
+    - ansible_distribution == "Ubuntu"
+    - ansible_distribution_major_version | int >= 20
+    - ansible_architecture == "x86_64"
+  tags: [qemu_config, adoptopenjdk]
+
+- name: Apply binfmt registration with F flag
+  shell:
+    cmd: >
+      echo ':qemu-riscv64:M:0:\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\xf3\x00:\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/usr/libexec/qemu-binfmt/riscv64-binfmt-P:POF'
+      > /proc/sys/fs/binfmt_misc/register
+    executable: /bin/bash
+  when:
+    - binfmt_conf.changed
+    - ansible_distribution == "Ubuntu"
+    - ansible_distribution_major_version | int >= 20
+    - ansible_architecture == "x86_64"
+  tags: [qemu_config, adoptopenjdk]
+
+- name: Verify riscv64 binfmt flags include F
+  shell:
+    cmd: grep flags /proc/sys/fs/binfmt_misc/qemu-riscv64
+    executable: /bin/bash
+  register: binfmt_flags
+  failed_when: "'F' not in binfmt_flags.stdout"
+  changed_when: false
+  when:
+    - ansible_distribution == "Ubuntu"
+    - ansible_distribution_major_version | int >= 20
+    - ansible_architecture == "x86_64"
+  tags: [qemu_config, adoptopenjdk]


### PR DESCRIPTION
Fixes #4447 

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)

:heavy_check_mark: VPC (To Check It Doesnt Break Regular PBs ): https://ci.adoptium.net/job/VagrantPlaybookCheck/2289/

DockerHost playbook completes ok locally.