### PR TITLE
UnixPB: Add Default Credential For Git Interactions

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -6,7 +6,7 @@
 # It can be defined as 'all' or a specific group which the host belongs to.
 # For example, it can be 'all' or 'x86' for when a host is in the group 'x86'.
 - name: Ansible Unix playbook
-  hosts: all
+  hosts: "{{ Groups | default('localhost:build:test:perf:jck:!*zos*:!*win*:!*aix*') }}"
   gather_facts: yes
   tasks:
     - name: Run Tasks
@@ -21,9 +21,9 @@
   # Roles #
   #########
   roles:
-    # - role: logs
-    #   position: "Start"
-    #   tags: always
+    - role: logs
+      position: "Start"
+      tags: always
     - Debug
     - role: Get_Vendor_Files
       tags: [vendor_files, adoptopenjdk, jenkins_user, nagios_plugins, superuser]
@@ -183,6 +183,6 @@
         script_action: check              # check/delete
     - pandoc                      # Build Of Man Pages JDK24+
     - adopt_syscfg
-    # - role: logs
-    #   position: "End"
-    #   tags: always
+    - role: logs
+      position: "End"
+      tags: always

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -6,7 +6,7 @@
 # It can be defined as 'all' or a specific group which the host belongs to.
 # For example, it can be 'all' or 'x86' for when a host is in the group 'x86'.
 - name: Ansible Unix playbook
-  hosts: "{{ Groups | default('localhost:build:test:perf:jck:!*zos*:!*win*:!*aix*') }}"
+  hosts: all
   gather_facts: yes
   tasks:
     - name: Run Tasks
@@ -21,9 +21,9 @@
   # Roles #
   #########
   roles:
-    - role: logs
-      position: "Start"
-      tags: always
+    # - role: logs
+    #   position: "Start"
+    #   tags: always
     - Debug
     - role: Get_Vendor_Files
       tags: [vendor_files, adoptopenjdk, jenkins_user, nagios_plugins, superuser]
@@ -37,6 +37,9 @@
     - autoconf
     - curl
     - Jenkins_User                # AdoptOpenJDK Infrastructure
+    - role: Git_Credentials       # AdoptOpenJDK Infrastructure
+      tags: [git_credentials, adoptopenjdk]
+      when: ansible_distribution != "MacOSX"
 #  - role: freemarker            # OpenJ9
 #      tags: [build_tools, build_tools_openj9]
     - role: macos_codesign
@@ -180,6 +183,6 @@
         script_action: check              # check/delete
     - pandoc                      # Build Of Man Pages JDK24+
     - adopt_syscfg
-    - role: logs
-      position: "End"
-      tags: always
+    # - role: logs
+    #   position: "End"
+    #   tags: always

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Git_Credentials/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Git_Credentials/tasks/main.yml
@@ -22,7 +22,7 @@
   tags:
     - git_credentials
     - adoptopenjdk
-    
+
 ####################
 # git-credentials  #
 ####################

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Git_Credentials/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Git_Credentials/tasks/main.yml
@@ -1,0 +1,39 @@
+---
+###################
+# Git_Credentials #
+###################
+
+- name: Set home_folder default for Git_Credentials role
+  set_fact:
+    home_folder: "{{ home_folder | default('/home/' ~ Jenkins_Username) }}"
+  tags: [git_credentials, adoptopenjdk]
+
+###############
+# git config  #
+###############
+- name: Set git credential helper for Jenkins user
+  command: git config --global credential.helper store
+  become: yes
+  environment:
+    HOME: "{{ home_folder }}"
+  changed_when: false
+  when:
+    - ansible_distribution != "MacOSX"
+  tags:
+    - git_credentials
+    - adoptopenjdk
+    
+####################
+# git-credentials  #
+####################
+- name: Write git-credentials file for Jenkins user
+  copy:
+    content: "{{ git_credentials }}\n"
+    dest: "{{ home_folder }}/.git-credentials"
+    owner: "{{ Jenkins_Username }}"
+    group: "{{ Jenkins_Username }}"
+    mode: "0600"
+  no_log: true
+  when:
+    - ansible_distribution != "MacOSX"
+  tags: [git_credentials, adoptopenjdk]


### PR DESCRIPTION
Fixes #4511 

Since github, now applies quite severe rate limits to anonymous http scrapes, many of our nodes are hitting 401 and 403 errors. 

I've updated the playbooks and added a new vendor file, to keep the username/password secret safe.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes]
- [X] VPC/QPC not applicable for this PR

VPC does not run vendor specific files..

Local testing has been completed with a Vagrant VM successfully.

Run on a single host, also successful..

```
TASK [Git_Credentials : Set home_folder default for Git_Credentials role] *******************************************************************************************************************************************
[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24.
Origin: /home/scfryer/Development/Github-Repos/infrastructure.gitcreds/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml:42:13

40     - role: Git_Credentials       # AdoptOpenJDK Infrastructure
41       tags: [git_credentials, adoptopenjdk]
42       when: ansible_distribution != "MacOSX"
               ^ column 13

Use `ansible_facts["fact_name"]` (no `ansible_` prefix) instead.

ok: [62.210.163.36]

TASK [Git_Credentials : Set git credential helper for Jenkins user] *************************************************************************************************************************************************
ok: [62.210.163.36]

TASK [Git_Credentials : Write git-credentials file for Jenkins user] ************************************************************************************************************************************************
ok: [62.210.163.36]

```

