### PR TITLE
tools: Add timestamp and latest version tooltip to jenkins capacity dashboard EOL tab

### DIFF
--- a/tools/jenkins-capacity-report/templates/dashboard.html
+++ b/tools/jenkins-capacity-report/templates/dashboard.html
@@ -601,6 +601,33 @@
         .eol-summary-card.ok-card  .value  { color: #28a745; }
         .eol-summary-card.unk-card .value  { color: #6c757d; }
 
+        /* Latest-version tooltip on EOL status badges */
+        .eol-tooltip-wrap {
+            position: relative;
+            display: inline-block;
+        }
+        .eol-tooltip-wrap[data-latest]::after {
+            content: "Latest: " attr(data-latest);
+            position: absolute;
+            bottom: calc(100% + 6px);
+            left: 50%;
+            transform: translateX(-50%);
+            background: #1f2328;
+            color: #fff;
+            font-size: 0.88em;
+            font-weight: 700;
+            white-space: nowrap;
+            padding: 7px 13px;
+            border-radius: 6px;
+            pointer-events: none;
+            opacity: 0;
+            transition: opacity 0.15s ease;
+            z-index: 100;
+        }
+        .eol-tooltip-wrap[data-latest]:hover::after {
+            opacity: 1;
+        }
+
         /* Jenkins link icon styling */
         .jenkins-link-icon {
             display: inline-block;
@@ -1234,7 +1261,11 @@
                 {% set unknown_count = eol_data | length - eol_count - supported_count %}
 
                 <div class="summary-section">
-                    <h2>⏳ OS End-of-Life Summary</h2>
+                    <h2>⏳ OS End-of-Life Summary
+                        {% if eol_timestamp %}
+                        <span style="font-size:0.6em; font-weight:400; color:#57606a; margin-left:10px;">Last updated: {{ eol_timestamp }}</span>
+                        {% endif %}
+                    </h2>
                     <div class="eol-summary-cards">
                         <div class="eol-summary-card">
                             <div class="label">Total Nodes Checked</div>
@@ -1280,6 +1311,11 @@
                                 <td>{{ entry.os or '—' }}</td>
                                 <td>{{ entry.version or '—' }}</td>
                                 <td>
+                                    {% if entry.latestLts %}
+                                        <span class="eol-tooltip-wrap" data-latest="{{ entry.latestLts }}">
+                                    {% else %}
+                                        <span class="eol-tooltip-wrap">
+                                    {% endif %}
                                     {% if entry.isEOL is true %}
                                         <span class="eol-badge eol">EOL</span>
                                     {% elif entry.isEOL is false %}
@@ -1287,6 +1323,7 @@
                                     {% else %}
                                         <span class="eol-badge unknown">Unknown</span>
                                     {% endif %}
+                                    </span>
                                 </td>
                                 <td>{{ entry.eolFrom or '—' }}</td>
                             </tr>

--- a/tools/jenkins-capacity-report/web_app.py
+++ b/tools/jenkins-capacity-report/web_app.py
@@ -625,23 +625,33 @@ def get_eol_data():
     """Read EOL status data from the JSON file produced by check_os_eol.py.
 
     Returns:
-        List of dicts with keys: name, os, version, isEOL, eolFrom
-        sorted by os (nulls last) then name.
-        Empty list if the file does not exist or cannot be parsed.
+        Tuple of (list, str|None):
+          - list of dicts with keys: name, os, version, isEOL, eolFrom, latestLts
+            sorted by os (nulls last) then name.
+            Empty list if the file does not exist or cannot be parsed.
+          - ISO-8601 timestamp string from the file, or None if unavailable.
     """
     try:
         eol_path = Path(config.eol_status_file)
         if not eol_path.exists():
-            return []
+            return [], None
         import json
         with eol_path.open() as f:
-            data = json.load(f)
+            raw = json.load(f)
+        # Support both the new wrapped format {timestamp, EOL_data:[...]}
+        # and the legacy flat-list format for backwards compatibility.
+        if isinstance(raw, dict):
+            data = raw.get('EOL_data', [])
+            eol_timestamp = raw.get('timestamp')
+        else:
+            data = raw
+            eol_timestamp = None
         # Sort: known OS first (alphabetically), then nulls; secondary sort by name
         data.sort(key=lambda d: (d.get('os') is None, d.get('os') or '', d.get('name') or ''))
-        return data
+        return data, eol_timestamp
     except Exception as e:
         logger.error(f"Error reading EOL status file: {e}")
-        return []
+        return [], None
 
 
 def is_eol_data_available():
@@ -850,7 +860,7 @@ def index():
     cloud_config_available = is_cloud_config_available()
 
     # EOL status data
-    eol_data = get_eol_data()
+    eol_data, eol_timestamp = get_eol_data()
     eol_data_available = is_eol_data_available()
 
     # Get current user role for UI permissions
@@ -872,6 +882,7 @@ def index():
         cloud_config_available=cloud_config_available,
         eol_data=eol_data,
         eol_data_available=eol_data_available,
+        eol_timestamp=eol_timestamp,
         machine_audit_data=machine_audit_data,
         timestamp=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         current_user=current_user,
@@ -1317,9 +1328,10 @@ def get_rbac_status():
 @optional_auth
 def eol_status():
     """API endpoint returning EOL status data from the pre-generated JSON file."""
-    data = get_eol_data()
+    data, eol_timestamp = get_eol_data()
     return jsonify({
         'available': len(data) > 0,
+        'timestamp': eol_timestamp,
         'data': data,
         'count': len(data),
         'eol_count': sum(1 for d in data if d.get('isEOL') is True),


### PR DESCRIPTION

- [x] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [faq.md](https://github.com/adoptium/infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] VPC/QPC not applicable for this PR
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

re https://github.com/adoptium/infrastructure/issues/4497

New tooltip which shows the latest os version for machines which are out of support

<img width="168" height="100" alt="image" src="https://github.com/user-attachments/assets/297e928b-c1e0-4c8f-bb56-5a5ad5529662" />

And time stamp of latest eol_status.json file
<img width="408" height="94" alt="image" src="https://github.com/user-attachments/assets/27d0a80d-ce0e-48b0-b4dd-8ae8f1f5184a" />
