### PR TITLE
Fix ulimit/core_pattern for Ubuntu 20+ hosts

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.u2004
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.u2004
@@ -23,6 +23,11 @@ RUN mkdir /home/jenkins/.ssh
 RUN echo "Jenkins_User_SSHKey" > /home/jenkins/.ssh/authorized_keys
 RUN chown -R jenkins /home/jenkins/.ssh
 RUN chmod -R og-rwx /home/jenkins/.ssh
+
+# Allow core dumps for the jenkins user via PAM limits
+RUN echo "jenkins soft core unlimited" > /etc/security/limits.d/jenkins-core.conf \
+    && echo "jenkins hard core unlimited" >> /etc/security/limits.d/jenkins-core.conf
+
 RUN service ssh start
 CMD ["/usr/sbin/sshd","-D"]
 RUN apt-get update && apt-get install -qq -y git curl make gcc xvfb libxrender1 libxi6 libxtst6 locales fontconfig fakeroot

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.u2204
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.u2204
@@ -28,6 +28,10 @@ RUN echo "Jenkins_User_SSHKey" > /home/jenkins/.ssh/authorized_keys
 RUN chown -R jenkins /home/jenkins/.ssh
 RUN chmod -R og-rwx /home/jenkins/.ssh
 
+# Allow core dumps for the jenkins user via PAM limits
+RUN echo "jenkins soft core unlimited" > /etc/security/limits.d/jenkins-core.conf \
+    && echo "jenkins hard core unlimited" >> /etc/security/limits.d/jenkins-core.conf
+
 RUN service ssh start
 CMD ["/usr/sbin/sshd","-D"]
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.u2310
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.u2310
@@ -28,6 +28,10 @@ RUN echo "Jenkins_User_SSHKey" > /home/jenkins/.ssh/authorized_keys
 RUN chown -R jenkins /home/jenkins/.ssh
 RUN chmod -R og-rwx /home/jenkins/.ssh
 
+# Allow core dumps for the jenkins user via PAM limits
+RUN echo "jenkins soft core unlimited" > /etc/security/limits.d/jenkins-core.conf \
+    && echo "jenkins hard core unlimited" >> /etc/security/limits.d/jenkins-core.conf
+
 RUN service ssh start
 CMD ["/usr/sbin/sshd","-D"]
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.u2404
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.u2404
@@ -31,6 +31,10 @@ RUN echo "Jenkins_User_SSHKey" > /home/jenkins/.ssh/authorized_keys
 RUN chown -R jenkins /home/jenkins/.ssh
 RUN chmod -R og-rwx /home/jenkins/.ssh
 
+# Allow core dumps for the jenkins user via PAM limits
+RUN echo "jenkins soft core unlimited" > /etc/security/limits.d/jenkins-core.conf \
+    && echo "jenkins hard core unlimited" >> /etc/security/limits.d/jenkins-core.conf
+
 RUN service ssh start
 CMD ["/usr/sbin/sshd","-D"]
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.u2410
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.u2410
@@ -28,6 +28,10 @@ RUN echo "Jenkins_User_SSHKey" > /home/jenkins/.ssh/authorized_keys
 RUN chown -R jenkins /home/jenkins/.ssh
 RUN chmod -R og-rwx /home/jenkins/.ssh
 
+# Allow core dumps for the jenkins user via PAM limits
+RUN echo "jenkins soft core unlimited" > /etc/security/limits.d/jenkins-core.conf \
+    && echo "jenkins hard core unlimited" >> /etc/security/limits.d/jenkins-core.conf
+
 RUN service ssh start
 CMD ["/usr/sbin/sshd","-D"]
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.u2604
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.u2604
@@ -31,6 +31,10 @@ RUN echo "Jenkins_User_SSHKey" > /home/jenkins/.ssh/authorized_keys
 RUN chown -R jenkins /home/jenkins/.ssh
 RUN chmod -R og-rwx /home/jenkins/.ssh
 
+# Allow core dumps for the jenkins user via PAM limits
+RUN echo "jenkins soft core unlimited" > /etc/security/limits.d/jenkins-core.conf \
+    && echo "jenkins hard core unlimited" >> /etc/security/limits.d/jenkins-core.conf
+
 # Set up Nagios user
 RUN useradd -m -d /home/nagios nagios
 RUN mkdir /home/nagios/.ssh

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Jenkins_User/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Jenkins_User/tasks/main.yml
@@ -115,11 +115,13 @@
   tags:
     - jenkins_user
 
-- name: Ensure proper limits are set in /etc/security/limits.conf (Ubuntu 22+)
+- name: Ensure proper limits are set in /etc/security/limits.d/ (Ubuntu 22+)
   lineinfile:
-    path: /etc/security/limits.conf
+    path: /etc/security/limits.d/jenkins.conf
     line: "{{ Jenkins_Username }} {{ item.limit_type }} {{ item.limit_name }} {{ item.limit_value }}"
     state: present
+    create: true
+    mode: '0644'
   with_items:
     - {limit_type: 'soft', limit_name: 'core', limit_value: 'unlimited'}
     - {limit_type: 'hard', limit_name: 'core', limit_value: 'unlimited'}

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Jenkins_User/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Jenkins_User/tasks/main.yml
@@ -114,3 +114,21 @@
     - ansible_distribution_major_version == "6" or ansible_distribution_major_version == "7"
   tags:
     - jenkins_user
+
+- name: Ensure proper limits are set in /etc/security/limits.conf (Ubuntu 22+)
+  lineinfile:
+    path: /etc/security/limits.conf
+    line: "{{ Jenkins_Username }} {{ item.limit_type }} {{ item.limit_name }} {{ item.limit_value }}"
+    state: present
+  with_items:
+    - {limit_type: 'soft', limit_name: 'core', limit_value: 'unlimited'}
+    - {limit_type: 'hard', limit_name: 'core', limit_value: 'unlimited'}
+    - {limit_type: 'soft', limit_name: 'nofile', limit_value: '1048576'}
+    - {limit_type: 'hard', limit_name: 'nofile', limit_value: '1048576'}
+    - {limit_type: 'soft', limit_name: 'nproc', limit_value: 'unlimited'}
+    - {limit_type: 'hard', limit_name: 'nproc', limit_value: 'unlimited'}
+  when:
+    - ansible_distribution == "Ubuntu"
+    - ansible_distribution_major_version | int >= 22
+  tags:
+    - jenkins_user

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adopt_syscfg/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adopt_syscfg/tasks/main.yml
@@ -22,3 +22,26 @@
     reload: yes
   when: ansible_distribution == "RedHat" and ansible_distribution_major_version == "8"
   tags: adoptopenjdk
+
+- name: Set kernel.core_pattern in sysctl.conf (Ubuntu 22+)
+  lineinfile:
+    path: /etc/sysctl.conf
+    regexp: '^kernel\.core_pattern\s*='
+    line: 'kernel.core_pattern = core.%p'
+    state: present
+    backup: yes
+  when:
+    - ansible_distribution == "Ubuntu"
+    - ansible_distribution_major_version | int >= 22
+  tags: adoptopenjdk
+
+- name: Apply sysctl settings immediately (Ubuntu 22+)
+  sysctl:
+    name: kernel.core_pattern
+    value: 'core.%p'
+    state: present
+    reload: yes
+  when:
+    - ansible_distribution == "Ubuntu"
+    - ansible_distribution_major_version | int >= 22
+  tags: adoptopenjdk


### PR DESCRIPTION
Fixes #4461 

Fix is required to both static docker nodes, and regular machines..

- adopt_syscfg: override kernel.core_pattern from apport pipe handler to 'core.%p' for Ubuntu 22+ (any architecture), mirroring the existing RHEL 8 fix
- Jenkins_User: add soft+hard limits.conf entries for core, nofile and nproc for Ubuntu 22+ (any architecture); the existing block only covered RedHat/CentOS 6-7 on x86_64

Fixes CreateCoredumpOnCrash JDK test failure where the apport pipe handler caused the test to throw regardless of ulimit -c value.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [x] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)

VPC Completed OK: https://ci.adoptium.net/job/VagrantPlaybookCheck/2291/

Playbooks Complete Locally OK: ( with adoptopenjdk tags.. )

```
PLAY RECAP ************************************************************************************************************************************************
localhost                  : ok=309  changed=97   unreachable=0    failed=0    skipped=547  rescued=0    ignored=0   

root@adoptopenjdkU24:/vagrant# 

```