### PR TITLE
docs: Static container rebuild documentation

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/README.md
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/README.md
@@ -100,3 +100,15 @@ python3 AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/scripts/updateDockerStatic
 This script uses [jenkinsapi](https://jenkinsapi.readthedocs.io/en/latest/) which can be installed with `pip install jenkinsapi`.
 
 If any changes are found, open a new branch and commit these changes in a pull request.
+
+## Scheduled Static Docker Rebuilds
+
+The Adoptium infrastructure team periodically rebuilds all running static Docker containers on each dockerhost. This ensures containers are running from the latest version of their Dockerfile, picking up any base image updates, new tooling, or configuration changes that have been committed since the containers were originally deployed.
+
+Rebuilds are carried out using the [`regenContainers.yml`](https://github.com/adoptium/infrastructure/blob/master/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/regenContainers.yml) playbook:
+
+```
+ansible-playbook -u root -i <host-file> AdoptOpenJDK_Unix_Playbook/regenContainers.yml
+```
+
+We aim to rebuild the running static containers in line with the jenkins server [maintenance schedule](https://github.com/adoptium/infrastructure/#maintenance-window-schedule).

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/README.md
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/README.md
@@ -103,7 +103,7 @@ If any changes are found, open a new branch and commit these changes in a pull r
 
 ## Scheduled Static Docker Rebuilds
 
-The Adoptium infrastructure team periodically rebuilds all running static Docker containers on each dockerhost. This ensures containers are running from the latest version of their Dockerfile, picking up any base image updates, new tooling, or configuration changes that have been committed since the containers were originally deployed.
+The Adoptium infrastructure team periodically rebuilds all running static Docker containers on each Linux dockerhost. This ensures containers are running from the latest version of their Dockerfile, picking up any base image updates, new tooling, or configuration changes that have been committed since the containers were originally deployed.
 
 Rebuilds are carried out using the [`regenContainers.yml`](https://github.com/adoptium/infrastructure/blob/master/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/regenContainers.yml) playbook:
 

--- a/docs/JenkinsMaintenance.md
+++ b/docs/JenkinsMaintenance.md
@@ -7,7 +7,7 @@ timing should typically avoid coinciding with release work, although if a
 release in the previous month is ongoing then the window can be delayed til
 the following Tuesday.
 
-Jenkins and it's plugins will be updated to the latest LTS every month. 
+Jenkins and it's plugins will be updated to the latest LTS every month. Alongside this we aim to [rebuild our linux static docker containers](https://github.com/adoptium/infrastructure/blob/master/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/README.md#scheduled-static-docker-rebuilds) at the same time to ensure that the containers are running off the latest changes to their Dockerfiles.
 Other services such as Bastillion, AWX, and Nagios will be updated as
 required on a quarterly basis (On the first month of each quarter) during
 the same window if required for security reasons. In some cases we may wish


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

Docs for https://github.com/adoptium/infrastructure/issues/4467