### PR TITLE
Docker: Ensure which is installed into static docker containers.

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alma10
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alma10
@@ -35,7 +35,7 @@ RUN su jenkins -c "mkdir -m 0755 /tmp/.X11-unix"
 RUN dnf install -y perl
 # turbojpeg needed as prereq for weston but it's not the UBI CRB repo so pull from CS10 one
 RUN dnf install -y --enablerepo=crb turbojpeg
-RUN dnf install -y git make gcc weston xwayland-run libXrender libXi libXtst fontconfig fakeroot procps-ng hostname diffutils shared-mime-info
+RUN dnf install -y git make gcc weston xwayland-run libXrender libXi libXtst fontconfig fakeroot procps-ng hostname diffutils shared-mime-info which
 RUN dnf install -y coreutils --allowerasing curl
 # Install SSL Test packages
 RUN dnf install -y gnutls gnutls-utils nss nss-tools

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.cent7
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.cent7
@@ -16,7 +16,7 @@ RUN if [ "$(uname -m)" = "aarch64" ]; then \
 
 RUN yum -y update && yum clean all
 
-RUN yum -y update && yum install -y perl openssh-server unzip zip wget epel-release perl-devel perl-Digest-SHA perl-Data-Dumper gettext zlib-devel git curl curl-devel make gcc libXrender libXi libXtst fontconfig fakeroot xorg-x11-server-Xvfb
+RUN yum -y update && yum install -y perl openssh-server unzip zip wget epel-release perl-devel perl-Digest-SHA perl-Data-Dumper gettext zlib-devel git curl curl-devel make gcc libXrender libXi libXtst fontconfig fakeroot xorg-x11-server-Xvfb which
 # Install OpenSSL Packages
 RUN yum install -y gnutls gnutls-utils nss-devel nss-tools
 RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -P ""

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.cent8
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.cent8
@@ -32,7 +32,7 @@ RUN chown -R jenkins /home/jenkins/.ssh
 RUN chmod -R og-rwx /home/jenkins/.ssh
 # RUN service ssh start
 CMD ["/usr/sbin/sshd","-D"]
-RUN dnf install -y git curl make gcc xorg-x11-server-Xvfb libXrender libXi libXtst fontconfig fakeroot
+RUN dnf install -y git curl make gcc xorg-x11-server-Xvfb libXrender libXi libXtst fontconfig fakeroot which
 RUN rm /run/nologin
 # ENTRYPOINT /usr/lib/jvm/jdk25/bin/java
 EXPOSE 22

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.centstream10
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.centstream10
@@ -36,7 +36,7 @@ RUN chmod -R og-rwx /home/jenkins/.ssh
 CMD ["/usr/sbin/sshd","-D"]
 
 RUN dnf -y --enablerepo=crb install turbojpeg
-RUN dnf install -y git make gcc weston xwayland-run libXrender libXi libXtst fontconfig fakeroot procps-ng hostname diffutils shared-mime-info
+RUN dnf install -y git make gcc weston xwayland-run libXrender libXi libXtst fontconfig fakeroot procps-ng hostname diffutils shared-mime-info which
 # Install SSL Test packages
 RUN dnf install -y gnutls gnutls-utils nss nss-tools openssl
 # ENTRYPOINT /usr/lib/jvm/jdk25/bin/java

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.centstream9
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.centstream9
@@ -32,7 +32,7 @@ RUN chmod -R og-rwx /home/jenkins/.ssh
 # RUN service ssh start
 CMD ["/usr/sbin/sshd","-D"]
 
-RUN dnf install -y git make gcc xorg-x11-server-Xvfb libXrender libXi libXtst fontconfig fakeroot procps-ng hostname diffutils shared-mime-info
+RUN dnf install -y git make gcc xorg-x11-server-Xvfb libXrender libXi libXtst fontconfig fakeroot procps-ng hostname diffutils shared-mime-info which
 RUN dnf install -y coreutils --allowerasing curl
 # Install SSL Test packages
 RUN dnf install -y gnutls gnutls-utils nss nss-tools

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.ubi10
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.ubi10
@@ -52,7 +52,7 @@ RUN su jenkins -c "mkdir -m 0755 /tmp/.X11-unix"
 RUN dnf install -y perl
 # turbojpeg needed as prereq for weston but it's not the UBI CRB repo so pull from CS10 one
 RUN dnf install -y --enablerepo=crb turbojpeg
-RUN dnf install -y git make gcc weston xwayland-run libXrender libXi libXtst fontconfig fakeroot procps-ng hostname diffutils shared-mime-info
+RUN dnf install -y git make gcc weston xwayland-run libXrender libXi libXtst fontconfig fakeroot procps-ng hostname diffutils shared-mime-info which
 RUN dnf install -y coreutils --allowerasing curl
 # Install SSL Test packages
 RUN dnf install -y gnutls gnutls-utils nss nss-tools

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.ubi8
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.ubi8
@@ -51,7 +51,7 @@ RUN chown -R jenkins /home/jenkins/.ssh
 RUN chmod -R og-rwx /home/jenkins/.ssh
 # RUN service ssh start
 CMD ["/usr/sbin/sshd","-D"]
-RUN dnf install -y git curl make gcc xorg-x11-server-Xvfb libXrender libXi libXtst fontconfig fakeroot procps-ng hostname diffutils shared-mime-info
+RUN dnf install -y git curl make gcc xorg-x11-server-Xvfb libXrender libXi libXtst fontconfig fakeroot procps-ng hostname diffutils shared-mime-info which
 RUN dnf install -y coreutils --allowerasing
 # Install SSL Test packages
 RUN dnf install -y gnutls gnutls-utils nss nss-tools

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.ubi9
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.ubi9
@@ -47,7 +47,7 @@ RUN chown -R jenkins /home/jenkins/.ssh
 RUN chmod -R og-rwx /home/jenkins/.ssh
 # RUN service ssh start
 CMD ["/usr/sbin/sshd","-D"]
-RUN dnf install -y git make gcc xorg-x11-server-Xvfb libXrender libXi libXtst fontconfig fakeroot procps-ng hostname diffutils shared-mime-info
+RUN dnf install -y git make gcc xorg-x11-server-Xvfb libXrender libXi libXtst fontconfig fakeroot procps-ng hostname diffutils shared-mime-info which
 RUN dnf install -y coreutils --allowerasing curl
 # Install SSL Test packages
 RUN dnf install -y gnutls gnutls-utils nss nss-tools


### PR DESCRIPTION
Fixes #4465 

Ensure which is installed into static docker containers as the tests use "which" for evaluating the presence of Xvfb ( amongst other things )

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR

