### PR TITLE
tools: Extend dependabot to cover new infra tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,21 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+
+  - package-ecosystem: pip
+    directory: /EOL_audit
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: pip
+    directory: /tools/jenkins-capacity-report
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: pip
+    directory: /ansible/machine_audit/backend
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Fixes #4481 

Extended .github/dependabot.yml to add weekly Dependabot scanning for:

EOL_audit/ — python-dotenv, python-jenkins, requests (pinned exact versions)
tools/jenkins-capacity-report/ — requests, flask, pydantic, werkzeug, apscheduler (lower-bound ranges)
ansible/machine_audit/backend/ — python-dotenv, python-jenkins (pinned exact versions)

All three entries use interval: weekly to reduce PR noise, which is appropriate for non-critical tooling dependencies.

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] VPC/QPC not applicable for this PR

