### PR TITLE
Update test_image_updater pipeline to run `cosign` correctly

### DIFF
--- a/ansible/docker/Jenkinsfile.test
+++ b/ansible/docker/Jenkinsfile.test
@@ -143,7 +143,12 @@ def cosign() {
               IMAGE="$(cat $IMAGE_SHA)"
               echo "Running cosign against image $IMAGE"
               cosign sign "$IMAGE" --oidc-issuer=https://auth.eclipse.org/auth/realms/foundation-service-accounts --identity-token=token.txt -y
-              cosign verify "${IMAGE}" --certificate-oidc-issuer=https://auth.eclipse.org/auth/realms/foundation-service-accounts --certificate-identity=temurin-bot@eclipse.org
+              # next line could be explicit and use --certificate-oidc-issuer=https://auth.eclipse.org/auth/realms/foundation-service-accounts --certificate-identity=temurin-bot@eclipse.org
+              cosign verify --certificate-identity-regexp '.*' --certificate-oidc-issuer-regexp '.*' "${IMAGE}" | jq .
+              cosign download signature "$IMAGE" > signatures.json
+              jq -r '.Payload' signatures.json | while read -r payload; do
+                   echo "$payload" | base64 -d | jq .
+              done
             done
             rm -vf token.txt
         '''


### PR DESCRIPTION
Some notes:
- I have not yet managed to make it work (i.e. be able to verify) with `--upload=false` due to the fact the signing cert is ephemeral. This means there is a signature file uploaded to the container repository along with the container itself.
- It has not yet been modified for cosign v3 so still requires v2
- Signature checking can be done as per the example that follows (either the implicit or explicit versions of the cosign verify command - both are shown below:
```
IMG=$(podman inspect ghcr.io/adoptium/test-containers:ubi10-amd64 | jq '.[0].RepoDigests[]' | tr -d '"')
cosign verify   --certificate-identity-regexp '.*'   --certificate-oidc-issuer-regexp '.*' "$IMG"
cosign verify   --certificate-identity-regexp temurin-bot@eclipse.org --certificate-oidc-issuer-regexp https://auth.eclipse.org/auth/realms/foundation-service-accounts "$IMG"
```

Tested at https://ci.adoptium.net/job/test_image_updater_sxa/74/
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [ ] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
